### PR TITLE
[codex] Tighten P1 sync and label automation

### DIFF
--- a/.github/workflows/p1-low-risk-automation.yml
+++ b/.github/workflows/p1-low-risk-automation.yml
@@ -85,12 +85,12 @@ jobs:
             }
 
             const labels = pr.labels.nodes.map((label) => label.name);
-            if (!labels.includes('res:l')) {
+            if (!labels.includes('residual:low')) {
               core.info('Pull request is not classified as residual low risk.');
               return;
             }
 
-            if (labels.includes('stale') || pr.mergeStateStatus === 'BEHIND') {
+            if (labels.includes('sync:needed') || pr.mergeStateStatus === 'BEHIND') {
               core.info('Pull request is behind the protected base branch.');
               return;
             }

--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -81,8 +81,8 @@ jobs:
             }
 
             const labels = pr.labels.nodes.map((label) => label.name);
-            if (labels.includes('stale') || pr.mergeStateStatus === 'BEHIND') {
-              core.setFailed('PR is stale and must be updated before policy can pass.');
+            if (labels.includes('sync:needed') || pr.mergeStateStatus === 'BEHIND') {
+              core.setFailed('PR is behind the protected base branch and must be updated before policy can pass.');
               return;
             }
 
@@ -103,13 +103,13 @@ jobs:
               return;
             }
 
-            const residual = labels.find((label) => ['res:l', 'res:m', 'res:h'].includes(label));
+            const residual = labels.find((label) => ['residual:low', 'residual:med', 'residual:high'].includes(label));
             if (!residual) {
               core.setFailed('Residual risk has not been set yet.');
               return;
             }
 
-            if (residual === 'res:l') {
+            if (residual === 'residual:low') {
               core.info('Residual risk is low; policy check passes without human approval.');
               return;
             }

--- a/.github/workflows/p1-risk-classification.yml
+++ b/.github/workflows/p1-risk-classification.yml
@@ -21,18 +21,18 @@ jobs:
             const repo = context.repo.repo;
             const pr = context.payload.pull_request;
             const marker = '<!-- p1-risk-classification -->';
-            const riskLabels = ['risk:l', 'risk:m', 'risk:h'];
-            const residualLabels = ['res:l', 'res:m', 'res:h'];
-            const staleLabel = 'stale';
+            const riskLabels = ['risk:low', 'risk:med', 'risk:high'];
+            const residualLabels = ['residual:low', 'residual:med', 'residual:high'];
+            const syncLabel = 'sync:needed';
 
             const labelPalette = {
-              'risk:l': '0e8a16',
-              'risk:m': 'fbca04',
-              'risk:h': 'd73a4a',
-              'res:l': '0e8a16',
-              'res:m': 'fbca04',
-              'res:h': 'd73a4a',
-              stale: '5319e7',
+              'risk:low': '0e8a16',
+              'risk:med': 'fbca04',
+              'risk:high': 'd73a4a',
+              'residual:low': '0e8a16',
+              'residual:med': 'fbca04',
+              'residual:high': 'd73a4a',
+              'sync:needed': '5319e7',
             };
 
             for (const [name, color] of Object.entries(labelPalette)) {
@@ -133,7 +133,7 @@ jobs:
             }
 
             const uniqueReasons = [...new Set(reasons)];
-            const riskLabel = `risk:${risk[0]}`;
+            const riskLabel = `risk:${risk === 'medium' ? 'med' : risk}`;
             const currentLabels = pr.labels.map((label) => label.name);
             const isBehind = pr.mergeable_state === 'behind';
 
@@ -161,27 +161,50 @@ jobs:
               });
             }
 
+
             for (const label of residualLabels) {
               if (!currentLabels.includes(label)) {
                 continue;
               }
+
+              if (risk !== 'low' || label !== 'residual:low') {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  name: label,
+                }).catch((error) => {
+                  if (error.status !== 404) {
+                    throw error;
+                  }
+                });
+              }
             }
 
-            if (isBehind && !currentLabels.includes(staleLabel)) {
+            if (risk === 'low' && !currentLabels.includes('residual:low')) {
               await github.rest.issues.addLabels({
                 owner,
                 repo,
                 issue_number: pr.number,
-                labels: [staleLabel],
+                labels: ['residual:low'],
               });
             }
 
-            if (!isBehind && currentLabels.includes(staleLabel)) {
+            if (isBehind && !currentLabels.includes(syncLabel)) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr.number,
+                labels: [syncLabel],
+              });
+            }
+
+            if (!isBehind && currentLabels.includes(syncLabel)) {
               await github.rest.issues.removeLabel({
                 owner,
                 repo,
                 issue_number: pr.number,
-                name: staleLabel,
+                name: syncLabel,
               }).catch((error) => {
                 if (error.status !== 404) {
                   throw error;
@@ -193,6 +216,7 @@ jobs:
               marker,
               `P1 initial risk: **${risk}**.`,
               `Branch freshness: **${isBehind ? 'outdated' : 'current'}**.`,
+              `Residual risk label: **${risk === 'low' ? 'residual:low (set automatically)' : 'pending review'}**.`,
               '',
               `Changed files: ${paths.map((path) => `\`${path}\``).join(', ')}`,
               '',
@@ -204,12 +228,12 @@ jobs:
               ...(isBehind
                 ? [
                     'Freshness gate:',
-                    '- This PR is behind the protected base branch and must be updated before approval or merge automation can continue.',
+                    '- This PR is behind the protected base branch and is labeled `sync:needed` until it is updated.',
                     '',
                   ]
                 : []),
               'Authority under `docs/P1_PR_EXECUTION_LOOP.md`:',
-              '- Initial risk determines review depth. Residual risk must still be set before policy can approve or merge.',
+              '- Initial risk determines review depth. Residual risk is set automatically only when repository policy can infer it directly from the PR state.',
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
+++ b/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
@@ -330,7 +330,7 @@ For deployments targeting **solo founders or minimal teams** in **B2B SaaS**, th
 - **Inputs:** PR metadata, diff, branch protection rules, required checks, threshold policy, branch freshness state, and residual-risk decision.
 - **Outputs:** Initial risk classification, residual-risk decision, freshness decision, validation evidence, review outcome, approval decision, and merge or escalation state.
 - **Capabilities:** Builder, Ops, Researcher, AI reviewer backend.
-- **Checkpoints:** Human approval is **MUST** for high-risk changes and **SHOULD** be required whenever confidence or evidence falls below policy thresholds. Event-ordering failures between automation steps **MUST NOT** by themselves force human review. Automation-owned PRs **MUST** be synced with the current protected branch before review authority is exercised, and deterministic PR state such as residual-risk labels **MUST** be set automatically when policy can infer it.
+- **Checkpoints:** Human approval is **MUST** for high-risk changes and **SHOULD** be required whenever confidence or evidence falls below policy thresholds. Event-ordering failures between automation steps **MUST NOT** by themselves force human review. Automation-owned PRs **MUST** be synced with the current protected branch before review authority is exercised, deterministic PR state such as residual-risk labels **MUST** be set automatically when policy can infer it, and control-plane PRs **MUST** be judged by the policy currently merged on the protected branch until the update itself lands.
 - **Playbook:** `docs/P1_PR_EXECUTION_LOOP.md`
 - **Events (examples):** `pr.risk_classified`, `pr.residual_risk_set`, `pr.branch_outdated`, `pr.review_completed`, `pr.escalated`, `pr.merged`.
 

--- a/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
+++ b/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
@@ -330,7 +330,7 @@ For deployments targeting **solo founders or minimal teams** in **B2B SaaS**, th
 - **Inputs:** PR metadata, diff, branch protection rules, required checks, threshold policy, branch freshness state, and residual-risk decision.
 - **Outputs:** Initial risk classification, residual-risk decision, freshness decision, validation evidence, review outcome, approval decision, and merge or escalation state.
 - **Capabilities:** Builder, Ops, Researcher, AI reviewer backend.
-- **Checkpoints:** Human approval is **MUST** for high-risk changes and **SHOULD** be required whenever confidence or evidence falls below policy thresholds. Event-ordering failures between automation steps **MUST NOT** by themselves force human review.
+- **Checkpoints:** Human approval is **MUST** for high-risk changes and **SHOULD** be required whenever confidence or evidence falls below policy thresholds. Event-ordering failures between automation steps **MUST NOT** by themselves force human review. Automation-owned PRs **MUST** be synced with the current protected branch before review authority is exercised, and deterministic PR state such as residual-risk labels **MUST** be set automatically when policy can infer it.
 - **Playbook:** `docs/P1_PR_EXECUTION_LOOP.md`
 - **Events (examples):** `pr.risk_classified`, `pr.residual_risk_set`, `pr.branch_outdated`, `pr.review_completed`, `pr.escalated`, `pr.merged`.
 

--- a/docs/P1_PR_EXECUTION_LOOP.md
+++ b/docs/P1_PR_EXECUTION_LOOP.md
@@ -111,11 +111,11 @@ Human approval is mandatory.
 
 Classification should be conservative. When in doubt, move the PR upward in risk.
 
-Short GitHub labels are recommended for visual clarity:
+GitHub labels should be compact but self-explanatory:
 
-- `risk:l`, `risk:m`, `risk:h` for initial risk
-- `res:l`, `res:m`, `res:h` for residual risk
-- `stale` for branch freshness failures
+- `risk:low`, `risk:med`, `risk:high` for initial risk
+- `residual:low`, `residual:med`, `residual:high` for residual risk
+- `sync:needed` when the PR branch is behind the protected base branch
 
 ## 1.5 Determine residual risk
 
@@ -124,6 +124,8 @@ Short GitHub labels are recommended for visual clarity:
 3. Emit a residual-risk decision separately from the initial classification.
 
 Residual risk may be lower than initial risk. Example: a workflow file change is structurally medium risk, but a one-line vetted dependency bump with passing checks may be residual low risk after review.
+
+When residual risk is fully determined by repository policy and machine-observable evidence, automation **SHOULD** assign the residual-risk label directly instead of waiting for a manual follow-up step.
 
 ## 2. Run deterministic checks
 
@@ -136,8 +138,9 @@ No PR should be approved or merged without passing required checks.
 ## 2.5 Enforce branch freshness
 
 1. Determine whether the PR branch is current with the protected base branch.
-2. If the PR is behind, label it as `stale` and stop approval or merge automation.
+2. If the PR is behind, label it as `sync:needed` and stop approval or merge automation.
 3. Re-run classification, review, and threshold checks after the branch is refreshed.
+4. If automation owns PR creation, it **MUST** sync with the current protected base branch before opening the PR.
 
 Branch freshness is a hard gate. A PR evaluation is stale if the base branch has advanced in a way that could affect policy, CI, CODEOWNERS, or runtime behavior.
 
@@ -188,7 +191,7 @@ A threshold policy should include at least:
 
 Escalation should be specific about why automation stopped.
 
-If the PR is behind the protected branch, escalation should explicitly request a rebase or branch update before any further approval decision.
+If the PR is behind the protected branch, escalation should explicitly request a rebase or branch update before any further approval decision. Automation-owned PRs should treat this as a creation failure and reopen the review loop only after syncing.
 
 ## 6. Approve and merge
 
@@ -208,8 +211,9 @@ Automation **MUST** converge without manual label toggling when the only blocker
 Required behavior:
 
 1. If policy evaluation fails because a required validation check has not completed yet on the current head SHA, the system **MUST** re-evaluate after that validation completes.
-2. If a stale failure exists but a newer successful policy evaluation exists on the same head SHA, the newer result **MUST** control the merge decision.
-3. Manual relabeling or comment nudges **SHOULD NOT** be required for ordinary convergence.
+2. If branch freshness or residual-risk state is deterministically derivable from the current PR state, automation **MUST** set or refresh that state without manual intervention.
+3. If a stale failure exists but a newer successful policy evaluation exists on the same head SHA, the newer result **MUST** control the merge decision.
+4. Manual relabeling or comment nudges **SHOULD NOT** be required for ordinary convergence.
 
 This rule prevents false human escalation caused only by event ordering.
 
@@ -272,7 +276,7 @@ Recommended first implementation for this repository:
 
 - Auto-classify PR risk from changed paths and labels.
 - Distinguish initial risk from residual risk after review.
-- Label stale PRs with `stale` and block automation until they are refreshed.
+- Label outdated PRs with `sync:needed` and block automation until they are refreshed.
 - Run `npm run validate` as the canonical required check.
 - Run automated agent review on every PR.
 - Allow automation to merge residual-low PRs.

--- a/docs/P1_PR_EXECUTION_LOOP.md
+++ b/docs/P1_PR_EXECUTION_LOOP.md
@@ -217,6 +217,16 @@ Required behavior:
 
 This rule prevents false human escalation caused only by event ordering.
 
+## 6.6 Control-plane changes
+
+PRs that modify the PR automation control plane itself, including workflow files, branch-protection assumptions, or review-policy logic, **MUST** be evaluated under the currently merged policy on the protected branch, not the proposed policy in the PR branch.
+
+Required behavior:
+
+1. Automation changes do not self-validate until they are merged into the protected branch.
+2. The active workflow version on the protected branch is the source of truth for labels, checks, and merge authority during review.
+3. Framework updates should record any bootstrap exception used to merge a control-plane change.
+
 ## 7. Record outcomes
 
 Record:


### PR DESCRIPTION
## What changed
- codifies that automation-owned PRs must be synced with the protected branch before review authority starts
- replaces overly short labels with compact descriptive labels
- makes low-risk residual labeling deterministic for policy-owned cases

## Why
This closes the gap exposed by PR #6: automation should not rely on manual relabeling or tolerate opening stale PRs.

## Validation
- npm run validate