### PR TITLE
[codex] Add P1 residual risk policy

### DIFF
--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -1,4 +1,4 @@
-name: p1-low-risk-automation
+name: p1-policy
 
 on:
   pull_request_target:
@@ -6,7 +6,7 @@ on:
   pull_request_review:
     types: [submitted, edited, dismissed]
   workflow_run:
-    workflows: ["validate-spec", "p1-risk-classification", "p1-policy"]
+    workflows: ["validate-spec", "p1-risk-classification"]
     types: [completed]
 
 permissions:
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  evaluate:
+  decide:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
@@ -29,16 +29,13 @@ jobs:
               if (context.eventName === 'pull_request_target') {
                 return context.payload.pull_request.number;
               }
-
               if (context.eventName === 'pull_request_review') {
                 return context.payload.pull_request.number;
               }
-
               if (context.eventName === 'workflow_run') {
                 const prs = context.payload.workflow_run.pull_requests || [];
                 return prs.length > 0 ? prs[0].number : null;
               }
-
               return null;
             }
 
@@ -48,29 +45,28 @@ jobs:
               return;
             }
 
-            const prQuery = await github.graphql(
+            const data = await github.graphql(
               `
-                query PullRequestState($owner: String!, $repo: String!, $number: Int!) {
+                query PullRequestPolicy($owner: String!, $repo: String!, $number: Int!) {
                   repository(owner: $owner, name: $repo) {
                     pullRequest(number: $number) {
                       id
                       number
-                      isDraft
                       state
-                      reviewDecision
+                      isDraft
                       mergeStateStatus
-                      autoMergeRequest {
-                        enabledAt
+                      headRefOid
+                      labels(first: 30) {
+                        nodes { name }
                       }
-                      author {
-                        login
-                      }
-                      labels(first: 20) {
+                      latestReviews(first: 20) {
                         nodes {
-                          name
+                          state
+                          author {
+                            login
+                          }
                         }
                       }
-                      headRefOid
                     }
                   }
                 }
@@ -78,20 +74,15 @@ jobs:
               { owner, repo, number: prNumber },
             );
 
-            const pr = prQuery.repository.pullRequest;
+            const pr = data.repository.pullRequest;
             if (!pr || pr.state !== 'OPEN' || pr.isDraft) {
-              core.info('Pull request is not open and ready for automation.');
+              core.info('Pull request is not open and ready for policy evaluation.');
               return;
             }
 
             const labels = pr.labels.nodes.map((label) => label.name);
-            if (!labels.includes('res:l')) {
-              core.info('Pull request is not classified as residual low risk.');
-              return;
-            }
-
             if (labels.includes('stale') || pr.mergeStateStatus === 'BEHIND') {
-              core.info('Pull request is behind the protected base branch.');
+              core.setFailed('PR is stale and must be updated before policy can pass.');
               return;
             }
 
@@ -108,54 +99,28 @@ jobs:
             );
 
             if (!validateCheck || validateCheck.status !== 'completed' || validateCheck.conclusion !== 'success') {
-              core.info(`Required check ${requiredCheck} is not successful yet.`);
+              core.setFailed(`Required check ${requiredCheck} is not successful.`);
               return;
             }
 
-            const policyCheck = checksResponse.data.check_runs.find(
-              (checkRun) => checkRun.name === 'decide',
-            );
-
-            if (!policyCheck || policyCheck.status !== 'completed' || policyCheck.conclusion !== 'success') {
-              core.info('Policy check has not passed yet.');
+            const residual = labels.find((label) => ['res:l', 'res:m', 'res:h'].includes(label));
+            if (!residual) {
+              core.setFailed('Residual risk has not been set yet.');
               return;
             }
 
-            const refreshed = await github.graphql(
-              `
-                query RefreshedPullRequest($owner: String!, $repo: String!, $number: Int!) {
-                  repository(owner: $owner, name: $repo) {
-                    pullRequest(number: $number) {
-                      id
-                      autoMergeRequest {
-                        enabledAt
-                      }
-                    }
-                  }
-                }
-              `,
-              { owner, repo, number: pr.number },
-            );
-
-            const refreshedPr = refreshed.repository.pullRequest;
-
-            if (refreshedPr.autoMergeRequest) {
-              core.info('Auto-merge is already enabled.');
+            if (residual === 'res:l') {
+              core.info('Residual risk is low; policy check passes without human approval.');
               return;
             }
 
-            await github.graphql(
-              `
-                mutation EnableAutoMerge($pullRequestId: ID!) {
-                  enablePullRequestAutoMerge(input: {
-                    pullRequestId: $pullRequestId,
-                    mergeMethod: SQUASH
-                  }) {
-                    pullRequest {
-                      number
-                    }
-                  }
-                }
-              `,
-              { pullRequestId: refreshedPr.id },
+            const humanApproved = pr.latestReviews.nodes.some((review) =>
+              review.state === 'APPROVED' && review.author && !review.author.login.endsWith('[bot]'),
             );
+
+            if (!humanApproved) {
+              core.setFailed('Residual risk requires a human approval before merge.');
+              return;
+            }
+
+            core.info('Residual risk requires human approval and one is present; policy check passes.');

--- a/.github/workflows/p1-risk-classification.yml
+++ b/.github/workflows/p1-risk-classification.yml
@@ -21,16 +21,18 @@ jobs:
             const repo = context.repo.repo;
             const pr = context.payload.pull_request;
             const marker = '<!-- p1-risk-classification -->';
-            const riskLabels = ['risk:low', 'risk:medium', 'risk:high'];
-            const autoMergeLabel = 'ai:auto-merge-candidate';
-            const needsUpdateLabel = 'needs:update';
+            const riskLabels = ['risk:l', 'risk:m', 'risk:h'];
+            const residualLabels = ['res:l', 'res:m', 'res:h'];
+            const staleLabel = 'stale';
 
             const labelPalette = {
-              'risk:low': '0e8a16',
-              'risk:medium': 'fbca04',
-              'risk:high': 'd73a4a',
-              'ai:auto-merge-candidate': '1d76db',
-              'needs:update': '5319e7',
+              'risk:l': '0e8a16',
+              'risk:m': 'fbca04',
+              'risk:h': 'd73a4a',
+              'res:l': '0e8a16',
+              'res:m': 'fbca04',
+              'res:h': 'd73a4a',
+              stale: '5319e7',
             };
 
             for (const [name, color] of Object.entries(labelPalette)) {
@@ -131,7 +133,7 @@ jobs:
             }
 
             const uniqueReasons = [...new Set(reasons)];
-            const riskLabel = `risk:${risk}`;
+            const riskLabel = `risk:${risk[0]}`;
             const currentLabels = pr.labels.map((label) => label.name);
             const isBehind = pr.mergeable_state === 'behind';
 
@@ -159,43 +161,27 @@ jobs:
               });
             }
 
-            if (risk === 'low' && !currentLabels.includes(autoMergeLabel)) {
+            for (const label of residualLabels) {
+              if (!currentLabels.includes(label)) {
+                continue;
+              }
+            }
+
+            if (isBehind && !currentLabels.includes(staleLabel)) {
               await github.rest.issues.addLabels({
                 owner,
                 repo,
                 issue_number: pr.number,
-                labels: [autoMergeLabel],
+                labels: [staleLabel],
               });
             }
 
-            if (risk !== 'low' && currentLabels.includes(autoMergeLabel)) {
+            if (!isBehind && currentLabels.includes(staleLabel)) {
               await github.rest.issues.removeLabel({
                 owner,
                 repo,
                 issue_number: pr.number,
-                name: autoMergeLabel,
-              }).catch((error) => {
-                if (error.status !== 404) {
-                  throw error;
-                }
-              });
-            }
-
-            if (isBehind && !currentLabels.includes(needsUpdateLabel)) {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: pr.number,
-                labels: [needsUpdateLabel],
-              });
-            }
-
-            if (!isBehind && currentLabels.includes(needsUpdateLabel)) {
-              await github.rest.issues.removeLabel({
-                owner,
-                repo,
-                issue_number: pr.number,
-                name: needsUpdateLabel,
+                name: staleLabel,
               }).catch((error) => {
                 if (error.status !== 404) {
                   throw error;
@@ -205,7 +191,7 @@ jobs:
 
             const body = [
               marker,
-              `P1 classification: **${risk}** risk.`,
+              `P1 initial risk: **${risk}**.`,
               `Branch freshness: **${isBehind ? 'outdated' : 'current'}**.`,
               '',
               `Changed files: ${paths.map((path) => `\`${path}\``).join(', ')}`,
@@ -223,9 +209,7 @@ jobs:
                   ]
                 : []),
               'Authority under `docs/P1_PR_EXECUTION_LOOP.md`:',
-              risk === 'low' && !isBehind
-                ? '- Eligible for automation after required checks pass.'
-                : '- Human approval or branch refresh remains required before merge.',
+              '- Initial risk determines review depth. Residual risk must still be set before policy can approve or merge.',
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
+++ b/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
@@ -327,12 +327,12 @@ For deployments targeting **solo founders or minimal teams** in **B2B SaaS**, th
 #### P1 - Pull request execution loop
 
 - **Objective:** Automate PR review, testing, approval, and merge within explicit human-governed thresholds.
-- **Inputs:** PR metadata, diff, branch protection rules, required checks, threshold policy, and branch freshness state.
-- **Outputs:** Risk classification, freshness decision, validation evidence, review outcome, approval decision, and merge or escalation state.
+- **Inputs:** PR metadata, diff, branch protection rules, required checks, threshold policy, branch freshness state, and residual-risk decision.
+- **Outputs:** Initial risk classification, residual-risk decision, freshness decision, validation evidence, review outcome, approval decision, and merge or escalation state.
 - **Capabilities:** Builder, Ops, Researcher, AI reviewer backend.
 - **Checkpoints:** Human approval is **MUST** for high-risk changes and **SHOULD** be required whenever confidence or evidence falls below policy thresholds.
 - **Playbook:** `docs/P1_PR_EXECUTION_LOOP.md`
-- **Events (examples):** `pr.risk_classified`, `pr.branch_outdated`, `pr.review_completed`, `pr.escalated`, `pr.merged`.
+- **Events (examples):** `pr.risk_classified`, `pr.residual_risk_set`, `pr.branch_outdated`, `pr.review_completed`, `pr.escalated`, `pr.merged`.
 
 After P1, the library **SHOULD** contain encoded workflows for the following six operating processes.
 

--- a/docs/P1_PR_EXECUTION_LOOP.md
+++ b/docs/P1_PR_EXECUTION_LOOP.md
@@ -16,7 +16,8 @@ Run P1 for every pull request targeting a protected branch.
 
 At the end of this playbook, each PR should have:
 
-- A risk classification.
+- An initial risk classification.
+- A residual risk decision after review.
 - A branch freshness decision.
 - Deterministic validation evidence.
 - Automated review output.
@@ -32,8 +33,13 @@ At the end of this playbook, each PR should have:
 - Threshold policy for low, medium, and high risk changes.
 - AI reviewer backend configuration and repository-specific review instructions.
 - Freshness policy for PR branches relative to the protected base branch.
+- A policy decision check that maps residual risk to merge authority.
 
 ## Risk tiers
+
+Initial risk answers: how carefully should this PR be reviewed?
+
+Residual risk answers: after review and evidence, is human approval still required?
 
 ### Low risk
 
@@ -105,6 +111,20 @@ Human approval is mandatory.
 
 Classification should be conservative. When in doubt, move the PR upward in risk.
 
+Short GitHub labels are recommended for visual clarity:
+
+- `risk:l`, `risk:m`, `risk:h` for initial risk
+- `res:l`, `res:m`, `res:h` for residual risk
+- `stale` for branch freshness failures
+
+## 1.5 Determine residual risk
+
+1. Review the actual diff and validation evidence.
+2. Identify whether the initial structural risk remains material after review.
+3. Emit a residual-risk decision separately from the initial classification.
+
+Residual risk may be lower than initial risk. Example: a workflow file change is structurally medium risk, but a one-line vetted dependency bump with passing checks may be residual low risk after review.
+
 ## 2. Run deterministic checks
 
 1. Execute required validation, lint, typecheck, test, and build commands for the repository.
@@ -116,7 +136,7 @@ No PR should be approved or merged without passing required checks.
 ## 2.5 Enforce branch freshness
 
 1. Determine whether the PR branch is current with the protected base branch.
-2. If the PR is behind, label it as needing update and stop approval or merge automation.
+2. If the PR is behind, label it as `stale` and stop approval or merge automation.
 3. Re-run classification, review, and threshold checks after the branch is refreshed.
 
 Branch freshness is a hard gate. A PR evaluation is stale if the base branch has advanced in a way that could affect policy, CI, CODEOWNERS, or runtime behavior.
@@ -144,15 +164,18 @@ Repository-specific reviewer guidance **SHOULD** live in versioned files such as
 
 Decision rules:
 
-- Low risk: agent may approve and enable merge when checks pass and no blocking findings remain.
-- Medium risk: agent may review and prepare the PR, but approval and merge follow repository-specific threshold policy.
-- High risk: human review is mandatory before approval or merge.
+- Initial risk sets review depth.
+- Residual risk sets approval and merge authority.
+- Residual low: automation may approve or merge when checks pass and no blocking findings remain.
+- Residual medium: approval and merge follow repository-specific threshold policy.
+- Residual high: human review is mandatory before approval or merge.
 
 A threshold policy should include at least:
 
 - affected paths or systems
 - diff size or complexity thresholds
 - branch freshness requirements
+- initial vs residual risk rules
 - required evidence types
 - required human approver roles
 - rollback expectations for risky changes
@@ -171,7 +194,7 @@ If the PR is behind the protected branch, escalation should explicitly request a
 
 When the PR is within policy and all required checks have passed:
 
-1. Apply approval if the actor is permitted to approve that risk tier.
+1. Apply the policy decision for the residual-risk tier.
 2. Enable auto-merge or merge directly according to repository policy.
 3. Ensure branch cleanup runs after merge.
 
@@ -182,7 +205,8 @@ Merge must also be blocked if the PR branch is behind the protected base branch.
 
 Record:
 
-- risk tier
+- initial risk tier
+- residual risk tier
 - branch freshness state
 - checks executed
 - findings summary
@@ -200,6 +224,7 @@ The first implementation should use:
 - Branch protection and auto-merge for merge enforcement
 - An AI reviewer backend for code review and safe autofix proposals
 - Labels or check runs for risk classification
+- A required policy check that decides whether human approval is still necessary
 - Labels or checks for branch freshness and update requirements
 
 Optional later layers:
@@ -219,7 +244,8 @@ Initial backend for this repository:
 
 Human involvement is required when any of the following apply:
 
-- high-risk change
+- residual high risk
+- residual medium risk when repository policy requires a human checkpoint
 - unclear ownership
 - branch is behind the protected base branch and cannot be refreshed automatically
 - failing or flaky required checks
@@ -233,12 +259,14 @@ Human involvement is required when any of the following apply:
 Recommended first implementation for this repository:
 
 - Auto-classify PR risk from changed paths and labels.
-- Label stale PRs with `needs:update` and block automation until they are refreshed.
+- Distinguish initial risk from residual risk after review.
+- Label stale PRs with `stale` and block automation until they are refreshed.
 - Run `npm run validate` as the canonical required check.
 - Run automated agent review on every PR.
-- Allow agent approval only for low-risk PRs.
+- Allow automation to merge residual-low PRs.
+- Require a policy decision check before merge instead of a blanket GitHub review gate.
 - Allow auto-merge only after required checks pass and policy allows approval.
-- Require human review for schema, workflow, security, and policy changes until thresholds are refined further.
+- Require human review only when residual risk and policy thresholds still warrant it.
 - Keep approval and merge authority in GitHub policy and workflows, not in the AI reviewer backend itself.
 
 ## Events
@@ -247,6 +275,7 @@ Example event names:
 
 - `pr.opened`
 - `pr.risk_classified`
+- `pr.residual_risk_set`
 - `pr.branch_outdated`
 - `pr.branch_refreshed`
 - `pr.validation_completed`


### PR DESCRIPTION
## What changed

This PR adds the missing distinction between initial risk and residual risk in `P1`.

It updates the framework and workflows so:
- initial risk determines review depth
- residual risk determines whether human approval is still required
- a required `p1-policy` check becomes the merge authority surface

## Why it changed

Path-based risk alone is too blunt. Some PRs touch protected surfaces but are still residual low risk after review and evidence. The framework needs to encode that distinction so the 10% human checkpoint happens only when the residual risk actually warrants it.

## Impact

- Updates `docs/P1_PR_EXECUTION_LOOP.md`
- Updates `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md`
- Shortens GitHub labels to `risk:*`, `res:*`, and `stale`
- Adds `p1-policy` workflow
- Updates low-risk automation to rely on residual low risk plus a passing policy check

## Validation

- `npm run validate`
- YAML parse check for `p1-risk-classification.yml`, `p1-policy.yml`, and `p1-low-risk-automation.yml`
