### PR TITLE
Document Copilot review ruleset in framework playbooks

### DIFF
--- a/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
+++ b/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
@@ -175,6 +175,7 @@ Bindings below are **recommended defaults** for greenfield implementations; the 
 
 | Concern | Default choice | Role |
 |---------|----------------|------|
+| **Source control / PR governance** | GitHub + branch protection + rulesets + Copilot code review (or equivalent) | Reviews, approvals, merge policy, audit trail |
 | **Frontend** | Next.js + Tailwind + shadcn/ui | Product UI, marketing surfaces |
 | **Application API** | Next.js route handlers or Node / FastAPI | Business logic, auth integration |
 | **Data** | PostgreSQL; Supabase for auth/storage/APIs | System of record |
@@ -330,7 +331,7 @@ For deployments targeting **solo founders or minimal teams** in **B2B SaaS**, th
 - **Inputs:** PR metadata, diff, branch protection rules, required checks, threshold policy, branch freshness state, and residual-risk decision.
 - **Outputs:** Initial risk classification, residual-risk decision, freshness decision, validation evidence, review outcome, approval decision, and merge or escalation state.
 - **Capabilities:** Builder, Ops, Researcher, AI reviewer backend.
-- **Checkpoints:** Human approval is **MUST** for high-risk changes and **SHOULD** be required whenever confidence or evidence falls below policy thresholds. Event-ordering failures between automation steps **MUST NOT** by themselves force human review. Automation-owned PRs **MUST** be synced with the current protected branch before review authority is exercised, deterministic PR state such as residual-risk labels **MUST** be set automatically when policy can infer it, and control-plane PRs **MUST** be judged by the policy currently merged on the protected branch until the update itself lands.
+- **Checkpoints:** Human approval is **MUST** for high-risk changes and **SHOULD** be required whenever confidence or evidence falls below policy thresholds. Event-ordering failures between automation steps **MUST NOT** by themselves force human review. Automation-owned PRs **MUST** be synced with the current protected branch before review authority is exercised, deterministic PR state such as residual-risk labels **MUST** be set automatically when policy can infer it, and control-plane PRs **MUST** be judged by the policy currently merged on the protected branch until the update itself lands. Repository-level auto-review configuration such as GitHub rulesets **MAY** request an AI review automatically, but **MUST NOT** itself be treated as approval authority.
 - **Playbook:** `docs/P1_PR_EXECUTION_LOOP.md`
 - **Events (examples):** `pr.risk_classified`, `pr.residual_risk_set`, `pr.branch_outdated`, `pr.review_completed`, `pr.escalated`, `pr.merged`.
 

--- a/docs/P0_REPOSITORY_FOUNDATION.md
+++ b/docs/P0_REPOSITORY_FOUNDATION.md
@@ -18,6 +18,7 @@ At the end of this playbook, the repository should have:
 - CI running on push and pull request.
 - Branch protection bound to real required checks.
 - Merge strategy and branch cleanup defaults configured.
+- Repository rulesets configured for any default automated review behavior.
 - Basic governance files for ownership, contribution flow, security reporting, issues, and pull requests.
 - Dependency and security automation enabled.
 - CODEOWNERS scoped to protected repository surfaces if low-risk PR automation will be allowed later.
@@ -72,8 +73,11 @@ Apply the following repository settings:
 - Enable issues if they are part of the operating loop.
 - Disable wiki unless it is intentionally used.
 - Set the repository description.
+- Configure repository rulesets for automated PR review if the repository will use a host-native reviewer such as GitHub Copilot.
 
 These choices keep history readable and prevent the repo from accumulating unmanaged side channels.
+
+If automated PR review is enabled at the repository level, the trigger configuration belongs in repository settings or rulesets, while repository-specific review behavior **SHOULD** remain in versioned files such as `.github/copilot-instructions.md`.
 
 ## 5. Protect the default branch
 
@@ -130,6 +134,9 @@ The first execution of P0 in this repository applied the following concrete sett
 - Force pushes: disabled
 - Branch deletions: disabled
 - Security automation: enabled
+- Automated PR review: GitHub Copilot via repository ruleset on `~DEFAULT_BRANCH`
+- Copilot review on new pushes: enabled
+- Copilot review on draft PRs: disabled
 
 ## Notes for future variants
 

--- a/docs/P1_PR_EXECUTION_LOOP.md
+++ b/docs/P1_PR_EXECUTION_LOOP.md
@@ -163,6 +163,8 @@ Automated review must leave an auditable artifact in the PR.
 
 Repository-specific reviewer guidance **SHOULD** live in versioned files such as `.github/copilot-instructions.md` so the AI backend can be swapped without changing the playbook's policy.
 
+For this repository, automated AI review is requested through a GitHub repository ruleset that enables GitHub Copilot code review on the default branch and on new pushes to matching pull requests. The ruleset controls when review is requested; `.github/copilot-instructions.md` controls repository-specific review behavior.
+
 ## 4. Apply threshold policy
 
 Decision rules:
@@ -262,7 +264,7 @@ Optional later layers:
 
 Initial backend for this repository:
 
-- GitHub Copilot for AI review comments and suggested changes
+- GitHub Copilot automatic code review via a repository ruleset targeting `~DEFAULT_BRANCH` with review on new pushes
 - Repository custom instructions in `.github/copilot-instructions.md`
 - GitHub Actions for classification, low-risk approval, and auto-merge orchestration
 
@@ -288,7 +290,7 @@ Recommended first implementation for this repository:
 - Distinguish initial risk from residual risk after review.
 - Label outdated PRs with `sync:needed` and block automation until they are refreshed.
 - Run `npm run validate` as the canonical required check.
-- Run automated agent review on every PR.
+- Run automated agent review on every PR, for example through a repository ruleset that requests GitHub Copilot review.
 - Allow automation to merge residual-low PRs.
 - Require a policy decision check before merge instead of a blanket GitHub review gate.
 - Allow auto-merge only after required checks pass and policy allows approval.


### PR DESCRIPTION
## Summary

- update `docs/P0_REPOSITORY_FOUNDATION.md` so repository rulesets and automated PR review are part of the repository foundation baseline
- update `docs/P1_PR_EXECUTION_LOOP.md` to describe the current GitHub Copilot ruleset setup and clarify that rulesets request review but do not grant approval authority
- update `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md` so the default tooling and P1 checkpoint language match the live repository configuration

## Validation

- [x] `npm run validate`

## Checklist

- [x] Schema, examples, and policy stay aligned
- [x] Documentation updated where behavior changed