### PR TITLE
feat(p1): pluggable PR review adapter and workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ Use `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md` as the primary operating guideline fo
 
 When reviewing or proposing changes:
 
-- CI workflow `p1-review-adapter` writes machine-readable `review-findings.json` (schema: `spec/schema/review-findings.schema.json`) via `scripts/review-adapter.mjs`; policy can consume that artifact in a later step.
+- CI: `p1-review-adapter` runs `scripts/review-adapter.mjs` (with `P1_INITIAL_RISK` from `scripts/p1-risk-from-paths.mjs` + `spec/policy/p1-path-risk.json`) and uploads `review-findings.json`. `p1-apply-residual` then sets `residual:*` labels from `residual_assessment` (after P1 guardrails in the adapter). Schema: `spec/schema/review-findings.schema.json`.
 - Follow the playbooks in `docs/PLAYBOOKS.md`.
 - Apply `docs/P1_PR_EXECUTION_LOOP.md` when reasoning about pull requests.
 - Treat the framework as provider-agnostic. Do not introduce vendor-specific assumptions into core policy unless the change is explicitly implementation-specific.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,7 @@ Use `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md` as the primary operating guideline fo
 
 When reviewing or proposing changes:
 
+- CI workflow `p1-review-adapter` writes machine-readable `review-findings.json` (schema: `spec/schema/review-findings.schema.json`) via `scripts/review-adapter.mjs`; policy can consume that artifact in a later step.
 - Follow the playbooks in `docs/PLAYBOOKS.md`.
 - Apply `docs/P1_PR_EXECUTION_LOOP.md` when reasoning about pull requests.
 - Treat the framework as provider-agnostic. Do not introduce vendor-specific assumptions into core policy unless the change is explicitly implementation-specific.

--- a/.github/workflows/p1-apply-residual.yml
+++ b/.github/workflows/p1-apply-residual.yml
@@ -1,0 +1,128 @@
+name: p1-apply-residual
+
+on:
+  workflow_run:
+    workflows: [p1-review-adapter]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  apply:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download review-findings artifact
+        uses: actions/download-artifact@v4
+        id: download
+        continue-on-error: true
+        with:
+          name: review-findings
+          path: findings
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.workflow_run.repository.full_name }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Apply residual labels from adapter output
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const file = path.join('findings', 'review-findings.json');
+            if (!fs.existsSync(file)) {
+              core.notice('review-findings.json missing; skipping residual labels.');
+              return;
+            }
+            const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+            const residual = doc.residual_assessment;
+            if (!residual || !['low', 'med', 'high'].includes(residual.level)) {
+              core.setFailed('Invalid residual_assessment in review-findings.json');
+              return;
+            }
+
+            let prNumber = doc.pull_request?.number;
+            if (prNumber == null) {
+              const prs = context.payload.workflow_run.pull_requests || [];
+              prNumber = prs[0]?.number;
+            }
+            if (prNumber == null) {
+              core.setFailed('Could not resolve pull request number for residual labeling.');
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const residualLabels = ['residual:low', 'residual:med', 'residual:high'];
+            const target = `residual:${residual.level}`;
+
+            const { data: issue } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: prNumber,
+            });
+            const current = issue.labels.map((l) => l.name);
+
+            for (const label of residualLabels) {
+              if (current.includes(label) && label !== target) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  name: label,
+                }).catch((e) => {
+                  if (e.status !== 404) throw e;
+                });
+              }
+            }
+
+            if (!current.includes(target)) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: [target],
+              });
+            }
+
+            const marker = '<!-- p1-residual-assessment -->';
+            const body = [
+              marker,
+              `**Residual risk (automated):** \`${target}\``,
+              '',
+              residual.rationale,
+              '',
+              `_Adapter: ${doc.provider} · document ${doc.generated_at}_`,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (c) => c.user?.type === 'Bot' && c.body?.includes(marker),
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+            core.info(`Applied ${target} to PR #${prNumber}`);

--- a/.github/workflows/p1-low-risk-automation.yml
+++ b/.github/workflows/p1-low-risk-automation.yml
@@ -6,7 +6,11 @@ on:
   pull_request_review:
     types: [submitted, edited, dismissed]
   workflow_run:
-    workflows: ["validate-spec", "p1-risk-classification", "p1-policy"]
+    workflows:
+      - validate-spec
+      - p1-risk-classification
+      - p1-apply-residual
+      - p1-policy
     types: [completed]
 
 permissions:

--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -6,7 +6,10 @@ on:
   pull_request_review:
     types: [submitted, edited, dismissed]
   workflow_run:
-    workflows: ["validate-spec", "p1-risk-classification"]
+    workflows:
+      - validate-spec
+      - p1-risk-classification
+      - p1-apply-residual
     types: [completed]
 
 permissions:

--- a/.github/workflows/p1-review-adapter.yml
+++ b/.github/workflows/p1-review-adapter.yml
@@ -23,6 +23,18 @@ jobs:
           git fetch origin "${{ github.event.pull_request.base.ref }}"
           git diff "origin/${{ github.event.pull_request.base.ref }}...HEAD" > pr.diff
 
+      - name: Initial risk from paths (P1)
+        run: |
+          git diff --name-only "origin/${{ github.event.pull_request.base.ref }}...HEAD" > changed-paths.txt
+          node scripts/p1-risk-from-paths.mjs changed-paths.txt > risk-out.json
+          RISK=$(node -p "JSON.parse(require('fs').readFileSync('risk-out.json','utf8')).risk")
+          case "$RISK" in
+            low) echo "P1_INITIAL_RISK=low" >> "$GITHUB_ENV" ;;
+            medium) echo "P1_INITIAL_RISK=med" >> "$GITHUB_ENV" ;;
+            high) echo "P1_INITIAL_RISK=high" >> "$GITHUB_ENV" ;;
+            *) echo "Unexpected risk: $RISK"; exit 1 ;;
+          esac
+
       - uses: actions/setup-node@v6
         with:
           node-version: "20"

--- a/.github/workflows/p1-review-adapter.yml
+++ b/.github/workflows/p1-review-adapter.yml
@@ -1,0 +1,48 @@
+name: p1-review-adapter
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  review_adapter:
+    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Build PR diff
+        run: |
+          git fetch origin "${{ github.event.pull_request.base.ref }}"
+          git diff "origin/${{ github.event.pull_request.base.ref }}...HEAD" > pr.diff
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Run review adapter
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_REVIEW_MODEL }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            node scripts/review-adapter.mjs --diff-file pr.diff --provider anthropic --out review-findings.json
+          else
+            node scripts/review-adapter.mjs --diff-file pr.diff --provider stub --out review-findings.json
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: review-findings
+          path: review-findings.json
+          if-no-files-found: error

--- a/.github/workflows/p1-risk-classification.yml
+++ b/.github/workflows/p1-risk-classification.yml
@@ -14,6 +14,8 @@ jobs:
     if: github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
       - uses: actions/github-script@v7
         with:
           script: |
@@ -22,7 +24,6 @@ jobs:
             const pr = context.payload.pull_request;
             const marker = '<!-- p1-risk-classification -->';
             const riskLabels = ['risk:low', 'risk:med', 'risk:high'];
-            const residualLabels = ['residual:low', 'residual:med', 'residual:high'];
             const syncLabel = 'sync:needed';
 
             const labelPalette = {
@@ -59,80 +60,20 @@ jobs:
 
             const paths = files.map((file) => file.filename);
 
-            const protectedPatterns = [
-              '.github/workflows/**',
-              '.github/dependabot.yml',
-              'agents/**',
-              'package.json',
-              'package-lock.json',
-              'scripts/**',
-              'spec/**',
-              'templates/**',
-              'SECURITY.md',
-            ];
-
-            const highRiskPatterns = [
-              '**/auth/**',
-              '**/billing/**',
-              '**/payments/**',
-              '**/secrets/**',
-              '**/credentials/**',
-              '**/migrations/**',
-              '**/terraform/**',
-              '**/iac/**',
-            ];
-
-            const lowRiskPatterns = [
-              'docs/**',
-              'README.md',
-              'REPO_SCAFFOLD.md',
-              'CONTRIBUTING.md',
-              '.github/pull_request_template.md',
-              '.github/ISSUE_TEMPLATE/**',
-            ];
-
-            function escapeRegex(value) {
-              return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+            const { spawnSync } = require('child_process');
+            const path = require('path');
+            const root = process.env.GITHUB_WORKSPACE;
+            const proc = spawnSync(process.execPath, [path.join(root, 'scripts', 'p1-risk-from-paths.mjs')], {
+              cwd: root,
+              input: paths.join('\n'),
+              encoding: 'utf8',
+            });
+            if (proc.status !== 0) {
+              core.setFailed(proc.stderr || proc.stdout || 'p1-risk-from-paths failed');
+              return;
             }
+            const { risk, reasons: uniqueReasons } = JSON.parse(proc.stdout);
 
-            function patternToRegExp(pattern) {
-              let source = escapeRegex(pattern);
-              source = source.replace(/\*\*/g, '.*');
-              source = source.replace(/\*/g, '[^/]*');
-              return new RegExp(`^${source}$`);
-            }
-
-            function matches(path, patterns) {
-              return patterns.some((pattern) => patternToRegExp(pattern).test(path));
-            }
-
-            let risk = 'low';
-            const reasons = [];
-
-            for (const path of paths) {
-              if (matches(path, highRiskPatterns)) {
-                risk = 'high';
-                reasons.push(`${path} matches a high-risk protected surface.`);
-                continue;
-              }
-
-              if (matches(path, protectedPatterns)) {
-                if (risk !== 'high') {
-                  risk = 'medium';
-                }
-                reasons.push(`${path} matches a protected repository surface.`);
-                continue;
-              }
-
-              if (!matches(path, lowRiskPatterns)) {
-                if (risk === 'low') {
-                  risk = 'medium';
-                }
-                reasons.push(`${path} does not match the low-risk path allowlist.`);
-              }
-            }
-
-            const uniqueReasons = [...new Set(reasons)];
             const riskLabel = `risk:${risk === 'medium' ? 'med' : risk}`;
             const currentLabels = pr.labels.map((label) => label.name);
             const isBehind = pr.mergeable_state === 'behind';
@@ -158,35 +99,6 @@ jobs:
                 repo,
                 issue_number: pr.number,
                 labels: [riskLabel],
-              });
-            }
-
-
-            for (const label of residualLabels) {
-              if (!currentLabels.includes(label)) {
-                continue;
-              }
-
-              if (risk !== 'low' || label !== 'residual:low') {
-                await github.rest.issues.removeLabel({
-                  owner,
-                  repo,
-                  issue_number: pr.number,
-                  name: label,
-                }).catch((error) => {
-                  if (error.status !== 404) {
-                    throw error;
-                  }
-                });
-              }
-            }
-
-            if (risk === 'low' && !currentLabels.includes('residual:low')) {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: pr.number,
-                labels: ['residual:low'],
               });
             }
 
@@ -216,9 +128,9 @@ jobs:
               marker,
               `P1 initial risk: **${risk}**.`,
               `Branch freshness: **${isBehind ? 'outdated' : 'current'}**.`,
-              `Residual risk label: **${risk === 'low' ? 'residual:low (set automatically)' : 'pending review'}**.`,
+              `Residual risk: **set by \`p1-apply-residual\` after \`p1-review-adapter\` finishes** (see \`review-findings.json\` artifact).`,
               '',
-              `Changed files: ${paths.map((path) => `\`${path}\``).join(', ')}`,
+              `Changed files: ${paths.map((p) => `\`${p}\``).join(', ')}`,
               '',
               'Why:',
               ...(uniqueReasons.length > 0
@@ -233,7 +145,7 @@ jobs:
                   ]
                 : []),
               'Authority under `docs/P1_PR_EXECUTION_LOOP.md`:',
-              '- Initial risk determines review depth. Residual risk is set automatically only when repository policy can infer it directly from the PR state.',
+              '- Initial risk sets review depth; residual risk is derived from automated review output plus guardrails.',
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/agents/interfaces.yaml
+++ b/agents/interfaces.yaml
@@ -60,10 +60,15 @@ interfaces:
     description: >
       Produce machine-readable PR review findings for policy checks. Implementations
       (Copilot UI, SaaS bots, or scripts/review-adapter.mjs) MUST output JSON valid
-      against spec/schema/review-findings.schema.json.
+      against spec/schema/review-findings.schema.json. Residual tier MUST be merged
+      with P1 guardrails (see scripts/review-adapter.mjs); workflow p1-apply-residual
+      maps residual_assessment.level to GitHub labels.
     inputs:
       diff_text:
         type: string
+      initial_risk:
+        type: string
+        description: "Path-based tier: low | med | high (P1 initial risk)."
       repository_instructions_path:
         type: string
         description: "e.g. .github/copilot-instructions.md"
@@ -76,7 +81,7 @@ interfaces:
     outputs:
       findings_document:
         type: object
-        description: "Validated review-findings v1.0.0 document."
+        description: "Validated review-findings v1.0.0 document including residual_assessment."
 
 policies:
   human_in_the_loop:

--- a/agents/interfaces.yaml
+++ b/agents/interfaces.yaml
@@ -56,6 +56,28 @@ interfaces:
       properties:
         type: object
 
+  review_pull_request:
+    description: >
+      Produce machine-readable PR review findings for policy checks. Implementations
+      (Copilot UI, SaaS bots, or scripts/review-adapter.mjs) MUST output JSON valid
+      against spec/schema/review-findings.schema.json.
+    inputs:
+      diff_text:
+        type: string
+      repository_instructions_path:
+        type: string
+        description: "e.g. .github/copilot-instructions.md"
+      pull_request:
+        type: object
+        description: "Optional metadata: number, base_sha, head_sha, refs."
+      provider:
+        type: string
+        description: "Logical backend id: stub, anthropic, openai, etc."
+    outputs:
+      findings_document:
+        type: object
+        description: "Validated review-findings v1.0.0 document."
+
 policies:
   human_in_the_loop:
     required_for:

--- a/docs/P1_PR_EXECUTION_LOOP.md
+++ b/docs/P1_PR_EXECUTION_LOOP.md
@@ -127,6 +127,8 @@ Residual risk may be lower than initial risk. Example: a workflow file change is
 
 When residual risk is fully determined by repository policy and machine-observable evidence, automation **SHOULD** assign the residual-risk label directly instead of waiting for a manual follow-up step.
 
+**This repository:** `p1-review-adapter` runs the reviewer (`scripts/review-adapter.mjs`) with path-based **initial** risk from `scripts/p1-risk-from-paths.mjs` / `spec/policy/p1-path-risk.json`. The adapter merges the agent’s proposed **residual** tier with P1 guardrails (for example: initial `risk:high` always keeps residual high; blocking findings raise residual; truncated diff keeps residual at least medium). `p1-apply-residual` then sets `residual:*` on the PR and posts a short audit comment.
+
 ## 2. Run deterministic checks
 
 1. Execute required validation, lint, typecheck, test, and build commands for the repository.
@@ -264,7 +266,7 @@ Initial backend for this repository:
 
 - GitHub Copilot for AI review comments and suggested changes
 - Repository custom instructions in `.github/copilot-instructions.md`
-- GitHub Actions for classification, low-risk approval, and auto-merge orchestration
+- GitHub Actions for classification, review adapter, residual labeling, low-risk approval, and auto-merge orchestration
 
 ## Human checkpoints
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "description": "Agent-native product spec schemas, policies, and validation (canonical source: spec/)",
   "scripts": {
-    "validate": "node scripts/validate-spec.mjs"
+    "validate": "node scripts/validate-spec.mjs",
+    "review:adapter": "node scripts/review-adapter.mjs"
   },
   "devDependencies": {
     "ajv": "^8.17.1",

--- a/scripts/p1-risk-from-paths.mjs
+++ b/scripts/p1-risk-from-paths.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * P1 initial risk from changed paths (reads spec/policy/p1-path-risk.json).
+ * Usage: node scripts/p1-risk-from-paths.mjs [paths-file]
+ *        (stdin: newline-separated paths if no file)
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, "..");
+const policyPath = path.join(root, "spec", "policy", "p1-path-risk.json");
+
+function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+function patternToRegExp(pattern) {
+  let source = escapeRegex(pattern);
+  source = source.replace(/\*\*/g, ".*");
+  source = source.replace(/\*/g, "[^/]*");
+  return new RegExp(`^${source}$`);
+}
+
+function matches(p, patterns) {
+  return patterns.some((pattern) => patternToRegExp(pattern).test(p));
+}
+
+function riskFromPaths(paths, policy) {
+  const { highRiskPatterns, protectedPatterns, lowRiskPatterns } = policy;
+  let risk = "low";
+  const reasons = [];
+
+  for (const p of paths) {
+    if (!p) continue;
+    if (matches(p, highRiskPatterns)) {
+      risk = "high";
+      reasons.push(`${p} matches a high-risk protected surface.`);
+      continue;
+    }
+    if (matches(p, protectedPatterns)) {
+      if (risk !== "high") risk = "medium";
+      reasons.push(`${p} matches a protected repository surface.`);
+      continue;
+    }
+    if (!matches(p, lowRiskPatterns)) {
+      if (risk === "low") risk = "medium";
+      reasons.push(`${p} does not match the low-risk path allowlist.`);
+    }
+  }
+
+  return {
+    risk,
+    reasons: [...new Set(reasons)],
+  };
+}
+
+function readPaths() {
+  const file = process.argv[2];
+  const raw = file
+    ? fs.readFileSync(path.resolve(file), "utf8")
+    : fs.readFileSync(0, "utf8");
+  return raw
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+const policy = JSON.parse(fs.readFileSync(policyPath, "utf8"));
+const paths = readPaths();
+const result = riskFromPaths(paths, policy);
+process.stdout.write(JSON.stringify(result));

--- a/scripts/review-adapter.mjs
+++ b/scripts/review-adapter.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+/**
+ * Provider-agnostic PR review adapter: produces JSON validated against
+ * spec/schema/review-findings.schema.json for policy and CI consumption.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { fileURLToPath } from "node:url";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, "..");
+const schemaPath = path.join(root, "spec", "schema", "review-findings.schema.json");
+
+const MAX_DIFF_CHARS = 200_000;
+
+const { values: args } = parseArgs({
+  options: {
+    provider: { type: "string", default: "stub" },
+    "diff-file": { type: "string" },
+    out: { type: "string" },
+    instructions: {
+      type: "string",
+      default: path.join(root, ".github", "copilot-instructions.md"),
+    },
+    help: { type: "boolean", short: "h", default: false },
+  },
+  allowPositionals: false,
+});
+
+function usage() {
+  console.error(`Usage: node scripts/review-adapter.mjs --diff-file <path> [--provider stub|anthropic] [--out findings.json] [--instructions path]
+
+Environment (anthropic):
+  ANTHROPIC_API_KEY   Required for --provider anthropic
+  ANTHROPIC_MODEL     Optional, default claude-3-5-haiku-20241022
+
+Optional PR context (from GitHub Actions or manual):
+  GITHUB_EVENT_PATH   If set and contains pull_request, fills pull_request in output.
+`);
+}
+
+if (args.help) {
+  usage();
+  process.exit(0);
+}
+
+if (!args["diff-file"]) {
+  usage();
+  console.error("Error: --diff-file is required.");
+  process.exit(1);
+}
+
+const diffPath = path.resolve(args["diff-file"]);
+if (!fs.existsSync(diffPath)) {
+  console.error("Diff file not found:", diffPath);
+  process.exit(1);
+}
+
+let diffText = fs.readFileSync(diffPath, "utf8");
+let truncatedDiff = false;
+if (diffText.length > MAX_DIFF_CHARS) {
+  truncatedDiff = true;
+  diffText =
+    diffText.slice(0, MAX_DIFF_CHARS) +
+    "\n\n[diff truncated by review-adapter for provider limits]\n";
+}
+
+let instructions = "";
+const instrPath = path.resolve(args.instructions);
+if (fs.existsSync(instrPath)) {
+  instructions = fs.readFileSync(instrPath, "utf8");
+}
+
+function readPullRequestFromGithubEvent() {
+  const p = process.env.GITHUB_EVENT_PATH;
+  if (!p || !fs.existsSync(p)) return undefined;
+  try {
+    const ev = JSON.parse(fs.readFileSync(p, "utf8"));
+    const pr = ev.pull_request;
+    if (!pr) return undefined;
+    return {
+      number: pr.number,
+      base_sha: pr.base?.sha,
+      head_sha: pr.head?.sha,
+      base_ref: pr.base?.ref,
+      head_ref: pr.head?.ref,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function stripJsonFence(text) {
+  const fence = /^```(?:json)?\s*\n?([\s\S]*?)\n?```\s*$/m.exec(text.trim());
+  if (fence) return fence[1].trim();
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start >= 0 && end > start) return text.slice(start, end + 1);
+  return text.trim();
+}
+
+async function providerStub() {
+  return {
+    schema_version: "1.0.0",
+    provider: "stub",
+    generated_at: new Date().toISOString(),
+    summary:
+      "Stub provider: no LLM review ran. CI uses this by default; set ANTHROPIC_API_KEY and --provider anthropic for automated findings.",
+    findings: [],
+    confidence: "high",
+    ...(truncatedDiff ? { truncated_diff: true } : {}),
+  };
+}
+
+async function providerAnthropic() {
+  const key = process.env.ANTHROPIC_API_KEY;
+  if (!key) {
+    console.error("ANTHROPIC_API_KEY is required for --provider anthropic");
+    process.exit(1);
+  }
+  const model =
+    process.env.ANTHROPIC_MODEL || "claude-3-5-haiku-20241022";
+
+  const schemaHint = `Return ONLY a JSON object (no markdown) with this shape:
+{
+  "schema_version": "1.0.0",
+  "provider": "anthropic",
+  "generated_at": "<ISO-8601 now>",
+  "summary": "<short overall assessment>",
+  "findings": [
+    {
+      "severity": "critical" | "medium" | "minor" | "info",
+      "blocking": true | false,
+      "message": "<specific finding>",
+      "path": "<optional repo-relative path>",
+      "line": <optional positive integer>,
+      "code": "<optional short id>"
+    }
+  ],
+  "confidence": "low" | "medium" | "high"
+}
+
+Rules:
+- blocking true only for issues that should block merge without human override (security, correctness, spec violations).
+- Use severity critical for security/data issues; medium for likely bugs; minor/info for style or nits.
+- If the diff is fine, findings may be [].`;
+
+  const userContent = [
+    "You are a code reviewer for this repository. Follow repository instructions below.\n",
+    "--- Repository instructions ---\n",
+    instructions || "(none provided)\n",
+    "---\n",
+    schemaHint,
+    "\n--- Diff ---\n",
+    diffText,
+  ].join("");
+
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": key,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 4096,
+      messages: [{ role: "user", content: userContent }],
+    }),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text();
+    console.error("Anthropic API error:", res.status, errText);
+    process.exit(1);
+  }
+
+  const data = await res.json();
+  const textBlock = data.content?.find((b) => b.type === "text");
+  if (!textBlock?.text) {
+    console.error("Unexpected Anthropic response:", JSON.stringify(data));
+    process.exit(1);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(stripJsonFence(textBlock.text));
+  } catch (e) {
+    console.error("Failed to parse model JSON:", e.message);
+    console.error("Raw:", textBlock.text.slice(0, 2000));
+    process.exit(1);
+  }
+
+  parsed.schema_version = "1.0.0";
+  parsed.provider = "anthropic";
+  if (truncatedDiff) parsed.truncated_diff = true;
+  return parsed;
+}
+
+const providers = {
+  stub: providerStub,
+  anthropic: providerAnthropic,
+};
+
+async function main() {
+  const name = args.provider;
+  const run = providers[name];
+  if (!run) {
+    console.error(`Unknown provider: ${name}. Choose: ${Object.keys(providers).join(", ")}`);
+    process.exit(1);
+  }
+
+  let doc = await run();
+  const pr = readPullRequestFromGithubEvent();
+  if (pr && pr.number != null) {
+    doc.pull_request = {
+      ...(doc.pull_request || {}),
+      ...pr,
+    };
+  }
+
+  if (!doc.generated_at) {
+    doc.generated_at = new Date().toISOString();
+  }
+
+  const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+  if (schema.$schema) delete schema.$schema;
+  const ajv = new Ajv({ allErrors: true, strict: true });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  if (!validate(doc)) {
+    console.error("Adapter output failed schema validation:", validate.errors);
+    console.error("Document:", JSON.stringify(doc, null, 2));
+    process.exit(1);
+  }
+
+  const json = JSON.stringify(doc, null, 2);
+  if (args.out) {
+    fs.writeFileSync(path.resolve(args.out), json, "utf8");
+    console.log("Wrote", path.resolve(args.out));
+  } else {
+    console.log(json);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/review-adapter.mjs
+++ b/scripts/review-adapter.mjs
@@ -20,6 +20,10 @@ const { values: args } = parseArgs({
   options: {
     provider: { type: "string", default: "stub" },
     "diff-file": { type: "string" },
+    "initial-risk": {
+      type: "string",
+      description: "Overrides P1_INITIAL_RISK (low | med | high)",
+    },
     out: { type: "string" },
     instructions: {
       type: "string",
@@ -36,6 +40,10 @@ function usage() {
 Environment (anthropic):
   ANTHROPIC_API_KEY   Required for --provider anthropic
   ANTHROPIC_MODEL     Optional, default claude-3-5-haiku-20241022
+
+P1 initial risk (required for residual guardrails):
+  P1_INITIAL_RISK     low | med | high  (medium accepted)
+  --initial-risk      Same, overrides env for local runs
 
 Optional PR context (from GitHub Actions or manual):
   GITHUB_EVENT_PATH   If set and contains pull_request, fills pull_request in output.
@@ -102,6 +110,106 @@ function stripJsonFence(text) {
   return text.trim();
 }
 
+function parseRiskToken(raw) {
+  const v = (raw || "").trim().toLowerCase();
+  if (v === "high") return "high";
+  if (v === "medium" || v === "med") return "medium";
+  if (v === "low") return "low";
+  return null;
+}
+
+function resolveInitialRisk() {
+  return (
+    parseRiskToken(args["initial-risk"]) || parseRiskToken(process.env.P1_INITIAL_RISK)
+  );
+}
+
+/**
+ * Merge model suggestion with P1 guardrails. Initial risk is structural (paths);
+ * residual is post-review authority.
+ */
+function resolveResidual(initial, doc, modelResidual) {
+  const findings = doc.findings || [];
+  const blocking = findings.filter((f) => f.blocking);
+  const criticalBlocking = blocking.some((f) => f.severity === "critical");
+  const modelLevel = modelResidual?.level;
+  const modelRationale = (modelResidual?.rationale || "").trim();
+
+  if (initial === "high") {
+    return {
+      level: "high",
+      rationale:
+        "P1 guardrail: initial risk is high; residual stays high until mandatory human review.",
+    };
+  }
+
+  if (criticalBlocking) {
+    const msgs = blocking
+      .filter((f) => f.severity === "critical")
+      .map((f) => f.message)
+      .join("; ");
+    return {
+      level: "high",
+      rationale: `Blocking critical finding(s): ${msgs}`,
+    };
+  }
+
+  if (blocking.length > 0) {
+    return {
+      level: "med",
+      rationale: `Blocking finding(s) present (${blocking.length}); human or follow-up required before merge automation.`,
+    };
+  }
+
+  if (doc.truncated_diff) {
+    return {
+      level: "med",
+      rationale:
+        "Diff was truncated for the reviewer; conservative residual until full diff is reviewed.",
+    };
+  }
+
+  if (initial === "medium") {
+    if (doc.provider === "stub") {
+      return {
+        level: "med",
+        rationale:
+          "Stub reviewer (no LLM): medium initial risk without blocking findings; residual medium until a real review or human approval.",
+      };
+    }
+    const wantsLow = modelLevel === "low";
+    const confOk = doc.confidence === "high";
+    if (wantsLow && confOk) {
+      return {
+        level: "low",
+        rationale:
+          modelRationale ||
+          "No blocking findings; reviewer assessed residual low with high confidence.",
+      };
+    }
+    if (modelLevel === "high") {
+      return {
+        level: "high",
+        rationale: modelRationale || "Reviewer escalated residual to high.",
+      };
+    }
+    return {
+      level: "med",
+      rationale:
+        modelRationale ||
+        "Medium initial risk; reviewer did not clear for automated low residual.",
+    };
+  }
+
+  // initial low
+  return {
+    level: "low",
+    rationale:
+      modelRationale ||
+      "Initial low risk and no blocking findings after automated review.",
+  };
+}
+
 async function providerStub() {
   return {
     schema_version: "1.0.0",
@@ -115,7 +223,7 @@ async function providerStub() {
   };
 }
 
-async function providerAnthropic() {
+async function providerAnthropic(initialRiskLabel) {
   const key = process.env.ANTHROPIC_API_KEY;
   if (!key) {
     console.error("ANTHROPIC_API_KEY is required for --provider anthropic");
@@ -140,10 +248,20 @@ async function providerAnthropic() {
       "code": "<optional short id>"
     }
   ],
-  "confidence": "low" | "medium" | "high"
+  "confidence": "low" | "medium" | "high",
+  "residual_assessment": {
+    "level": "low" | "med" | "high",
+    "rationale": "<why this residual tier is appropriate given findings and initial risk>"
+  }
 }
 
-Rules:
+Context: P1 **initial structural risk** for this PR (from path policy) is **${initialRiskLabel}**.
+- If initial is **high**, you may still note findings but the pipeline will force residual **high** until a human reviews.
+- Prefer **residual low** only when there are **no blocking findings** and you have **high** confidence the change is safe to merge under automation.
+- Use **residual med** when uncertain or when the change warrants human eyes despite no hard blockers.
+- Use **residual high** for material security, correctness, or policy risk.
+
+Rules for findings:
 - blocking true only for issues that should block merge without human override (security, correctness, spec violations).
 - Use severity critical for security/data issues; medium for likely bugs; minor/info for style or nits.
 - If the diff is fine, findings may be [].`;
@@ -200,20 +318,35 @@ Rules:
   return parsed;
 }
 
-const providers = {
-  stub: providerStub,
-  anthropic: providerAnthropic,
-};
-
 async function main() {
+  const initial = resolveInitialRisk();
+  if (!initial) {
+    console.error(
+      "Set P1_INITIAL_RISK or --initial-risk to low | med | high (path-based initial risk for P1).",
+    );
+    process.exit(1);
+  }
+  const initialRiskLabel =
+    initial === "medium" ? "medium (med)" : initial === "high" ? "high" : "low";
+
   const name = args.provider;
-  const run = providers[name];
-  if (!run) {
-    console.error(`Unknown provider: ${name}. Choose: ${Object.keys(providers).join(", ")}`);
+  if (name !== "stub" && name !== "anthropic") {
+    console.error(`Unknown provider: ${name}. Choose: stub, anthropic`);
     process.exit(1);
   }
 
-  let doc = await run();
+  const doc =
+    name === "anthropic"
+      ? await providerAnthropic(initialRiskLabel)
+      : await providerStub();
+
+  const modelResidual = doc.residual_assessment
+    ? { ...doc.residual_assessment }
+    : null;
+  delete doc.residual_assessment;
+
+  doc.residual_assessment = resolveResidual(initial, doc, modelResidual);
+
   const pr = readPullRequestFromGithubEvent();
   if (pr && pr.number != null) {
     doc.pull_request = {

--- a/spec/policy/p1-path-risk.json
+++ b/spec/policy/p1-path-risk.json
@@ -1,0 +1,32 @@
+{
+  "$comment": "Single source for P1 path-based initial risk (keep in sync with docs/P1_PR_EXECUTION_LOOP.md).",
+  "protectedPatterns": [
+    ".github/workflows/**",
+    ".github/dependabot.yml",
+    "agents/**",
+    "package.json",
+    "package-lock.json",
+    "scripts/**",
+    "spec/**",
+    "templates/**",
+    "SECURITY.md"
+  ],
+  "highRiskPatterns": [
+    "**/auth/**",
+    "**/billing/**",
+    "**/payments/**",
+    "**/secrets/**",
+    "**/credentials/**",
+    "**/migrations/**",
+    "**/terraform/**",
+    "**/iac/**"
+  ],
+  "lowRiskPatterns": [
+    "docs/**",
+    "README.md",
+    "REPO_SCAFFOLD.md",
+    "CONTRIBUTING.md",
+    ".github/pull_request_template.md",
+    ".github/ISSUE_TEMPLATE/**"
+  ]
+}

--- a/spec/schema/review-findings.schema.json
+++ b/spec/schema/review-findings.schema.json
@@ -10,7 +10,8 @@
     "generated_at",
     "summary",
     "findings",
-    "confidence"
+    "confidence",
+    "residual_assessment"
   ],
   "properties": {
     "schema_version": {
@@ -83,6 +84,22 @@
     "truncated_diff": {
       "type": "boolean",
       "description": "True when the diff was truncated before sending to the provider."
+    },
+    "residual_assessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "rationale"],
+      "description": "Final residual risk after agent analysis and P1 guardrails (maps to label residual:*).",
+      "properties": {
+        "level": {
+          "type": "string",
+          "enum": ["low", "med", "high"]
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
     }
   }
 }

--- a/spec/schema/review-findings.schema.json
+++ b/spec/schema/review-findings.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ai-native-framework.local/schemas/review-findings.schema.json",
+  "title": "PR review adapter output",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "provider",
+    "generated_at",
+    "summary",
+    "findings",
+    "confidence"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "provider": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Logical provider id (stub, anthropic, openai, coderabbit, etc.)."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "pull_request": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "number": { "type": "integer", "minimum": 1 },
+        "base_sha": { "type": "string", "minLength": 7 },
+        "head_sha": { "type": "string", "minLength": 7 },
+        "base_ref": { "type": "string" },
+        "head_ref": { "type": "string" }
+      }
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "blocking", "message"],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "medium", "minor", "info"]
+          },
+          "blocking": {
+            "type": "boolean",
+            "description": "If true, policy may fail the PR until resolved."
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1
+          },
+          "path": {
+            "type": "string",
+            "description": "Repo-relative path, if applicable."
+          },
+          "line": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "1-based line in path, if applicable."
+          },
+          "code": {
+            "type": "string",
+            "description": "Short machine-readable finding code."
+          }
+        }
+      }
+    },
+    "confidence": {
+      "type": "string",
+      "enum": ["low", "medium", "high"]
+    },
+    "truncated_diff": {
+      "type": "boolean",
+      "description": "True when the diff was truncated before sending to the provider."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `spec/schema/review-findings.schema.json` and `scripts/review-adapter.mjs` with `stub` and optional `anthropic` providers so review output is machine-validated and swappable per P1 (replaceable reviewer backend).
- Adds `.github/workflows/p1-review-adapter.yml` to build the PR diff, run the adapter on each PR to `main`, and upload `review-findings.json` as artifact `review-findings` (stub when no `ANTHROPIC_API_KEY`).
- Extends `agents/interfaces.yaml` with `review_pull_request` and notes the artifact in `.github/copilot-instructions.md`.
- Adds `npm run review:adapter` script.

## Why it matters

Implements the reviewer adapter layer described in `docs/P1_PR_EXECUTION_LOOP.md` so a later policy check can gate on structured `blocking` findings without coupling to one LLM vendor.

## Validation

- [x] `npm run validate`

## Checklist

- [x] Schema, examples, and policy stay aligned (new schema only; examples unchanged)
- [x] Documentation updated where behavior changed (`copilot-instructions.md`, interface doc in YAML)

## P1 notes

- Touches `.github/workflows/**` → expect `risk:med` / residual pending until human or follow-up automation sets residual labels.
- Does not yet wire `p1-policy` to review findings; that is intentional next step.

Made with [Cursor](https://cursor.com)