### PR TITLE
[codex] Add P0/P1 framework docs and PR automation baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,10 @@
-* @andelizondo
+# Protected surfaces that always require owner review.
+.github/workflows/ @andelizondo
+.github/dependabot.yml @andelizondo
+agents/ @andelizondo
+package.json @andelizondo
+package-lock.json @andelizondo
+scripts/ @andelizondo
+spec/ @andelizondo
+templates/ @andelizondo
+SECURITY.md @andelizondo

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+# Repository instructions for GitHub Copilot
+
+Use `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md` as the primary operating guideline for this repository.
+
+When reviewing or proposing changes:
+
+- Follow the playbooks in `docs/PLAYBOOKS.md`.
+- Apply `docs/P1_PR_EXECUTION_LOOP.md` when reasoning about pull requests.
+- Treat the framework as provider-agnostic. Do not introduce vendor-specific assumptions into core policy unless the change is explicitly implementation-specific.
+- Prefer conservative escalation over unsafe approval when the change touches workflows, schemas, policy, security, or protected repository surfaces.
+- For this repository, the canonical validation command is `npm run validate`.
+- Distinguish blocking risks from non-blocking suggestions.
+- Preserve branch protection, auditability, and human checkpoints for medium- and high-risk changes.

--- a/.github/workflows/p1-low-risk-automation.yml
+++ b/.github/workflows/p1-low-risk-automation.yml
@@ -1,0 +1,166 @@
+name: p1-low-risk-automation
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  workflow_run:
+    workflows: ["validate-spec", "p1-risk-classification"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          REQUIRED_CHECK: validate
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            function getPrNumber() {
+              if (context.eventName === 'pull_request_target') {
+                return context.payload.pull_request.number;
+              }
+
+              if (context.eventName === 'pull_request_review') {
+                return context.payload.pull_request.number;
+              }
+
+              if (context.eventName === 'workflow_run') {
+                const prs = context.payload.workflow_run.pull_requests || [];
+                return prs.length > 0 ? prs[0].number : null;
+              }
+
+              return null;
+            }
+
+            const prNumber = getPrNumber();
+            if (!prNumber) {
+              core.info('No pull request is associated with this event.');
+              return;
+            }
+
+            const prQuery = await github.graphql(
+              `
+                query PullRequestState($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      id
+                      number
+                      isDraft
+                      state
+                      reviewDecision
+                      mergeStateStatus
+                      autoMergeRequest {
+                        enabledAt
+                      }
+                      author {
+                        login
+                      }
+                      labels(first: 20) {
+                        nodes {
+                          name
+                        }
+                      }
+                      headRefOid
+                    }
+                  }
+                }
+              `,
+              { owner, repo, number: prNumber },
+            );
+
+            const pr = prQuery.repository.pullRequest;
+            if (!pr || pr.state !== 'OPEN' || pr.isDraft) {
+              core.info('Pull request is not open and ready for automation.');
+              return;
+            }
+
+            const labels = pr.labels.nodes.map((label) => label.name);
+            if (!labels.includes('risk:low')) {
+              core.info('Pull request is not classified as low risk.');
+              return;
+            }
+
+            const checksResponse = await github.rest.checks.listForRef({
+              owner,
+              repo,
+              ref: pr.headRefOid,
+              per_page: 100,
+            });
+
+            const requiredCheck = process.env.REQUIRED_CHECK;
+            const validateCheck = checksResponse.data.check_runs.find(
+              (checkRun) => checkRun.name === requiredCheck,
+            );
+
+            if (!validateCheck || validateCheck.status !== 'completed' || validateCheck.conclusion !== 'success') {
+              core.info(`Required check ${requiredCheck} is not successful yet.`);
+              return;
+            }
+
+            if (pr.reviewDecision !== 'APPROVED') {
+              await github.rest.pulls.createReview({
+                owner,
+                repo,
+                pull_number: pr.number,
+                event: 'APPROVE',
+                body: [
+                  'P1 low-risk approval by automation.',
+                  '',
+                  'This PR is labeled `risk:low`, the required `validate` check passed, and no protected repository surfaces were detected.',
+                ].join('\n'),
+              });
+            }
+
+            const refreshed = await github.graphql(
+              `
+                query RefreshedPullRequest($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      id
+                      reviewDecision
+                      autoMergeRequest {
+                        enabledAt
+                      }
+                    }
+                  }
+                }
+              `,
+              { owner, repo, number: pr.number },
+            );
+
+            const refreshedPr = refreshed.repository.pullRequest;
+            if (refreshedPr.reviewDecision !== 'APPROVED') {
+              core.info('Automation could not obtain an approving review.');
+              return;
+            }
+
+            if (refreshedPr.autoMergeRequest) {
+              core.info('Auto-merge is already enabled.');
+              return;
+            }
+
+            await github.graphql(
+              `
+                mutation EnableAutoMerge($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(input: {
+                    pullRequestId: $pullRequestId,
+                    mergeMethod: SQUASH
+                  }) {
+                    pullRequest {
+                      number
+                    }
+                  }
+                }
+              `,
+              { pullRequestId: refreshedPr.id },
+            );

--- a/.github/workflows/p1-risk-classification.yml
+++ b/.github/workflows/p1-risk-classification.yml
@@ -1,0 +1,223 @@
+name: p1-risk-classification
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  classify:
+    if: github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const marker = '<!-- p1-risk-classification -->';
+            const riskLabels = ['risk:low', 'risk:medium', 'risk:high'];
+            const autoMergeLabel = 'ai:auto-merge-candidate';
+
+            const labelPalette = {
+              'risk:low': '0e8a16',
+              'risk:medium': 'fbca04',
+              'risk:high': 'd73a4a',
+              'ai:auto-merge-candidate': '1d76db',
+            };
+
+            for (const [name, color] of Object.entries(labelPalette)) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name,
+                  color,
+                });
+              } catch (error) {
+                if (error.status !== 422) {
+                  throw error;
+                }
+              }
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const paths = files.map((file) => file.filename);
+
+            const protectedPatterns = [
+              '.github/workflows/**',
+              '.github/dependabot.yml',
+              'agents/**',
+              'package.json',
+              'package-lock.json',
+              'scripts/**',
+              'spec/**',
+              'templates/**',
+              'SECURITY.md',
+            ];
+
+            const highRiskPatterns = [
+              '**/auth/**',
+              '**/billing/**',
+              '**/payments/**',
+              '**/secrets/**',
+              '**/credentials/**',
+              '**/migrations/**',
+              '**/terraform/**',
+              '**/iac/**',
+            ];
+
+            const lowRiskPatterns = [
+              'docs/**',
+              'README.md',
+              'REPO_SCAFFOLD.md',
+              'CONTRIBUTING.md',
+              '.github/pull_request_template.md',
+              '.github/ISSUE_TEMPLATE/**',
+            ];
+
+            function escapeRegex(value) {
+              return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+            }
+
+            function patternToRegExp(pattern) {
+              let source = escapeRegex(pattern);
+              source = source.replace(/\*\*/g, '.*');
+              source = source.replace(/\*/g, '[^/]*');
+              return new RegExp(`^${source}$`);
+            }
+
+            function matches(path, patterns) {
+              return patterns.some((pattern) => patternToRegExp(pattern).test(path));
+            }
+
+            let risk = 'low';
+            const reasons = [];
+
+            for (const path of paths) {
+              if (matches(path, highRiskPatterns)) {
+                risk = 'high';
+                reasons.push(`${path} matches a high-risk protected surface.`);
+                continue;
+              }
+
+              if (matches(path, protectedPatterns)) {
+                if (risk !== 'high') {
+                  risk = 'medium';
+                }
+                reasons.push(`${path} matches a protected repository surface.`);
+                continue;
+              }
+
+              if (!matches(path, lowRiskPatterns)) {
+                if (risk === 'low') {
+                  risk = 'medium';
+                }
+                reasons.push(`${path} does not match the low-risk path allowlist.`);
+              }
+            }
+
+            const uniqueReasons = [...new Set(reasons)];
+            const riskLabel = `risk:${risk}`;
+            const currentLabels = pr.labels.map((label) => label.name);
+
+            for (const label of riskLabels) {
+              if (currentLabels.includes(label) && label !== riskLabel) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  name: label,
+                }).catch((error) => {
+                  if (error.status !== 404) {
+                    throw error;
+                  }
+                });
+              }
+            }
+
+            if (!currentLabels.includes(riskLabel)) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr.number,
+                labels: [riskLabel],
+              });
+            }
+
+            if (risk === 'low' && !currentLabels.includes(autoMergeLabel)) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr.number,
+                labels: [autoMergeLabel],
+              });
+            }
+
+            if (risk !== 'low' && currentLabels.includes(autoMergeLabel)) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: pr.number,
+                name: autoMergeLabel,
+              }).catch((error) => {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              });
+            }
+
+            const body = [
+              marker,
+              `P1 classification: **${risk}** risk.`,
+              '',
+              `Changed files: ${paths.map((path) => `\`${path}\``).join(', ')}`,
+              '',
+              'Why:',
+              ...(uniqueReasons.length > 0
+                ? uniqueReasons.map((reason) => `- ${reason}`)
+                : ['- All changed paths are currently within the low-risk allowlist.']),
+              '',
+              'Authority under `docs/P1_PR_EXECUTION_LOOP.md`:',
+              risk === 'low'
+                ? '- Eligible for automation after required checks pass.'
+                : '- Human approval remains required before merge.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 **Policy:** [`spec/policy/event-taxonomy.yaml`](spec/policy/event-taxonomy.yaml).  
 **Agent tool contracts:** [`agents/interfaces.yaml`](agents/interfaces.yaml).  
 **Operating framework (normative prose, v0.1):** [`docs/AI_NATIVE_FRAMEWORK_COMPLETE.md`](docs/AI_NATIVE_FRAMEWORK_COMPLETE.md) - read after `spec/` when bootstrapping company-wide behavior.  
+**Playbooks:** [`docs/PLAYBOOKS.md`](docs/PLAYBOOKS.md) - reusable procedures for bootstrapping and operating framework-aligned repos.  
 Optional human-readable mirrors can live under `docs/` (generate or keep in sync).
 
 ## Quick start
@@ -26,6 +27,7 @@ CI runs the same check (see [`.github/workflows/validate.yml`](.github/workflows
 | `agents/`                              | Provider-agnostic logical interfaces                                 |
 | `scripts/`                             | `validate-spec.mjs` (AJV + YAML)                                     |
 | `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md` | Full operating framework (agent-oriented; initial v0.1)              |
+| `docs/PLAYBOOKS.md`                    | Index of reusable playbooks and operating procedures                 |
 | `REPO_SCAFFOLD.md`                     | Full copy-paste bundle + Appendix (keep in sync when editing schema) |
 
 

--- a/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
+++ b/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
@@ -324,7 +324,17 @@ For deployments targeting **solo founders or minimal teams** in **B2B SaaS**, th
 - **Playbook:** `docs/P0_REPOSITORY_FOUNDATION.md`
 - **Events (examples):** `ops.repo_published`, `ops.branch_protection_enabled`, `ops.security_automation_enabled`.
 
-After P0, the library **SHOULD** contain encoded workflows for the following six operating processes.
+#### P1 - Pull request execution loop
+
+- **Objective:** Automate PR review, testing, approval, and merge within explicit human-governed thresholds.
+- **Inputs:** PR metadata, diff, branch protection rules, required checks, and threshold policy.
+- **Outputs:** Risk classification, validation evidence, review outcome, approval decision, and merge or escalation state.
+- **Capabilities:** Builder, Ops, Researcher.
+- **Checkpoints:** Human approval is **MUST** for high-risk changes and **SHOULD** be required whenever confidence or evidence falls below policy thresholds.
+- **Playbook:** `docs/P1_PR_EXECUTION_LOOP.md`
+- **Events (examples):** `pr.risk_classified`, `pr.review_completed`, `pr.escalated`, `pr.merged`.
+
+After P1, the library **SHOULD** contain encoded workflows for the following six operating processes.
 
 #### W1 — Opportunity research
 

--- a/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
+++ b/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
@@ -199,6 +199,7 @@ Typical layout for a framework-aligned repo:
 | `agents/interfaces.yaml` | Logical tool contracts |
 | `scripts/validate-spec.mjs` | Local and CI validation |
 | `.github/workflows/` | CI pipelines |
+| `docs/PLAYBOOKS.md` | Human-readable index of reusable playbooks |
 
 ---
 
@@ -311,7 +312,19 @@ The Process Library is the **encoded moat**: reusable, versioned procedures—tr
 
 ### 11.4 V1 default workflow set (B2B SaaS, small team)
 
-For deployments targeting **solo founders or minimal teams** in **B2B SaaS**, the library **SHOULD** contain encoded workflows for the following six processes.
+For deployments targeting **solo founders or minimal teams** in **B2B SaaS**, the library **SHOULD** contain encoded workflows for the following baseline sequence.
+
+#### P0 - Repository foundation
+
+- **Objective:** Make the repository safe for parallel human and agent execution before normal product work starts.
+- **Inputs:** Repository owner, default branch, maintainer handle, and at least one validation command.
+- **Outputs:** Protected default branch, CI baseline, merge policy, security defaults, and governance files.
+- **Capabilities:** Builder, Product, Ops.
+- **Checkpoints:** Human confirmation of repository owner, visibility, and merge policy before protection is enforced.
+- **Playbook:** `docs/P0_REPOSITORY_FOUNDATION.md`
+- **Events (examples):** `ops.repo_published`, `ops.branch_protection_enabled`, `ops.security_automation_enabled`.
+
+After P0, the library **SHOULD** contain encoded workflows for the following six operating processes.
 
 #### W1 — Opportunity research
 

--- a/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
+++ b/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
@@ -329,7 +329,7 @@ For deployments targeting **solo founders or minimal teams** in **B2B SaaS**, th
 - **Objective:** Automate PR review, testing, approval, and merge within explicit human-governed thresholds.
 - **Inputs:** PR metadata, diff, branch protection rules, required checks, and threshold policy.
 - **Outputs:** Risk classification, validation evidence, review outcome, approval decision, and merge or escalation state.
-- **Capabilities:** Builder, Ops, Researcher.
+- **Capabilities:** Builder, Ops, Researcher, AI reviewer backend.
 - **Checkpoints:** Human approval is **MUST** for high-risk changes and **SHOULD** be required whenever confidence or evidence falls below policy thresholds.
 - **Playbook:** `docs/P1_PR_EXECUTION_LOOP.md`
 - **Events (examples):** `pr.risk_classified`, `pr.review_completed`, `pr.escalated`, `pr.merged`.

--- a/docs/P0_REPOSITORY_FOUNDATION.md
+++ b/docs/P0_REPOSITORY_FOUNDATION.md
@@ -1,0 +1,134 @@
+# P0 - Repository foundation
+
+## Objective
+
+Create a repository that is safe to collaborate in before product, growth, or operations workflows start shipping changes.
+
+This is the first playbook step in the framework. It converts a raw repository into a governed execution surface with validation, review controls, security defaults, and contributor guidance.
+
+## When to run
+
+Run P0 immediately after creating a new repository and before opening normal feature branches.
+
+## Outcomes
+
+At the end of this playbook, the repository should have:
+
+- A default branch pushed and treated as the protected source of truth.
+- CI running on push and pull request.
+- Branch protection bound to real required checks.
+- Merge strategy and branch cleanup defaults configured.
+- Basic governance files for ownership, contribution flow, security reporting, issues, and pull requests.
+- Dependency and security automation enabled.
+
+## Inputs
+
+- Repository name and owner.
+- Default branch name (`main` unless policy requires otherwise).
+- At least one passing validation workflow.
+- Initial maintainer or owner handle for CODEOWNERS.
+
+## Procedure
+
+### 1. Publish the repository
+
+1. Initialize git history if needed and push the default branch to GitHub.
+2. Confirm the remote URL and authenticated GitHub identity are correct.
+3. Ensure workflow publishing has the required token scopes before pushing `.github/workflows/*`.
+
+## 2. Establish a minimum CI baseline
+
+1. Add a workflow that runs on `push` and `pull_request`.
+2. Make the workflow execute the repository's canonical validation command.
+3. Prefer deterministic installs and caching where available.
+4. Push the workflow and verify at least one successful run on the default branch.
+
+For this repository, the required validation command is `npm run validate` and the required check context is `validate`.
+
+## 3. Add repository governance files
+
+Create the following files before broader collaboration begins:
+
+- `.github/CODEOWNERS`
+- `.github/pull_request_template.md`
+- `.github/ISSUE_TEMPLATE/*`
+- `.github/dependabot.yml`
+- `CONTRIBUTING.md`
+- `SECURITY.md`
+
+These files establish who must review changes, how work enters the repo, and how vulnerabilities are handled.
+
+## 4. Configure repository defaults on GitHub
+
+Apply the following repository settings:
+
+- Enable squash merge.
+- Disable merge commits unless the repo has a specific reason to preserve them.
+- Disable rebase merge unless the team explicitly prefers it.
+- Enable delete branch on merge.
+- Enable issues if they are part of the operating loop.
+- Disable wiki unless it is intentionally used.
+- Set the repository description.
+
+These choices keep history readable and prevent the repo from accumulating unmanaged side channels.
+
+## 5. Protect the default branch
+
+Bind branch protection to the actual successful CI check emitted by GitHub Actions.
+
+Recommended minimum protection:
+
+- Require pull requests before merging.
+- Require at least one approving review.
+- Require CODEOWNERS review.
+- Dismiss stale approvals on new commits.
+- Require conversation resolution before merge.
+- Enforce rules for administrators.
+- Require linear history.
+- Disallow force pushes.
+- Disallow branch deletion.
+- Require the canonical validation check.
+
+Do not guess the required check name. Read it from the repository's check runs after the workflow has succeeded.
+
+## 6. Enable security automation
+
+Enable:
+
+- Dependabot alerts
+- Automated security fixes
+- Secret scanning
+- Push protection
+
+Security automation should be on before contributors begin adding integrations, secrets, or deployment credentials.
+
+## 7. Verify and record
+
+1. Run the validation command locally.
+2. Confirm the default branch is clean and tracking the remote.
+3. Read back repository settings and branch protection from GitHub.
+4. Record the applied configuration in the framework playbook so future repos reuse the same baseline.
+
+## Baseline applied in this repository
+
+The first execution of P0 in this repository applied the following concrete settings:
+
+- Default branch: `main`
+- Required check: `validate`
+- Merge strategy: squash only
+- Delete branch on merge: enabled
+- Branch protection: enabled on `main`
+- Reviews required: 1
+- CODEOWNERS review: required
+- Stale review dismissal: enabled
+- Conversation resolution: required
+- Linear history: required
+- Force pushes: disabled
+- Branch deletions: disabled
+- Security automation: enabled
+
+## Notes for future variants
+
+- Organizations may add team-based CODEOWNERS, signed-commit requirements, deployment environments, or release workflows on top of P0.
+- Repositories with multiple validation lanes may require more than one status check.
+- If the framework later introduces machine-readable process schemas under `spec/processes/`, P0 should be encoded there as well as in Markdown.

--- a/docs/P0_REPOSITORY_FOUNDATION.md
+++ b/docs/P0_REPOSITORY_FOUNDATION.md
@@ -20,6 +20,7 @@ At the end of this playbook, the repository should have:
 - Merge strategy and branch cleanup defaults configured.
 - Basic governance files for ownership, contribution flow, security reporting, issues, and pull requests.
 - Dependency and security automation enabled.
+- CODEOWNERS scoped to protected repository surfaces if low-risk PR automation will be allowed later.
 
 ## Inputs
 
@@ -57,6 +58,8 @@ Create the following files before broader collaboration begins:
 - `SECURITY.md`
 
 These files establish who must review changes, how work enters the repo, and how vulnerabilities are handled.
+
+If the repository will later allow low-risk automated PR approval or merge, CODEOWNERS **SHOULD** target protected surfaces instead of every file in the repository. A blanket `*` owner rule blocks low-risk automation by forcing owner review on every change.
 
 ## 4. Configure repository defaults on GitHub
 
@@ -120,6 +123,7 @@ The first execution of P0 in this repository applied the following concrete sett
 - Branch protection: enabled on `main`
 - Reviews required: 1
 - CODEOWNERS review: required
+- CODEOWNERS scope: protected surfaces only
 - Stale review dismissal: enabled
 - Conversation resolution: required
 - Linear history: required
@@ -130,5 +134,6 @@ The first execution of P0 in this repository applied the following concrete sett
 ## Notes for future variants
 
 - Organizations may add team-based CODEOWNERS, signed-commit requirements, deployment environments, or release workflows on top of P0.
+- Repositories that want low-risk auto-merge should keep CODEOWNERS focused on protected paths, not documentation-only surfaces.
 - Repositories with multiple validation lanes may require more than one status check.
 - If the framework later introduces machine-readable process schemas under `spec/processes/`, P0 should be encoded there as well as in Markdown.

--- a/docs/P1_PR_EXECUTION_LOOP.md
+++ b/docs/P1_PR_EXECUTION_LOOP.md
@@ -6,6 +6,8 @@ Automate the path from open pull request to merge while preserving explicit huma
 
 P1 is the first operating playbook that runs continuously after repository foundation is in place. It defines how agents, CI, GitHub policy, and human checkpoints work together on every PR.
 
+The AI reviewer backend **MUST** be treated as replaceable. The framework's policy layer decides authority; the reviewer implementation supplies comments, findings, and suggested changes.
+
 ## When to run
 
 Run P1 for every pull request targeting a protected branch.
@@ -27,6 +29,7 @@ At the end of this playbook, each PR should have:
 - Repository test and validation commands.
 - CODEOWNERS and protected path definitions.
 - Threshold policy for low, medium, and high risk changes.
+- AI reviewer backend configuration and repository-specific review instructions.
 
 ## Risk tiers
 
@@ -45,6 +48,8 @@ Default agent authority:
 - Review: yes
 - Approve: yes
 - Merge: yes, if all required checks pass and policy gates are satisfied
+
+Low-risk automation only works if branch protection and CODEOWNERS are scoped so that documentation-only or metadata-only changes do not still require human codeowner review.
 
 ### Medium risk
 
@@ -115,6 +120,8 @@ No PR should be approved or merged without passing required checks.
 
 Automated review must leave an auditable artifact in the PR.
 
+Repository-specific reviewer guidance **SHOULD** live in versioned files such as `.github/copilot-instructions.md` so the AI backend can be swapped without changing the playbook's policy.
+
 ## 4. Apply threshold policy
 
 Decision rules:
@@ -168,7 +175,7 @@ The first implementation should use:
 
 - GitHub Actions for deterministic checks and PR metadata workflows
 - Branch protection and auto-merge for merge enforcement
-- An agent reviewer for code review and safe autofix proposals
+- An AI reviewer backend for code review and safe autofix proposals
 - Labels or check runs for risk classification
 
 Optional later layers:
@@ -177,6 +184,12 @@ Optional later layers:
 - Preview environments
 - Policy engine for path-based authority
 - Structured workflow state outside GitHub
+
+Initial backend for this repository:
+
+- GitHub Copilot for AI review comments and suggested changes
+- Repository custom instructions in `.github/copilot-instructions.md`
+- GitHub Actions for classification, low-risk approval, and auto-merge orchestration
 
 ## Human checkpoints
 
@@ -200,6 +213,7 @@ Recommended first implementation for this repository:
 - Allow agent approval only for low-risk PRs.
 - Allow auto-merge only after required checks pass and policy allows approval.
 - Require human review for schema, workflow, security, and policy changes until thresholds are refined further.
+- Keep approval and merge authority in GitHub policy and workflows, not in the AI reviewer backend itself.
 
 ## Events
 
@@ -219,3 +233,4 @@ Example event names:
 - P1 should eventually be encoded in machine-readable process definitions under `spec/processes/`.
 - Risk tiering should evolve from simple path rules toward evidence-based thresholds.
 - Approval policy should remain stricter than review policy.
+- The reviewer backend may change over time; the threshold policy should not depend on a single provider.

--- a/docs/P1_PR_EXECUTION_LOOP.md
+++ b/docs/P1_PR_EXECUTION_LOOP.md
@@ -1,0 +1,221 @@
+# P1 - Pull request execution loop
+
+## Objective
+
+Automate the path from open pull request to merge while preserving explicit human authority for changes that exceed defined risk thresholds.
+
+P1 is the first operating playbook that runs continuously after repository foundation is in place. It defines how agents, CI, GitHub policy, and human checkpoints work together on every PR.
+
+## When to run
+
+Run P1 for every pull request targeting a protected branch.
+
+## Outcomes
+
+At the end of this playbook, each PR should have:
+
+- A risk classification.
+- Deterministic validation evidence.
+- Automated review output.
+- A decision: auto-approve, escalate, request changes, or merge when allowed.
+- An audit trail recorded in GitHub state, comments, labels, checks, or events.
+
+## Inputs
+
+- Pull request metadata, diff, changed files, labels, and author.
+- Branch protection rules and required check contexts.
+- Repository test and validation commands.
+- CODEOWNERS and protected path definitions.
+- Threshold policy for low, medium, and high risk changes.
+
+## Risk tiers
+
+### Low risk
+
+Typical examples:
+
+- Documentation
+- Comments
+- Templates
+- Non-runtime metadata
+- Safe dependency bumps with passing checks
+
+Default agent authority:
+
+- Review: yes
+- Approve: yes
+- Merge: yes, if all required checks pass and policy gates are satisfied
+
+### Medium risk
+
+Typical examples:
+
+- Application logic
+- Schemas
+- CI workflows
+- Internal tooling
+- Observability configuration
+
+Default agent authority:
+
+- Review: yes
+- Approve: conditional
+- Merge: conditional
+
+Escalate when:
+
+- The change affects protected surfaces.
+- Automated review finds unresolved material risk.
+- The diff is large, cross-cutting, or behavior-changing without clear evidence.
+
+### High risk
+
+Typical examples:
+
+- Auth and permissions
+- Billing and money movement
+- Secrets handling
+- Security policy
+- Destructive migrations
+- Production infrastructure access
+- Irreversible user-facing effects
+
+Default agent authority:
+
+- Review: yes
+- Approve: no
+- Merge: no
+
+Human approval is mandatory.
+
+## Procedure
+
+### 1. Ingest and classify
+
+1. Read the PR diff, changed files, labels, and target branch.
+2. Map changed paths and detected behavior to a risk tier.
+3. Emit the classification as a label, status, or comment.
+
+Classification should be conservative. When in doubt, move the PR upward in risk.
+
+## 2. Run deterministic checks
+
+1. Execute required validation, lint, typecheck, test, and build commands for the repository.
+2. Run security and dependency checks where applicable.
+3. Fail closed when required checks are missing or inconclusive.
+
+No PR should be approved or merged without passing required checks.
+
+## 3. Perform automated review
+
+1. Run an agent review against the diff and repository context.
+2. Produce concrete findings, not generic commentary.
+3. Distinguish blocking findings from suggestions.
+4. Attempt safe autofixes only when the policy allows it.
+
+Automated review must leave an auditable artifact in the PR.
+
+## 4. Apply threshold policy
+
+Decision rules:
+
+- Low risk: agent may approve and enable merge when checks pass and no blocking findings remain.
+- Medium risk: agent may review and prepare the PR, but approval and merge follow repository-specific threshold policy.
+- High risk: human review is mandatory before approval or merge.
+
+A threshold policy should include at least:
+
+- affected paths or systems
+- diff size or complexity thresholds
+- required evidence types
+- required human approver roles
+- rollback expectations for risky changes
+
+## 5. Resolve or escalate
+
+1. If findings are autofixable and within authority, update the branch and rerun checks.
+2. If findings are not autofixable, request changes with explicit reasons.
+3. If the PR crosses a human checkpoint, notify the required approver with the evidence bundle.
+
+Escalation should be specific about why automation stopped.
+
+## 6. Approve and merge
+
+When the PR is within policy and all required checks have passed:
+
+1. Apply approval if the actor is permitted to approve that risk tier.
+2. Enable auto-merge or merge directly according to repository policy.
+3. Ensure branch cleanup runs after merge.
+
+Merge must be blocked if required checks are pending, stale, or bypassed.
+
+## 7. Record outcomes
+
+Record:
+
+- risk tier
+- checks executed
+- findings summary
+- approval source
+- merge decision
+- escalation reason if applicable
+
+These records should be queryable from GitHub or emitted as framework events.
+
+## Recommended implementation layers
+
+The first implementation should use:
+
+- GitHub Actions for deterministic checks and PR metadata workflows
+- Branch protection and auto-merge for merge enforcement
+- An agent reviewer for code review and safe autofix proposals
+- Labels or check runs for risk classification
+
+Optional later layers:
+
+- Merge queue
+- Preview environments
+- Policy engine for path-based authority
+- Structured workflow state outside GitHub
+
+## Human checkpoints
+
+Human involvement is required when any of the following apply:
+
+- high-risk change
+- unclear ownership
+- failing or flaky required checks
+- unresolved blocking review findings
+- security-sensitive paths
+- broad cross-cutting refactors
+- confidence below the configured threshold
+
+## Baseline target for this repository
+
+Recommended first implementation for this repository:
+
+- Auto-classify PR risk from changed paths and labels.
+- Run `npm run validate` as the canonical required check.
+- Run automated agent review on every PR.
+- Allow agent approval only for low-risk PRs.
+- Allow auto-merge only after required checks pass and policy allows approval.
+- Require human review for schema, workflow, security, and policy changes until thresholds are refined further.
+
+## Events
+
+Example event names:
+
+- `pr.opened`
+- `pr.risk_classified`
+- `pr.validation_completed`
+- `pr.review_completed`
+- `pr.escalated`
+- `pr.approved`
+- `pr.auto_merge_enabled`
+- `pr.merged`
+
+## Notes for future variants
+
+- P1 should eventually be encoded in machine-readable process definitions under `spec/processes/`.
+- Risk tiering should evolve from simple path rules toward evidence-based thresholds.
+- Approval policy should remain stricter than review policy.

--- a/docs/PLAYBOOKS.md
+++ b/docs/PLAYBOOKS.md
@@ -1,0 +1,7 @@
+# Framework playbooks
+
+This directory turns repeated operational work into reusable procedures.
+
+Start here when bootstrapping a new framework-aligned repository:
+
+1. [`P0_REPOSITORY_FOUNDATION.md`](P0_REPOSITORY_FOUNDATION.md) - establish repository governance, CI, security, and merge policy before feature work begins.

--- a/docs/PLAYBOOKS.md
+++ b/docs/PLAYBOOKS.md
@@ -5,3 +5,4 @@ This directory turns repeated operational work into reusable procedures.
 Start here when bootstrapping a new framework-aligned repository:
 
 1. [`P0_REPOSITORY_FOUNDATION.md`](P0_REPOSITORY_FOUNDATION.md) - establish repository governance, CI, security, and merge policy before feature work begins.
+2. [`P1_PR_EXECUTION_LOOP.md`](P1_PR_EXECUTION_LOOP.md) - automate PR review, testing, approval, and merge within explicit risk thresholds.


### PR DESCRIPTION
## What changed

This PR turns the first framework steps into both documentation and initial repository automation.

It now includes:
- `P0 - Repository foundation`
- `P1 - Pull request execution loop`
- the initial GitHub implementation of `P1`

## Why it changed

The framework should not stop at describing governance. The first implementation of the product-led company needs those steps codified in the repo so PR handling can move from manual judgment toward policy-driven automation.

## Impact

- Adds the framework playbook index in `docs/PLAYBOOKS.md`
- Adds `docs/P0_REPOSITORY_FOUNDATION.md`
- Adds `docs/P1_PR_EXECUTION_LOOP.md`
- Extends `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md` so `P0` and `P1` are first-class framework steps
- Adds `.github/copilot-instructions.md` so Copilot review follows repo-specific guidance
- Adds PR risk classification workflow
- Adds low-risk approval and auto-merge orchestration workflow
- Scopes `CODEOWNERS` to protected repository surfaces so low-risk PR automation is possible
- Enables repository auto-merge on GitHub

## Validation

- `npm run validate`
- YAML parse check for `.github/workflows/*.yml`

## Notes

The new `P1` workflows are defined in this PR, so they will only start running against other PRs after this branch is merged into `main`.
