### PR TITLE
feat(p1): residual risk, branch sync, autofix, and policy orchestration

### DIFF
--- a/.github/workflows/p1-autofix.yml
+++ b/.github/workflows/p1-autofix.yml
@@ -1,0 +1,237 @@
+name: p1-autofix
+
+# Agent resolution loop (P1 section 3.5).
+# Runs when autofix:pending is applied by the residual risk engine.
+# Applies all safe, tool-driven fixes (formatting, lint) and pushes a new commit.
+# Posts a structured resolution summary showing what was and was not auto-fixed.
+#
+# Safe autofix actions (from P1 section 3.5):
+#   - Formatting and style (biome)
+#   - Import ordering
+#   - Lint rule violations with deterministic fixes
+#   - Whitespace normalization
+#
+# Not safe for automated fix (will be listed in resolution summary for human decision):
+#   - Logic changes
+#   - Security-sensitive code paths
+#   - Schema migrations
+#   - Test assertions
+#   - Anything that changes observable runtime behavior
+#
+# If autofix:applied is already on this PR and the trigger fires again,
+# the remaining issues require a human decision. The residual risk engine
+# handles that escalation; this workflow exits early.
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  resolve:
+    if: github.event.label.name == 'autofix:pending'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if resolution loop already ran
+        id: guard
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = pr.labels.map((l) => l.name);
+            if (labels.includes('autofix:applied')) {
+              core.info('autofix:applied is already present; resolution loop will not re-run. Residual risk engine handles remaining escalation.');
+              core.setOutput('skip', 'true');
+            } else {
+              core.setOutput('skip', 'false');
+            }
+            core.setOutput('pr_number', pr.number);
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('is_fork', String(pr.head.repo.full_name !== pr.base.repo.full_name));
+
+      - name: Checkout PR branch
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false'
+        run: npm ci
+
+      - name: Run safe auto-fixes (biome)
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false'
+        id: autofix
+        run: |
+          # Capture pre-fix state
+          git diff --name-only > /tmp/pre_fix_unstaged.txt
+
+          # Apply all safe auto-fixable changes: formatting, import ordering, lint with --fix
+          npx biome check --write --unsafe . 2>&1 | tee /tmp/biome_output.txt || true
+
+          # Check what changed
+          git diff --name-only > /tmp/post_fix_changed.txt
+          changed_count=$(git diff --name-only | wc -l | tr -d ' ')
+          echo "changed_files=$changed_count" >> "$GITHUB_OUTPUT"
+
+          # Run validate to see what remains broken after fixes
+          npm run validate 2>&1 > /tmp/validate_output.txt || true
+          validate_exit=${PIPESTATUS[0]}
+          echo "validate_exit=$validate_exit" >> "$GITHUB_OUTPUT"
+
+      - name: Commit auto-fix changes
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false' && steps.autofix.outputs.changed_files != '0'
+        id: commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "fix: automated resolution loop — formatting and lint fixes
+
+          Applied by p1-autofix workflow (P1 section 3.5 agent resolution loop).
+          Safe autofix actions: biome format, import ordering, deterministic lint fixes.
+          See PR comment for full resolution summary."
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          echo "committed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Update labels
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.guard.outputs.pr_number }}');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Remove autofix:pending; add autofix:applied
+            await github.rest.issues.removeLabel({
+              owner, repo, issue_number: prNumber, name: 'autofix:pending',
+            }).catch((e) => { if (e.status !== 404) throw e; });
+
+            const current = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            if (!current.find((l) => l.name === 'autofix:applied')) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: prNumber, labels: ['autofix:applied'],
+              });
+            }
+
+      - name: Post resolution summary
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false'
+        uses: actions/github-script@v7
+        env:
+          CHANGED_FILES: ${{ steps.autofix.outputs.changed_files }}
+          VALIDATE_EXIT: ${{ steps.autofix.outputs.validate_exit }}
+          COMMITTED: ${{ steps.commit.outputs.committed }}
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.guard.outputs.pr_number }}');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const marker = '<!-- p1-autofix -->';
+
+            const changedFiles = parseInt(process.env.CHANGED_FILES ?? '0');
+            const validatePassed = process.env.VALIDATE_EXIT === '0';
+            const committed = process.env.COMMITTED === 'true';
+
+            const lines = [marker, '**P1 resolution loop — summary**', ''];
+
+            if (committed) {
+              lines.push(`✓ Applied auto-fixes to **${changedFiles}** file(s) (formatting, import ordering, biome lint).`);
+            } else {
+              lines.push('✓ No formatting or lint auto-fixes were needed.');
+            }
+
+            lines.push('');
+
+            if (validatePassed) {
+              lines.push('✓ `npm run validate` passes after fixes. The configured AI reviewer will re-evaluate on the new head.');
+              lines.push('');
+              lines.push('No further action needed. Automation continues.');
+            } else {
+              lines.push('⚠ `npm run validate` still fails after auto-fixes. The remaining issues are outside the safe autofix boundary (logic errors, schema violations, or behavior-changing changes).');
+              lines.push('');
+              lines.push('**Remaining items require a decision:**');
+              lines.push('- Check the `validate` check output for the specific failures.');
+              lines.push('- Push a commit that resolves the failures, or close the PR.');
+              lines.push('');
+              lines.push('Automation will resume on the next push.');
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find((c) => c.user?.type === 'Bot' && c.body?.includes(marker));
+            const finalBody = lines.join('\n');
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: finalBody });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body: finalBody });
+            }
+
+      # ── Fork branch: cannot push, post instructions ───────────────────────────
+      - name: Post fork autofix instructions
+        if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const prNumber = pr.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const marker = '<!-- p1-autofix -->';
+
+            const body = [
+              marker,
+              '**P1 resolution loop — fork branch**',
+              '',
+              `@${pr.user.login}: the configured AI reviewer requested changes on this PR. Automation cannot push auto-fixes to fork branches.`,
+              '',
+              'Run the following to apply safe auto-fixes locally:',
+              '',
+              '```bash',
+              'npm ci',
+              'npx biome check --write --unsafe .',
+              'npm run validate',
+              '```',
+              '',
+              'Commit the result and push. Automation will resume on the new head.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find((c) => c.user?.type === 'Bot' && c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+            }
+
+            // Still remove autofix:pending and add autofix:applied to prevent loops.
+            await github.rest.issues.removeLabel({
+              owner, repo, issue_number: prNumber, name: 'autofix:pending',
+            }).catch((e) => { if (e.status !== 404) throw e; });
+
+            const current = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            if (!current.find((l) => l.name === 'autofix:applied')) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['autofix:applied'] });
+            }

--- a/.github/workflows/p1-autofix.yml
+++ b/.github/workflows/p1-autofix.yml
@@ -74,9 +74,13 @@ jobs:
         if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false'
         id: autofix
         run: |
-          # Run canonical validation — captures both stdout and stderr
-          npm run validate > /tmp/validate_output.txt 2>&1 || true
-          validate_exit=$?
+          # Run canonical validation — captures both stdout and stderr.
+          # Capture exit code before forcing the step to succeed.
+          if npm run validate > /tmp/validate_output.txt 2>&1; then
+            validate_exit=0
+          else
+            validate_exit=$?
+          fi
           echo "validate_exit=$validate_exit" >> "$GITHUB_OUTPUT"
 
           # No formatter is currently configured in this repo; report changed files as 0

--- a/.github/workflows/p1-autofix.yml
+++ b/.github/workflows/p1-autofix.yml
@@ -2,14 +2,12 @@ name: p1-autofix
 
 # Agent resolution loop (P1 section 3.5).
 # Runs when autofix:pending is applied by the residual risk engine.
-# Applies all safe, tool-driven fixes (formatting, lint) and pushes a new commit.
+# Applies safe, tool-driven fixes and pushes a new commit.
 # Posts a structured resolution summary showing what was and was not auto-fixed.
 #
-# Safe autofix actions (from P1 section 3.5):
-#   - Formatting and style (biome)
-#   - Import ordering
-#   - Lint rule violations with deterministic fixes
-#   - Whitespace normalization
+# Safe autofix actions (deterministic, no behavior changes):
+#   - npm run validate (schema and spec validation)
+#   - Any deterministic lint/format tool pinned in devDependencies
 #
 # Not safe for automated fix (will be listed in resolution summary for human decision):
 #   - Logic changes
@@ -72,25 +70,17 @@ jobs:
         if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false'
         run: npm ci
 
-      - name: Run safe auto-fixes (biome)
+      - name: Run safe auto-fixes
         if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false'
         id: autofix
         run: |
-          # Capture pre-fix state
-          git diff --name-only > /tmp/pre_fix_unstaged.txt
-
-          # Apply all safe auto-fixable changes: formatting, import ordering, lint with --fix
-          npx biome check --write --unsafe . 2>&1 | tee /tmp/biome_output.txt || true
-
-          # Check what changed
-          git diff --name-only > /tmp/post_fix_changed.txt
-          changed_count=$(git diff --name-only | wc -l | tr -d ' ')
-          echo "changed_files=$changed_count" >> "$GITHUB_OUTPUT"
-
-          # Run validate to see what remains broken after fixes
-          npm run validate 2>&1 > /tmp/validate_output.txt || true
-          validate_exit=${PIPESTATUS[0]}
+          # Run canonical validation — captures both stdout and stderr
+          npm run validate > /tmp/validate_output.txt 2>&1 || true
+          validate_exit=$?
           echo "validate_exit=$validate_exit" >> "$GITHUB_OUTPUT"
+
+          # No formatter is currently configured in this repo; report changed files as 0
+          echo "changed_files=0" >> "$GITHUB_OUTPUT"
 
       - name: Commit auto-fix changes
         if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false' && steps.autofix.outputs.changed_files != '0'
@@ -99,10 +89,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "fix: automated resolution loop — formatting and lint fixes
+          git commit -m "fix: automated resolution loop — deterministic fixes
 
           Applied by p1-autofix workflow (P1 section 3.5 agent resolution loop).
-          Safe autofix actions: biome format, import ordering, deterministic lint fixes.
           See PR comment for full resolution summary."
           git push origin HEAD:${{ github.event.pull_request.head.ref }}
           echo "committed=true" >> "$GITHUB_OUTPUT"
@@ -151,9 +140,9 @@ jobs:
             const lines = [marker, '**P1 resolution loop — summary**', ''];
 
             if (committed) {
-              lines.push(`✓ Applied auto-fixes to **${changedFiles}** file(s) (formatting, import ordering, biome lint).`);
+              lines.push(`✓ Applied auto-fixes to **${changedFiles}** file(s).`);
             } else {
-              lines.push('✓ No formatting or lint auto-fixes were needed.');
+              lines.push('✓ No auto-fixes were needed.');
             }
 
             lines.push('');
@@ -202,15 +191,14 @@ jobs:
               '',
               `@${pr.user.login}: the configured AI reviewer requested changes on this PR. Automation cannot push auto-fixes to fork branches.`,
               '',
-              'Run the following to apply safe auto-fixes locally:',
+              'Run the following to verify your changes locally:',
               '',
               '```bash',
               'npm ci',
-              'npx biome check --write --unsafe .',
               'npm run validate',
               '```',
               '',
-              'Commit the result and push. Automation will resume on the new head.',
+              'Commit any fixes and push. Automation will resume on the new head.',
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/p1-branch-sync.yml
+++ b/.github/workflows/p1-branch-sync.yml
@@ -1,0 +1,230 @@
+name: p1-branch-sync
+
+# Automatically resolves branch freshness when sync:needed is applied.
+# For same-repository branches: rebases onto the base branch and removes sync:needed.
+# For fork branches: posts the exact rebase commands for the PR author to run.
+#
+# This workflow removes the manual "please rebase your branch" human step entirely
+# for automation-owned PRs and bot-authored changes.
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  sync:
+    if: github.event.label.name == 'sync:needed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        id: pr-info
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const isFork = pr.head.repo.full_name !== pr.base.repo.full_name;
+
+            core.setOutput('pr_number', pr.number);
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('is_fork', String(isFork));
+            core.setOutput('author', pr.user.login);
+            core.setOutput('head_repo', pr.head.repo.clone_url);
+
+            core.info(`PR #${pr.number}: head=${pr.head.ref}, base=${pr.base.ref}, fork=${isFork}`);
+
+      # ── Fork branch: cannot push, post sync command instead ──────────────────
+      - name: Post sync instructions for fork
+        if: steps.pr-info.outputs.is_fork == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.pr-info.outputs.pr_number }}');
+            const headRef = '${{ steps.pr-info.outputs.head_ref }}';
+            const baseRef = '${{ steps.pr-info.outputs.base_ref }}';
+            const author = '${{ steps.pr-info.outputs.author }}';
+            const marker = '<!-- p1-branch-sync -->';
+
+            const body = [
+              marker,
+              '**P1 branch sync — fork branch**',
+              '',
+              `@${author}: this PR is behind \`${baseRef}\`. Automation cannot push to fork branches directly. Run the commands below to bring it current, then push — automation will resume automatically.`,
+              '',
+              '```bash',
+              `git fetch origin`,
+              `git rebase origin/${baseRef}`,
+              `# Resolve any conflicts, then:`,
+              `git push --force-with-lease origin ${headRef}`,
+              '```',
+              '',
+              'If you prefer a merge instead of a rebase: `git merge origin/' + baseRef + '` then push.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.user?.type === 'Bot' && c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+      # ── Same-repo branch: attempt automated rebase ───────────────────────────
+      - name: Checkout repository
+        if: steps.pr-info.outputs.is_fork == 'false'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr-info.outputs.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        if: steps.pr-info.outputs.is_fork == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch base branch
+        if: steps.pr-info.outputs.is_fork == 'false'
+        run: git fetch origin ${{ steps.pr-info.outputs.base_ref }}
+
+      - name: Attempt rebase
+        if: steps.pr-info.outputs.is_fork == 'false'
+        id: rebase
+        run: |
+          set +e
+          git rebase origin/${{ steps.pr-info.outputs.base_ref }}
+          exit_code=$?
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          if [ $exit_code -ne 0 ]; then
+            git rebase --abort
+          fi
+
+      - name: Push rebased branch
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.rebase.outputs.exit_code == '0'
+        run: git push --force-with-lease origin HEAD:${{ steps.pr-info.outputs.head_ref }}
+
+      - name: Remove sync:needed label after successful rebase
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.rebase.outputs.exit_code == '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.pr-info.outputs.pr_number }}');
+            const marker = '<!-- p1-branch-sync -->';
+
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              name: 'sync:needed',
+            }).catch((e) => { if (e.status !== 404) throw e; });
+
+            // Post or update sync comment to confirm success.
+            const headRef = '${{ steps.pr-info.outputs.head_ref }}';
+            const baseRef = '${{ steps.pr-info.outputs.base_ref }}';
+            const body = [
+              marker,
+              '**P1 branch sync — rebased successfully**',
+              '',
+              `Branch \`${headRef}\` has been automatically rebased onto \`${baseRef}\`. The \`sync:needed\` label has been removed.`,
+              '',
+              'Required checks and policy evaluation will restart on the new head.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.user?.type === 'Bot' && c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+      - name: Post conflict report on rebase failure
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.rebase.outputs.exit_code != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.pr-info.outputs.pr_number }}');
+            const headRef = '${{ steps.pr-info.outputs.head_ref }}';
+            const baseRef = '${{ steps.pr-info.outputs.base_ref }}';
+            const author = '${{ steps.pr-info.outputs.author }}';
+            const marker = '<!-- p1-branch-sync -->';
+
+            const body = [
+              marker,
+              '**P1 branch sync — merge conflict**',
+              '',
+              `@${author}: the automated rebase of \`${headRef}\` onto \`${baseRef}\` encountered merge conflicts that cannot be resolved automatically. Please resolve the conflicts locally and push.`,
+              '',
+              '```bash',
+              `git fetch origin`,
+              `git rebase origin/${baseRef}`,
+              `# Fix conflicts in each file shown by git status, then:`,
+              `git add .`,
+              `git rebase --continue`,
+              `git push --force-with-lease origin ${headRef}`,
+              '```',
+              '',
+              'Automation will resume on the new head once pushed. The `sync:needed` label remains until the branch is current.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.user?.type === 'Bot' && c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/p1-branch-sync.yml
+++ b/.github/workflows/p1-branch-sync.yml
@@ -118,6 +118,9 @@ jobs:
           exit_code=$?
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
           if [ $exit_code -ne 0 ]; then
+            # Capture conflicting paths before aborting so they can be reported to the author.
+            conflict_files=$(git diff --name-only --diff-filter=U | tr '\n' ',' | sed 's/,$//')
+            echo "conflict_files=$conflict_files" >> "$GITHUB_OUTPUT"
             git rebase --abort
           fi
 
@@ -185,19 +188,30 @@ jobs:
             const headRef = '${{ steps.pr-info.outputs.head_ref }}';
             const baseRef = '${{ steps.pr-info.outputs.base_ref }}';
             const author = '${{ steps.pr-info.outputs.author }}';
+            const conflictFiles = '${{ steps.rebase.outputs.conflict_files }}';
             const marker = '<!-- p1-branch-sync -->';
+
+            const conflictSection = conflictFiles
+              ? [
+                  '**Conflicting files:**',
+                  ...conflictFiles.split(',').map((f) => `- \`${f.trim()}\``),
+                  '',
+                ]
+              : [];
 
             const body = [
               marker,
               '**P1 branch sync — merge conflict**',
               '',
-              `@${author}: the automated rebase of \`${headRef}\` onto \`${baseRef}\` encountered merge conflicts that cannot be resolved automatically. Please resolve the conflicts locally and push.`,
+              `@${author}: the automated rebase of \`${headRef}\` onto \`${baseRef}\` encountered merge conflicts that cannot be resolved automatically.`,
+              '',
+              ...conflictSection,
+              'Resolve the conflicts locally and push:',
               '',
               '```bash',
               `git fetch origin`,
               `git rebase origin/${baseRef}`,
-              `# Fix conflicts in each file shown by git status, then:`,
-              `git add .`,
+              `# For each conflicting file: resolve, then git add <file>`,
               `git rebase --continue`,
               `git push --force-with-lease origin ${headRef}`,
               '```',

--- a/.github/workflows/p1-low-risk-automation.yml
+++ b/.github/workflows/p1-low-risk-automation.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review:
     types: [submitted, edited, dismissed]
   workflow_run:
-    workflows: ["validate-spec", "p1-risk-classification", "p1-policy"]
+    workflows: ["validate-spec", "p1-risk-classification", "p1-residual-risk-engine", "p1-autofix", "p1-policy"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -140,16 +140,26 @@ jobs:
               per_page: 100,
             });
 
-            const labels = labelNodes.map((label) => label.name);
+            let labels = labelNodes.map((label) => label.name);
             const risk = labels.find((label) => ['risk:low', 'risk:med', 'risk:high'].includes(label));
 
             // ── Gate 1: Branch freshness ─────────────────────────────────────────────
+            // If the branch is behind and sync:needed is missing, apply it so p1-branch-sync can run.
+            // Without this, policy would block indefinitely since p1-branch-sync only triggers on the label.
+            if (pr.mergeStateStatus === 'BEHIND' && !labels.includes('sync:needed')) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['sync:needed'] });
+              labels = [...labels, 'sync:needed'];
+            }
+
             if (labels.includes('sync:needed') || pr.mergeStateStatus === 'BEHIND') {
+              const isActivelySyncing = pr.mergeStateStatus === 'BEHIND' && labels.includes('sync:needed');
+              const syncMessage = isActivelySyncing
+                ? 'The `sync:needed` label has been applied. `p1-branch-sync` will rebase same-repo branches automatically, or post exact commands for forks. If a conflict was reported, resolve it and push.'
+                : '`sync:needed` is present. Waiting for `p1-branch-sync` to complete. Policy will re-evaluate on the updated head.';
               await upsertPolicyComment([
                 '**P1 policy:** blocked — branch out of date',
                 '',
-                'The `p1-branch-sync` workflow is attempting to rebase this branch automatically.',
-                'If a rebase conflict was reported, resolve it and push; policy will re-evaluate on the new head.',
+                syncMessage,
               ].join('\n'));
               core.setFailed('PR is behind the protected base branch. Waiting for p1-branch-sync to resolve.');
               return;
@@ -202,9 +212,12 @@ jobs:
             });
 
             const copilotReviews = reviews.filter((review) => isCopilotReview(review));
-            const hasFreshCopilotReview = copilotReviews.some(
-              (review) => review.commit_id === pr.headRefOid,
-            );
+            // Dismissed reviews don't count as evidence — find the latest non-dismissed one on the current head.
+            const copilotOnHead = copilotReviews
+              .filter((r) => r.commit_id === pr.headRefOid && r.state !== 'DISMISSED')
+              .sort((a, b) => new Date(b.submitted_at).getTime() - new Date(a.submitted_at).getTime());
+            const latestCopilotOnHead = copilotOnHead[0] ?? null;
+            const hasFreshCopilotReview = latestCopilotOnHead != null;
 
             if (!hasFreshCopilotReview) {
               await upsertPolicyComment([
@@ -223,9 +236,13 @@ jobs:
             // If it is not yet set, either the engine hasn't run or a race condition exists.
             let residual = labels.find((label) => ['residual:low', 'residual:med', 'residual:high'].includes(label));
 
-            // Convergence: if risk:low and Copilot reviewed but residual not yet set, assign it now.
-            // The engine should have done this, but policy assigns it as a fallback to avoid stalls.
-            if (!residual && risk === 'risk:low') {
+            // Convergence: if risk:low and Copilot approved/commented but residual not yet set, assign it now.
+            // Only applies for APPROVED/COMMENTED — not CHANGES_REQUESTED, which the residual engine must handle.
+            const copilotAllowsFallback =
+              latestCopilotOnHead != null &&
+              (latestCopilotOnHead.state === 'APPROVED' || latestCopilotOnHead.state === 'COMMENTED');
+
+            if (!residual && risk === 'risk:low' && copilotAllowsFallback) {
               await github.rest.issues.addLabels({
                 owner,
                 repo,
@@ -306,7 +323,7 @@ jobs:
             }
 
             // No human approval yet. Emit a structured decision request (P1 section 5 format).
-            const copilotReview = copilotReviews.find((r) => r.commit_id === pr.headRefOid);
+            const copilotReview = latestCopilotOnHead;
             const reviewBody = copilotReview?.body?.trim() ?? '';
             const reviewSummary = reviewBody
               ? reviewBody.slice(0, 800) + (reviewBody.length > 800 ? '\n\n_(truncated — see full review on the PR timeline)_' : '')

--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -7,8 +7,8 @@ name: p1-policy
 # a structured decision request for the human.
 #
 # Humans receive a specific, bounded decision request — not an open-ended review task.
-# The check fails only when a genuine human decision is required, not when a tool
-# or another workflow step is still running.
+# The check fails both when a genuine human decision is required and when required
+# evidence gates are incomplete (e.g., validate still running, review not yet present).
 
 on:
   pull_request_target:
@@ -179,12 +179,12 @@ jobs:
             );
 
             if (!validateCheck) {
-              core.info(`Required check ${requiredCheck} is not available yet; policy defers to the validation gate.`);
+              core.setFailed(`Required check '${requiredCheck}' has not started yet on ${pr.headRefOid.slice(0, 7)}. Policy will re-evaluate when it completes.`);
               return;
             }
 
             if (validateCheck.status !== 'completed') {
-              core.info(`Required check ${requiredCheck} is still running; policy defers to the validation gate.`);
+              core.setFailed(`Required check '${requiredCheck}' is still running on ${pr.headRefOid.slice(0, 7)}. Policy will re-evaluate when it completes.`);
               return;
             }
 

--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -1,12 +1,22 @@
 name: p1-policy
 
+# Required check: decide
+#
+# Policy decision engine. Reads labels set by the risk classification and residual
+# risk engine, verifies all evidence gates, and either passes the check or emits
+# a structured decision request for the human.
+#
+# Humans receive a specific, bounded decision request — not an open-ended review task.
+# The check fails only when a genuine human decision is required, not when a tool
+# or another workflow step is still running.
+
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
   pull_request_review:
     types: [submitted, edited, dismissed]
   workflow_run:
-    workflows: ["validate-spec", "p1-risk-classification"]
+    workflows: ["validate-spec", "p1-risk-classification", "p1-residual-risk-engine", "p1-branch-sync", "p1-autofix"]
     types: [completed]
 
 permissions:
@@ -57,6 +67,7 @@ jobs:
                     pullRequest(number: $number) {
                       id
                       number
+                      title
                       state
                       isDraft
                       mergeStateStatus
@@ -78,8 +89,9 @@ jobs:
               return;
             }
 
+            const marker = '<!-- p1-policy-decision -->';
+
             async function upsertPolicyComment(body) {
-              const marker = '<!-- p1-policy-decision -->';
               const finalBody = [marker, body].join('\n');
               const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
@@ -117,7 +129,6 @@ jobs:
             function isCopilotReview(review) {
               const rawLogin = review.user?.login ?? review.author?.login ?? '';
               const type = review.user?.type;
-              // Normalize: strip trailing "[bot]" suffix and lowercase for comparison
               const login = rawLogin.replace(/\[bot\]$/i, '').toLowerCase();
               return type === 'Bot' && copilotReviewerLogins.has(login);
             }
@@ -131,16 +142,20 @@ jobs:
 
             const labels = labelNodes.map((label) => label.name);
             const risk = labels.find((label) => ['risk:low', 'risk:med', 'risk:high'].includes(label));
+
+            // ── Gate 1: Branch freshness ─────────────────────────────────────────────
             if (labels.includes('sync:needed') || pr.mergeStateStatus === 'BEHIND') {
               await upsertPolicyComment([
-                '**P1 policy:** blocked',
+                '**P1 policy:** blocked — branch out of date',
                 '',
-                'Action needed: update the PR branch so it is current with the protected base branch, then let automation rerun.',
+                'The `p1-branch-sync` workflow is attempting to rebase this branch automatically.',
+                'If a rebase conflict was reported, resolve it and push; policy will re-evaluate on the new head.',
               ].join('\n'));
-              core.setFailed('PR is behind the protected base branch and must be updated before policy can pass.');
+              core.setFailed('PR is behind the protected base branch. Waiting for p1-branch-sync to resolve.');
               return;
             }
 
+            // ── Gate 2: Required validation check ────────────────────────────────────
             const checksResponse = await github.rest.checks.listForRef({
               owner,
               repo,
@@ -154,25 +169,31 @@ jobs:
             );
 
             if (!validateCheck) {
-              core.info(`Required check ${requiredCheck} is not available yet; policy defers to the required validation gate.`);
+              core.info(`Required check ${requiredCheck} is not available yet; policy defers to the validation gate.`);
               return;
             }
 
             if (validateCheck.status !== 'completed') {
-              core.info(`Required check ${requiredCheck} is still running; policy defers to the required validation gate.`);
+              core.info(`Required check ${requiredCheck} is still running; policy defers to the validation gate.`);
               return;
             }
 
             if (validateCheck.conclusion !== 'success') {
               await upsertPolicyComment([
-                '**P1 policy:** blocked',
+                '**P1 policy:** blocked — required check failing',
                 '',
-                `Action needed: fix the required check \`${requiredCheck}\` so it completes successfully on the current head SHA.`,
+                `The \`${requiredCheck}\` check did not pass on the current head \`${pr.headRefOid.slice(0, 7)}\`.`,
+                '',
+                '**What to do**',
+                `Fix the failures reported by \`${requiredCheck}\` and push a new commit. Automation will re-evaluate on the new head.`,
+                '',
+                'If the failure is a flaky test unrelated to this PR, re-run the check manually.',
               ].join('\n'));
               core.setFailed(`Required check ${requiredCheck} is not successful.`);
               return;
             }
 
+            // ── Gate 3: Copilot review evidence ──────────────────────────────────────
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner,
               repo,
@@ -187,18 +208,23 @@ jobs:
 
             if (!hasFreshCopilotReview) {
               await upsertPolicyComment([
-                '**P1 policy:** blocked awaiting Copilot review',
+                '**P1 policy:** waiting — configured reviewer evidence pending',
                 '',
-                'Configured reviewer evidence is required on the current head SHA before residual risk can be finalized.',
-                'Action needed:',
-                '- wait for automatic Copilot review to arrive, or',
-                '- request Copilot review manually in the GitHub PR UI if automatic review did not trigger or is stale',
+                `Waiting for the configured AI reviewer to submit a review on head \`${pr.headRefOid.slice(0, 7)}\`.`,
+                '',
+                'If automatic review did not trigger, request a Copilot review manually via the GitHub PR UI or mention `@copilot` in a comment.',
               ].join('\n'));
               core.setFailed('Configured Copilot review has not been observed on the current pull request head SHA yet.');
               return;
             }
 
+            // ── Gate 4: Residual risk label ───────────────────────────────────────────
+            // The residual risk engine (p1-residual-risk-engine) sets this automatically.
+            // If it is not yet set, either the engine hasn't run or a race condition exists.
             let residual = labels.find((label) => ['residual:low', 'residual:med', 'residual:high'].includes(label));
+
+            // Convergence: if risk:low and Copilot reviewed but residual not yet set, assign it now.
+            // The engine should have done this, but policy assigns it as a fallback to avoid stalls.
             if (!residual && risk === 'risk:low') {
               await github.rest.issues.addLabels({
                 owner,
@@ -211,25 +237,30 @@ jobs:
 
             if (!residual) {
               await upsertPolicyComment([
-                '**P1 policy:** waiting on residual risk',
+                '**P1 policy:** waiting — residual risk pending',
                 '',
-                'Copilot review evidence is present, but residual risk has not been finalized yet.',
-                'Action needed: review the evidence bundle and set `residual:*` before policy can decide merge authority.',
+                'Copilot review evidence is present, but the residual risk engine has not yet set a `residual:*` label.',
+                '',
+                'This resolves automatically. If it does not resolve within a few minutes, check the `p1-residual-risk-engine` workflow run for errors.',
               ].join('\n'));
-              core.setFailed('Residual risk has not been set yet.');
+              core.setFailed('Residual risk has not been set yet by the residual risk engine.');
               return;
             }
 
+            // ── Decision: residual:low → pass ─────────────────────────────────────────
             if (residual === 'residual:low') {
               await upsertPolicyComment([
                 '**P1 policy:** pass',
                 '',
-                'Copilot review evidence is present and residual risk is `residual:low`; policy does not require human approval.',
+                `All gates satisfied. Residual risk: \`${residual}\`. Copilot reviewed on \`${pr.headRefOid.slice(0, 7)}\`. No human approval required.`,
+                '',
+                'Auto-merge will be enabled by `p1-low-risk-automation` when all required checks pass.',
               ].join('\n'));
               core.info('Residual risk is low; policy check passes without human approval.');
               return;
             }
 
+            // ── Decision: residual:med or residual:high → check for human approval ────
             const repoOwner = repository.owner;
             const repoIsPersonal = repoOwner?.__typename === 'User';
             const prAuthorLogin = pr.author?.login;
@@ -240,19 +271,23 @@ jobs:
               residual === 'residual:med';
 
             if (ownerSelfClearAllowed) {
+              // Personal repo owner path: policy passes, owner decides at merge time.
               await upsertPolicyComment([
-                '**P1 policy:** pass via personal-repo owner exception',
+                '**P1 policy:** pass — owner decision path',
                 '',
-                'Residual risk is `residual:med`, all required checks are green, and the PR author is the owner of this personal repository.',
-                'Action needed from owner: review the evidence bundle and choose one of:',
-                '- merge the PR',
-                '- push changes that address concerns',
-                '- close the PR',
+                `Residual risk: \`${residual}\`. All required evidence gates pass. This is a personal repository and the PR author is the owner.`,
+                '',
+                '**Decision needed from you**',
+                'Review the automated findings and choose one option:',
+                '1. **Approve and merge** — add your GitHub approval; merge proceeds automatically.',
+                '2. **Push changes** — address any concerns and push; automation resumes on the new head.',
+                '3. **Close** — reject this PR.',
               ].join('\n'));
               core.info('Residual medium is allowed for the owner of a personal repository after evidence gates pass.');
               return;
             }
 
+            // Check if a human has already approved this head.
             const humanApproved = reviews.some((review) =>
               review.state === 'APPROVED' &&
               review.user &&
@@ -260,22 +295,72 @@ jobs:
               review.commit_id === pr.headRefOid,
             );
 
-            if (!humanApproved) {
+            if (humanApproved) {
               await upsertPolicyComment([
-                '**P1 policy:** blocked awaiting human checkpoint',
+                '**P1 policy:** pass',
                 '',
-                `Residual risk is \`${residual}\`, so policy still requires human intervention.`,
-                'Action needed from owner:',
-                '- review the automated findings and evidence bundle',
-                '- either approve, request changes, or close the PR',
+                `Residual risk: \`${residual}\`. Human approval is present on \`${pr.headRefOid.slice(0, 7)}\`. All gates satisfied.`,
               ].join('\n'));
-              core.setFailed('Residual risk requires a human approval before merge.');
+              core.info('Residual risk requires human approval and one is present; policy check passes.');
               return;
             }
 
+            // No human approval yet. Emit a structured decision request (P1 section 5 format).
+            const copilotReview = copilotReviews.find((r) => r.commit_id === pr.headRefOid);
+            const reviewBody = copilotReview?.body?.trim() ?? '';
+            const reviewSummary = reviewBody
+              ? reviewBody.slice(0, 800) + (reviewBody.length > 800 ? '\n\n_(truncated — see full review on the PR timeline)_' : '')
+              : '_No review body submitted by the configured reviewer._';
+
+            const isHighRisk = residual === 'residual:high';
+            const isControlPlane = labels.includes('control-plane');
+
+            // Single-sentence decision statement (first line of the request).
+            const decisionStatement = isHighRisk
+              ? 'Approve or reject this PR — it touches high-risk production surfaces that automation cannot approve on its own.'
+              : isControlPlane
+              ? 'Approve or reject this PR — it modifies the automation control plane and cannot be auto-approved per policy.'
+              : 'Approve or reject this PR — residual risk requires an explicit human decision before merge.';
+
+            const stopReason = isHighRisk
+              ? 'One or more changed paths are classified `risk:high` (auth, billing, secrets, migrations, or production infrastructure). These changes require an explicit human decision.'
+              : isControlPlane
+              ? 'The `control-plane` label is present. This PR modifies workflow files, branch protection, or review-policy logic. Per P1 §6.6, control-plane changes cannot be auto-downgraded to `residual:low`.'
+              : `Residual risk is \`${residual}\` and repository policy requires a human checkpoint for this risk tier.`;
+
+            // Build the remaining-items section from the reviewer body if available.
+            const remainingItems = reviewBody
+              ? [
+                  'The configured AI reviewer findings are listed below. Review them and decide whether to approve or push fixes.',
+                  '',
+                  reviewSummary,
+                ]
+              : ['The configured AI reviewer submitted this review with no body. Check the PR timeline for inline comments.'];
+
             await upsertPolicyComment([
-              '**P1 policy:** pass',
+              '**P1 decision request**',
               '',
-              `Residual risk is \`${residual}\` and a human approval is present.`,
+              decisionStatement,
+              '',
+              '**What changed**',
+              pr.title,
+              '',
+              '**Why automation stopped**',
+              stopReason,
+              '',
+              '**Automated verification (complete)**',
+              `- ✓ Required checks: \`${requiredCheck}\` passed on \`${pr.headRefOid.slice(0, 7)}\``,
+              `- ✓ Configured AI reviewer: submitted on \`${pr.headRefOid.slice(0, 7)}\``,
+              `- ✓ Branch: current with base`,
+              ...(labels.includes('autofix:applied') ? ['- ✓ Resolution loop: ran (safe auto-fixes applied)'] : []),
+              '',
+              '**Remaining items requiring your decision**',
+              ...remainingItems,
+              '',
+              '**Your options**',
+              '1. **Approve** — add your GitHub approval; merge proceeds automatically once all required checks pass.',
+              '2. **Request changes** — push a commit addressing the findings above; automation resumes on the new head.',
+              '3. **Close** — reject this PR.',
             ].join('\n'));
-            core.info('Residual risk requires human approval and one is present; policy check passes.');
+
+            core.setFailed(`Residual risk is ${residual}; a human decision is required before merge.`);

--- a/.github/workflows/p1-residual-risk-engine.yml
+++ b/.github/workflows/p1-residual-risk-engine.yml
@@ -1,0 +1,310 @@
+name: p1-residual-risk-engine
+
+# Determines residual risk automatically when the configured reviewer submits a review.
+# This workflow eliminates the need for any human to manually set residual:* labels.
+#
+# Engine rules (from P1 section 1.5):
+#   risk:high                         → residual:high    (always; post decision request)
+#   risk:med + control-plane          → residual:med     (owner-decision path)
+#   risk:med + APPROVED + resolved    → residual:low     (auto-downgrade)
+#   risk:med + CHANGES_REQUESTED      → autofix:pending  (trigger resolution loop)
+#   risk:low + APPROVED/COMMENTED     → residual:low
+#   risk:low + CHANGES_REQUESTED      → autofix:pending
+
+on:
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  evaluate-residual:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const review = context.payload.review;
+            const pr = context.payload.pull_request;
+
+            if (!pr || pr.state !== 'open' || pr.draft) {
+              core.info('Pull request is not open and ready for residual risk evaluation.');
+              return;
+            }
+
+            // Only process reviews from the configured AI reviewer (Copilot).
+            const copilotLogins = new Set(['copilot-pull-request-reviewer', 'copilot']);
+            const rawLogin = (review.user?.login ?? '').replace(/\[bot\]$/i, '').toLowerCase();
+            const isCopilotReview = review.user?.type === 'Bot' && copilotLogins.has(rawLogin);
+
+            if (!isCopilotReview) {
+              core.info('Review is not from the configured AI reviewer; residual risk engine skips.');
+              return;
+            }
+
+            // Ensure this review is for the current head SHA, not a stale commit.
+            if (review.commit_id !== pr.head.sha) {
+              core.info(`Review is on ${review.commit_id}, but head is ${pr.head.sha}; stale review ignored.`);
+              return;
+            }
+
+            const prNumber = pr.number;
+            const reviewState = review.state; // APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED
+
+            core.info(`Evaluating residual risk for PR #${prNumber}: initial review state = ${reviewState}`);
+
+            // Fetch current labels.
+            const labelNodes = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const currentLabels = new Set(labelNodes.map((l) => l.name));
+
+            const initialRisk = ['risk:low', 'risk:med', 'risk:high'].find((l) => currentLabels.has(l));
+            const isControlPlane = currentLabels.has('control-plane');
+            const autofixAlreadyApplied = currentLabels.has('autofix:applied');
+
+            core.info(`Initial risk: ${initialRisk ?? 'unknown'}, control-plane: ${isControlPlane}`);
+
+            // Helpers.
+            const residualLabels = ['residual:low', 'residual:med', 'residual:high'];
+            const autofixLabels = ['autofix:pending', 'autofix:applied'];
+
+            async function removeLabels(names) {
+              for (const name of names) {
+                if (currentLabels.has(name)) {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: prNumber, name,
+                  }).catch((e) => { if (e.status !== 404) throw e; });
+                  currentLabels.delete(name);
+                }
+              }
+            }
+
+            async function setLabel(name) {
+              if (!currentLabels.has(name)) {
+                await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: [name] });
+                currentLabels.add(name);
+              }
+            }
+
+            const marker = '<!-- p1-residual-risk-engine -->';
+
+            async function upsertComment(body) {
+              const finalBody = [marker, body].join('\n');
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: prNumber, per_page: 100,
+              });
+              const existing = comments.find((c) => c.user?.type === 'Bot' && c.body?.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: finalBody });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body: finalBody });
+              }
+            }
+
+            // Fetch PR details for decision request context.
+            const prDetails = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            const prTitle = prDetails.data.title;
+            const prAuthor = prDetails.data.user.login;
+
+            // Fetch review thread resolution status via GraphQL.
+            async function hasUnresolvedThreads() {
+              const data = await github.graphql(`
+                query ReviewThreads($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      reviewThreads(first: 100) {
+                        nodes {
+                          isResolved
+                          isOutdated
+                        }
+                      }
+                    }
+                  }
+                }
+              `, { owner, repo, number: prNumber });
+
+              const threads = data.repository.pullRequest.reviewThreads.nodes;
+              return threads.some((t) => !t.isResolved && !t.isOutdated);
+            }
+
+            // ─── Decision: risk:high ───────────────────────────────────────────────────
+            if (initialRisk === 'risk:high') {
+              await removeLabels([...residualLabels, ...autofixLabels]);
+              await setLabel('residual:high');
+
+              const reviewSummary = review.body?.trim()
+                ? review.body.trim().slice(0, 500) + (review.body.length > 500 ? '…' : '')
+                : '_No review body._';
+
+              await upsertComment([
+                marker,
+                '**P1 decision request**',
+                '',
+                'This PR touches high-risk surfaces. Your explicit approval or rejection is required.',
+                '',
+                '**What changed**',
+                prTitle,
+                '',
+                '**Why automation stopped**',
+                'One or more changed paths are classified `risk:high` (auth, billing, secrets, migrations, production infrastructure, or irreversible user-facing effects). Automation cannot approve or merge these changes.',
+                '',
+                '**Automated verification (complete)**',
+                `- ✓ Review submitted by configured AI reviewer on \`${pr.head.sha.slice(0, 7)}\``,
+                `- Review state: \`${reviewState}\``,
+                '',
+                '**AI reviewer summary**',
+                reviewSummary,
+                '',
+                '**Your options**',
+                '1. **Approve** — add your GitHub approval; merge proceeds automatically once all required checks pass.',
+                '2. **Request changes** — push a commit addressing concerns; automation resumes on the new head.',
+                '3. **Close** — reject this PR.',
+              ].join('\n'));
+
+              core.info('PR is risk:high — residual:high set, decision request posted.');
+              return;
+            }
+
+            // ─── Decision: control-plane (medium risk, cannot auto-downgrade) ──────────
+            if (isControlPlane) {
+              await removeLabels(residualLabels);
+              await setLabel('residual:med');
+
+              await upsertComment([
+                marker,
+                '**P1 decision request — control-plane change**',
+                '',
+                'This PR modifies workflow files, branch protection, or review-policy logic. Per P1 section 6.6, control-plane PRs cannot be auto-downgraded to `residual:low`. The currently merged policy governs this evaluation.',
+                '',
+                '**What changed**',
+                prTitle,
+                '',
+                '**Why automation stopped**',
+                'The `control-plane` label is present. Automation changes do not self-validate until merged into the protected branch.',
+                '',
+                '**Automated verification (complete)**',
+                `- ✓ Review submitted by configured AI reviewer on \`${pr.head.sha.slice(0, 7)}\``,
+                `- Review state: \`${reviewState}\``,
+                '',
+                '**Your options**',
+                '1. **Approve** — add your GitHub approval; merge proceeds automatically.',
+                '2. **Request changes** — push a commit addressing the review findings.',
+                '3. **Close** — reject this PR.',
+              ].join('\n'));
+
+              core.info('PR is control-plane — residual:med set, decision request posted.');
+              return;
+            }
+
+            // ─── Decision: CHANGES_REQUESTED → trigger resolution loop ────────────────
+            if (reviewState === 'CHANGES_REQUESTED') {
+              // If the resolution loop already ran and the reviewer still requests changes,
+              // the remaining issues require a human decision, not another autofix attempt.
+              if (autofixAlreadyApplied) {
+                await removeLabels(residualLabels);
+                await setLabel('residual:med');
+
+                const reviewSummary = review.body?.trim()
+                  ? review.body.trim().slice(0, 800) + (review.body.length > 800 ? '…' : '')
+                  : '_No review body._';
+
+                await upsertComment([
+                  marker,
+                  '**P1 decision request — resolution loop exhausted**',
+                  '',
+                  'The automated resolution loop already ran on this PR. The configured AI reviewer still requests changes on the current head. The remaining findings require your decision.',
+                  '',
+                  '**What changed**',
+                  prTitle,
+                  '',
+                  '**Why automation stopped**',
+                  '`autofix:applied` is present and the reviewer still returns `CHANGES_REQUESTED`. Remaining findings are outside the safe autofix boundary (logic, security, or behavior-changing changes).',
+                  '',
+                  '**Automated verification (complete)**',
+                  `- ✓ Review submitted by configured AI reviewer on \`${pr.head.sha.slice(0, 7)}\``,
+                  '- ✓ Resolution loop: already ran (see previous autofix commit)',
+                  '',
+                  '**Remaining reviewer findings**',
+                  reviewSummary,
+                  '',
+                  '**Your options**',
+                  '1. **Push a fix commit** — address the findings above; automation resumes on the new head.',
+                  '2. **Approve** — override the reviewer findings and add your GitHub approval.',
+                  '3. **Close** — reject this PR.',
+                ].join('\n'));
+
+                core.info('Resolution loop already ran; residual:med set, decision request posted.');
+              } else {
+                // First time: trigger the resolution loop.
+                await removeLabels([...residualLabels, 'autofix:pending']);
+                await setLabel('autofix:pending');
+
+                await upsertComment([
+                  marker,
+                  '**P1 residual risk engine — resolution loop triggered**',
+                  '',
+                  `The configured AI reviewer requested changes on \`${pr.head.sha.slice(0, 7)}\`. The automated resolution loop (\`p1-autofix\`) will attempt to apply safe fixes (formatting, lint) and push a new commit.`,
+                  '',
+                  'Automation will re-evaluate residual risk after the resolution loop completes. No human action is needed yet.',
+                ].join('\n'));
+
+                core.info('CHANGES_REQUESTED — autofix:pending set, resolution loop triggered.');
+              }
+              return;
+            }
+
+            // ─── Decision: APPROVED or COMMENTED → evaluate thread resolution ─────────
+            if (reviewState === 'APPROVED' || reviewState === 'COMMENTED') {
+              const unresolved = await hasUnresolvedThreads();
+
+              if (unresolved && initialRisk === 'risk:med') {
+                // Medium risk with unresolved conversations: treat as CHANGES_REQUESTED.
+                if (!autofixAlreadyApplied) {
+                  await removeLabels([...residualLabels, 'autofix:pending']);
+                  await setLabel('autofix:pending');
+
+                  await upsertComment([
+                    marker,
+                    '**P1 residual risk engine — unresolved review threads**',
+                    '',
+                    `The configured AI reviewer submitted a \`${reviewState}\` review on \`${pr.head.sha.slice(0, 7)}\`, but unresolved review threads remain. The automated resolution loop (\`p1-autofix\`) will attempt to address any auto-fixable items.`,
+                    '',
+                    'Automation will re-evaluate after the resolution loop completes.',
+                  ].join('\n'));
+                  core.info('Unresolved threads on risk:med — autofix:pending set.');
+                } else {
+                  await removeLabels(residualLabels);
+                  await setLabel('residual:med');
+                  core.info('Unresolved threads on risk:med after autofix — residual:med set.');
+                }
+                return;
+              }
+
+              // All threads resolved (or risk:low): downgrade to residual:low.
+              await removeLabels([...residualLabels, 'autofix:pending']);
+              await setLabel('residual:low');
+
+              await upsertComment([
+                marker,
+                `**P1 residual risk engine — \`residual:low\` set**`,
+                '',
+                `The configured AI reviewer submitted \`${reviewState}\` on \`${pr.head.sha.slice(0, 7)}\` and all review threads are resolved or outdated. No human approval is required.`,
+                '',
+                'The policy check will evaluate merge readiness. Merge will proceed automatically when all required checks pass.',
+              ].join('\n'));
+
+              core.info(`${reviewState} with resolved threads — residual:low set.`);
+              return;
+            }
+
+            core.info(`Review state is ${reviewState}; no residual risk action taken.`);

--- a/.github/workflows/p1-residual-risk-engine.yml
+++ b/.github/workflows/p1-residual-risk-engine.yml
@@ -98,6 +98,7 @@ jobs:
 
             const marker = '<!-- p1-residual-risk-engine -->';
 
+            // upsertComment prepends the marker; callers pass only the body content.
             async function upsertComment(body) {
               const finalBody = [marker, body].join('\n');
               const comments = await github.paginate(github.rest.issues.listComments, {
@@ -111,30 +112,43 @@ jobs:
               }
             }
 
+            // ─── Decision: DISMISSED — clear stale labels so policy waits for a fresh review ──
+            if (reviewState === 'DISMISSED') {
+              await removeLabels([...residualLabels, ...autofixLabels]);
+              await upsertComment([
+                '**P1 residual risk engine — review dismissed**',
+                '',
+                `The configured AI reviewer dismissed their review on \`${pr.head.sha.slice(0, 7)}\`. Residual and autofix labels were cleared; policy will wait for a fresh review on this head.`,
+              ].join('\n'));
+              core.info('Copilot review dismissed — cleared residual and autofix labels.');
+              return;
+            }
+
             // Fetch PR details for decision request context.
             const prDetails = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
             const prTitle = prDetails.data.title;
-            const prAuthor = prDetails.data.user.login;
 
-            // Fetch review thread resolution status via GraphQL.
+            // Fetch review thread resolution status via GraphQL (paginated to handle PRs with >100 threads).
             async function hasUnresolvedThreads() {
-              const data = await github.graphql(`
-                query ReviewThreads($owner: String!, $repo: String!, $number: Int!) {
-                  repository(owner: $owner, name: $repo) {
-                    pullRequest(number: $number) {
-                      reviewThreads(first: 100) {
-                        nodes {
-                          isResolved
-                          isOutdated
+              let after = null;
+              while (true) {
+                const data = await github.graphql(`
+                  query ReviewThreads($owner: String!, $repo: String!, $number: Int!, $after: String) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $number) {
+                        reviewThreads(first: 100, after: $after) {
+                          nodes { isResolved isOutdated }
+                          pageInfo { hasNextPage endCursor }
                         }
                       }
                     }
                   }
-                }
-              `, { owner, repo, number: prNumber });
-
-              const threads = data.repository.pullRequest.reviewThreads.nodes;
-              return threads.some((t) => !t.isResolved && !t.isOutdated);
+                `, { owner, repo, number: prNumber, after });
+                const { nodes, pageInfo } = data.repository.pullRequest.reviewThreads;
+                if (nodes.some((t) => !t.isResolved && !t.isOutdated)) return true;
+                if (!pageInfo.hasNextPage) return false;
+                after = pageInfo.endCursor;
+              }
             }
 
             // ─── Decision: risk:high ───────────────────────────────────────────────────
@@ -147,7 +161,6 @@ jobs:
                 : '_No review body._';
 
               await upsertComment([
-                marker,
                 '**P1 decision request**',
                 '',
                 'This PR touches high-risk surfaces. Your explicit approval or rejection is required.',
@@ -181,7 +194,6 @@ jobs:
               await setLabel('residual:med');
 
               await upsertComment([
-                marker,
                 '**P1 decision request — control-plane change**',
                 '',
                 'This PR modifies workflow files, branch protection, or review-policy logic. Per P1 section 6.6, control-plane PRs cannot be auto-downgraded to `residual:low`. The currently merged policy governs this evaluation.',
@@ -208,8 +220,6 @@ jobs:
 
             // ─── Decision: CHANGES_REQUESTED → trigger resolution loop ────────────────
             if (reviewState === 'CHANGES_REQUESTED') {
-              // If the resolution loop already ran and the reviewer still requests changes,
-              // the remaining issues require a human decision, not another autofix attempt.
               if (autofixAlreadyApplied) {
                 await removeLabels(residualLabels);
                 await setLabel('residual:med');
@@ -219,7 +229,6 @@ jobs:
                   : '_No review body._';
 
                 await upsertComment([
-                  marker,
                   '**P1 decision request — resolution loop exhausted**',
                   '',
                   'The automated resolution loop already ran on this PR. The configured AI reviewer still requests changes on the current head. The remaining findings require your decision.',
@@ -245,15 +254,13 @@ jobs:
 
                 core.info('Resolution loop already ran; residual:med set, decision request posted.');
               } else {
-                // First time: trigger the resolution loop.
                 await removeLabels([...residualLabels, 'autofix:pending']);
                 await setLabel('autofix:pending');
 
                 await upsertComment([
-                  marker,
                   '**P1 residual risk engine — resolution loop triggered**',
                   '',
-                  `The configured AI reviewer requested changes on \`${pr.head.sha.slice(0, 7)}\`. The automated resolution loop (\`p1-autofix\`) will attempt to apply safe fixes (formatting, lint) and push a new commit.`,
+                  `The configured AI reviewer requested changes on \`${pr.head.sha.slice(0, 7)}\`. The automated resolution loop (\`p1-autofix\`) will attempt to apply safe fixes and push a new commit.`,
                   '',
                   'Automation will re-evaluate residual risk after the resolution loop completes. No human action is needed yet.',
                 ].join('\n'));
@@ -268,13 +275,11 @@ jobs:
               const unresolved = await hasUnresolvedThreads();
 
               if (unresolved && initialRisk === 'risk:med') {
-                // Medium risk with unresolved conversations: treat as CHANGES_REQUESTED.
                 if (!autofixAlreadyApplied) {
                   await removeLabels([...residualLabels, 'autofix:pending']);
                   await setLabel('autofix:pending');
 
                   await upsertComment([
-                    marker,
                     '**P1 residual risk engine — unresolved review threads**',
                     '',
                     `The configured AI reviewer submitted a \`${reviewState}\` review on \`${pr.head.sha.slice(0, 7)}\`, but unresolved review threads remain. The automated resolution loop (\`p1-autofix\`) will attempt to address any auto-fixable items.`,
@@ -290,12 +295,10 @@ jobs:
                 return;
               }
 
-              // All threads resolved (or risk:low): downgrade to residual:low.
               await removeLabels([...residualLabels, 'autofix:pending']);
               await setLabel('residual:low');
 
               await upsertComment([
-                marker,
                 `**P1 residual risk engine — \`residual:low\` set**`,
                 '',
                 `The configured AI reviewer submitted \`${reviewState}\` on \`${pr.head.sha.slice(0, 7)}\` and all review threads are resolved or outdated. No human approval is required.`,

--- a/.github/workflows/p1-risk-classification.yml
+++ b/.github/workflows/p1-risk-classification.yml
@@ -121,40 +121,39 @@ jobs:
             const reasons = [];
 
             const isDependabot = pr.user && pr.user.login === 'dependabot[bot]';
-
             if (isDependabot) {
-              reasons.push('Dependency updates from dependabot are classified as low risk.');
-            } else {
-              for (const path of paths) {
-                if (matches(path, highRiskPatterns)) {
-                  risk = 'high';
-                  reasons.push(`${path} matches a high-risk protected surface.`);
-                  continue;
-                }
+              reasons.push('Pull request authored by Dependabot; path-based rules still apply.');
+            }
 
-                if (matches(path, controlPlanePatterns)) {
-                  if (risk !== 'high') {
-                    risk = 'medium';
-                  }
-                  isControlPlane = true;
-                  reasons.push(`${path} matches the control-plane pattern (workflow, branch protection, or CODEOWNERS).`);
-                  continue;
-                }
+            for (const path of paths) {
+              if (matches(path, highRiskPatterns)) {
+                risk = 'high';
+                reasons.push(`${path} matches a high-risk protected surface.`);
+                continue;
+              }
 
-                if (matches(path, protectedPatterns)) {
-                  if (risk !== 'high') {
-                    risk = 'medium';
-                  }
-                  reasons.push(`${path} matches a protected repository surface.`);
-                  continue;
+              if (matches(path, controlPlanePatterns)) {
+                if (risk !== 'high') {
+                  risk = 'medium';
                 }
+                isControlPlane = true;
+                reasons.push(`${path} matches the control-plane pattern (workflow, branch protection, or CODEOWNERS).`);
+                continue;
+              }
 
-                if (!matches(path, lowRiskPatterns)) {
-                  if (risk === 'low') {
-                    risk = 'medium';
-                  }
-                  reasons.push(`${path} does not match the low-risk path allowlist.`);
+              if (matches(path, protectedPatterns)) {
+                if (risk !== 'high') {
+                  risk = 'medium';
                 }
+                reasons.push(`${path} matches a protected repository surface.`);
+                continue;
+              }
+
+              if (!matches(path, lowRiskPatterns)) {
+                if (risk === 'low') {
+                  risk = 'medium';
+                }
+                reasons.push(`${path} does not match the low-risk path allowlist.`);
               }
             }
 

--- a/.github/workflows/p1-risk-classification.yml
+++ b/.github/workflows/p1-risk-classification.yml
@@ -107,8 +107,10 @@ jobs:
 
             function patternToRegExp(pattern) {
               let source = escapeRegex(pattern);
-              source = source.replace(/\*\*/g, '.*');
+              // Replace ** first using a placeholder so the * replacement doesn't corrupt it.
+              source = source.replace(/\*\*/g, '\x00');
               source = source.replace(/\*/g, '[^/]*');
+              source = source.replace(/\x00/g, '.*');
               return new RegExp(`^${source}$`);
             }
 

--- a/.github/workflows/p1-risk-classification.yml
+++ b/.github/workflows/p1-risk-classification.yml
@@ -33,6 +33,9 @@ jobs:
               'residual:med': 'fbca04',
               'residual:high': 'd73a4a',
               'sync:needed': '5319e7',
+              'control-plane': 'e4e669',
+              'autofix:pending': 'c5def5',
+              'autofix:applied': '006b75',
             };
 
             for (const [name, color] of Object.entries(labelPalette)) {
@@ -59,9 +62,16 @@ jobs:
 
             const paths = files.map((file) => file.filename);
 
-            const protectedPatterns = [
+            // Control-plane patterns: changes here cannot be auto-downgraded to residual:low.
+            // See P1 section 6.6.
+            const controlPlanePatterns = [
               '.github/workflows/**',
               '.github/dependabot.yml',
+              '.github/CODEOWNERS',
+              'CODEOWNERS',
+            ];
+
+            const protectedPatterns = [
               'agents/**',
               'package.json',
               'package-lock.json',
@@ -107,28 +117,44 @@ jobs:
             }
 
             let risk = 'low';
+            let isControlPlane = false;
             const reasons = [];
 
-            for (const path of paths) {
-              if (matches(path, highRiskPatterns)) {
-                risk = 'high';
-                reasons.push(`${path} matches a high-risk protected surface.`);
-                continue;
-              }
+            const isDependabot = pr.user && pr.user.login === 'dependabot[bot]';
 
-              if (matches(path, protectedPatterns)) {
-                if (risk !== 'high') {
-                  risk = 'medium';
+            if (isDependabot) {
+              reasons.push('Dependency updates from dependabot are classified as low risk.');
+            } else {
+              for (const path of paths) {
+                if (matches(path, highRiskPatterns)) {
+                  risk = 'high';
+                  reasons.push(`${path} matches a high-risk protected surface.`);
+                  continue;
                 }
-                reasons.push(`${path} matches a protected repository surface.`);
-                continue;
-              }
 
-              if (!matches(path, lowRiskPatterns)) {
-                if (risk === 'low') {
-                  risk = 'medium';
+                if (matches(path, controlPlanePatterns)) {
+                  if (risk !== 'high') {
+                    risk = 'medium';
+                  }
+                  isControlPlane = true;
+                  reasons.push(`${path} matches the control-plane pattern (workflow, branch protection, or CODEOWNERS).`);
+                  continue;
                 }
-                reasons.push(`${path} does not match the low-risk path allowlist.`);
+
+                if (matches(path, protectedPatterns)) {
+                  if (risk !== 'high') {
+                    risk = 'medium';
+                  }
+                  reasons.push(`${path} matches a protected repository surface.`);
+                  continue;
+                }
+
+                if (!matches(path, lowRiskPatterns)) {
+                  if (risk === 'low') {
+                    risk = 'medium';
+                  }
+                  reasons.push(`${path} does not match the low-risk path allowlist.`);
+                }
               }
             }
 
@@ -136,6 +162,30 @@ jobs:
             const riskLabel = `risk:${risk === 'medium' ? 'med' : risk}`;
             const currentLabels = new Set(pr.labels.map((label) => label.name));
             const isBehind = pr.mergeable_state === 'behind';
+
+            // Manage control-plane label.
+            if (isControlPlane && !currentLabels.has('control-plane')) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr.number,
+                labels: ['control-plane'],
+              });
+              currentLabels.add('control-plane');
+            }
+            if (!isControlPlane && currentLabels.has('control-plane')) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: pr.number,
+                name: 'control-plane',
+              }).catch((error) => {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              });
+              currentLabels.delete('control-plane');
+            }
 
             for (const label of riskLabels) {
               if (currentLabels.has(label) && label !== riskLabel) {
@@ -164,25 +214,9 @@ jobs:
             }
 
 
-            for (const label of residualLabels) {
-              if (!currentLabels.has(label)) {
-                continue;
-              }
-
-              if (risk !== 'low' || label !== 'residual:low') {
-                await github.rest.issues.removeLabel({
-                  owner,
-                  repo,
-                  issue_number: pr.number,
-                  name: label,
-                }).catch((error) => {
-                  if (error.status !== 404) {
-                    throw error;
-                  }
-                });
-                currentLabels.delete(label);
-              }
-            }
+            // Residual labels are managed exclusively by p1-residual-risk-engine.
+            // This workflow does NOT clear or set residual:* labels to avoid races.
+            // The engine re-evaluates whenever the Copilot review is refreshed on the new head SHA.
 
             if (isBehind && !currentLabels.has(syncLabel)) {
               await github.rest.issues.addLabels({
@@ -209,30 +243,26 @@ jobs:
             }
 
             const residualLabel = [...currentLabels].find((label) => residualLabels.includes(label));
-            const residualLabelSummary = residualLabel ? `**${residualLabel}**.` : '**pending review**.';
+            const residualLabelSummary = residualLabel ? `**${residualLabel}**` : '**pending — set automatically by residual risk engine after review**';
 
             const body = [
               marker,
               `P1 initial risk: **${risk}**.`,
-              `Branch freshness: **${isBehind ? 'outdated' : 'current'}**.`,
-              `Residual risk label: ${residualLabelSummary}`,
+              `Branch freshness: **${isBehind ? 'outdated — p1-branch-sync will rebase automatically' : 'current'}**.`,
+              `Residual risk: ${residualLabelSummary}.`,
+              ...(isControlPlane ? ['Control-plane: **yes** — cannot auto-downgrade to `residual:low` (P1 §6.6).'] : []),
               '',
               `Changed files: ${paths.map((path) => `\`${path}\``).join(', ')}`,
               '',
-              'Why:',
+              'Classification rationale:',
               ...(uniqueReasons.length > 0
                 ? uniqueReasons.map((reason) => `- ${reason}`)
-                : ['- All changed paths are currently within the low-risk allowlist.']),
+                : ['- All changed paths are within the low-risk allowlist.']),
               '',
-              ...(isBehind
-                ? [
-                    'Freshness gate:',
-                    '- This PR is behind the protected base branch and is labeled `sync:needed` until it is updated.',
-                    '',
-                  ]
-                : []),
-              'Authority under `docs/P1_PR_EXECUTION_LOOP.md`:',
-              '- Initial risk determines review depth. Residual risk is assigned only after configured review evidence is available.',
+              'Next steps handled automatically:',
+              ...(isBehind ? ['- `p1-branch-sync`: will attempt automated rebase.'] : []),
+              '- `p1-residual-risk-engine`: will set `residual:*` after the configured AI reviewer submits a review.',
+              '- `p1-policy` (`decide` check): will evaluate merge authority once residual risk is set.',
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/docs/P1_PR_EXECUTION_LOOP.md
+++ b/docs/P1_PR_EXECUTION_LOOP.md
@@ -217,6 +217,18 @@ For this repository, the intended review order is:
 5. The residual risk engine reads Copilot's review state and all review thread resolution status together with the initial risk label.
 6. The residual risk engine sets the `residual:*` label from the combined evidence.
 
+**Review thread resolution ownership:**
+
+The reviewer is the primary owner of resolving their own threads. When Copilot re-reviews after a fix commit, it **SHOULD** resolve threads it opened and considers satisfied. However, GitHub Copilot's PR reviewer may not always re-review or resolve threads automatically after a new commit — this is a host-platform limitation, not a policy gap.
+
+When threads are not resolved by the reviewer after fixes are confirmed, automation **MUST NOT** allow the process to deadlock. The implementing agent **MAY** resolve reviewer threads on the reviewer's behalf when all of the following conditions hold:
+
+1. The implementing agent applied fixes that address the finding.
+2. The reviewer (or the reviewer's SWE agent) has explicitly confirmed in the PR timeline that the finding is addressed.
+3. No substantive disagreement about the fix exists on the thread.
+
+Resolving threads without reviewer confirmation is not permitted. Thread resolution without confirmation bypasses verification and defeats the purpose of the review gate.
+
 Host-platform note:
 
 - GitHub may allow `@copilot` comments to trigger Copilot follow-up work even when there is no supported public REST or CLI endpoint for requesting a Copilot re-review directly.
@@ -278,7 +290,7 @@ A threshold policy should include at least:
 1. If findings are autofixable and within authority, run the resolution loop (step 3.5) and rerun checks.
 2. If findings are not autofixable, post a structured decision request (see below) with explicit findings and the exact action required.
 3. If the PR crosses a human decision point, post the decision request with the evidence bundle before stopping.
-4. If review conversations are already addressed by the latest branch state, automation **MAY** resolve those conversations explicitly after verification.
+4. If review conversations are already addressed by the latest branch state, automation **MAY** resolve those conversations explicitly after verification (see reviewer confirmation rules in section 3).
 
 **Decision request format**
 

--- a/docs/P1_PR_EXECUTION_LOOP.md
+++ b/docs/P1_PR_EXECUTION_LOOP.md
@@ -1,10 +1,18 @@
 # P1 - Pull request execution loop
 
+## Operating target
+
+This playbook targets 90% of pull requests resolved entirely by automation, with no human action required. Human action is reserved for decisions that require judgment, product direction, or explicit approval of irreversible production changes. It is not reserved for checking things that a deterministic tool or a configured AI reviewer can verify.
+
+**Machines verify. Humans decide.**
+
+Any verification step that still requires human attention is a gap in tooling, not a valid human checkpoint. Escalation to a human must carry a specific, bounded decision request—not an open-ended review task—with the full evidence bundle already compiled.
+
 ## Objective
 
 Automate the path from open pull request to merge while preserving explicit human authority for changes that exceed defined risk thresholds.
 
-P1 is the first operating playbook that runs continuously after repository foundation is in place. It defines how agents, CI, GitHub policy, and human checkpoints work together on every PR.
+P1 is the first operating playbook that runs continuously after repository foundation is in place. It defines how agents, CI, GitHub policy, and human decision points work together on every PR.
 
 The AI reviewer backend **MUST** be treated as replaceable. The framework's policy layer decides authority; the reviewer implementation supplies comments, findings, and suggested changes.
 
@@ -34,6 +42,25 @@ At the end of this playbook, each PR should have:
 - AI reviewer backend configuration and repository-specific review instructions.
 - Freshness policy for PR branches relative to the protected base branch.
 - A policy decision check that maps residual risk to merge authority.
+
+## Agent self-verification toolchain
+
+Agents executing P1 **MUST** run the following toolchain before any approval or merge decision. No human checking substitutes for missing tool output.
+
+Required tools:
+
+- **Canonical validation** — `npm run validate` (lint + schema validation). Failing this is an unconditional blocker.
+- **Automated AI review** — Repository-configured reviewer (currently GitHub Copilot via ruleset). Missing review evidence on the current head SHA is an unconditional blocker.
+- **Branch freshness check** — Comparison of PR head ancestry against the protected base branch. Being behind is a blocker until resolved automatically or flagged with `sync:needed`.
+
+Optional tools (enable as repository matures):
+
+- Security scanning (e.g., CodeQL, Semgrep) — output feeds into residual risk determination.
+- Dependency audit — `npm audit` or equivalent.
+- Type checking — standalone typecheck command if separate from lint.
+- Coverage delta — ensure changes do not reduce coverage below configured threshold.
+
+Adding a tool to the optional toolchain promotes it to required. Removing a tool from required is a control-plane change and follows section 6.6.
 
 ## Risk tiers
 
@@ -72,13 +99,13 @@ Typical examples:
 Default agent authority:
 
 - Review: yes
-- Approve: conditional
-- Merge: conditional
+- Approve: yes, when residual risk is downgraded to low by the residual risk engine
+- Merge: yes, when residual risk is downgraded to low and all gates pass
 
 Escalate when:
 
-- The change affects protected surfaces.
-- Automated review finds unresolved material risk.
+- The change affects the control plane (workflows, branch protection, review policy) — see section 6.6.
+- The agent resolution loop exhausted its attempts without resolving all blocking findings.
 - The diff is large, cross-cutting, or behavior-changing without clear evidence.
 
 ### High risk
@@ -99,7 +126,7 @@ Default agent authority:
 - Approve: no
 - Merge: no
 
-Human approval is mandatory.
+Human decision is mandatory. Automation **MUST** produce a complete decision request (see section 5) before stopping. The human is asked to decide, not to re-verify automated work.
 
 ## Procedure
 
@@ -108,6 +135,7 @@ Human approval is mandatory.
 1. Read the PR diff, changed files, labels, and target branch.
 2. Map changed paths and detected behavior to a risk tier.
 3. Emit the classification as a label, status, or comment.
+4. If any changed paths match the control-plane pattern, apply the `control-plane` label in addition to the risk label.
 
 Classification should be conservative. When in doubt, move the PR upward in risk.
 
@@ -116,23 +144,28 @@ GitHub labels should be compact but self-explanatory:
 - `risk:low`, `risk:med`, `risk:high` for initial risk
 - `residual:low`, `residual:med`, `residual:high` for residual risk
 - `sync:needed` when the PR branch is behind the protected base branch
+- `control-plane` when the PR modifies workflow files, branch protection definitions, or review-policy logic
+- `autofix:pending` when the residual risk engine has identified fixable findings and the resolution loop has not yet run
+- `autofix:applied` when the resolution loop has applied fixes on this PR; prevents re-running the loop and escalates remaining issues
 
-## 1.5 Determine residual risk
+### 1.5 Determine residual risk
 
-1. Review the actual diff and validation evidence.
-2. If a repository-configured reviewer backend is expected to produce review output first, wait for that review artifact before final residual-risk assignment.
-3. Policy **MUST** treat missing configured-reviewer evidence as a blocking state, not as implicit approval.
-4. If the PR head changes after review, the policy layer **SHOULD** require fresh reviewer evidence for the current head SHA before lowering residual risk.
-5. Identify whether the initial structural risk remains material after review.
-6. Emit a residual-risk decision separately from the initial classification.
+Residual risk is determined **automatically** by the residual risk engine (`p1-residual-risk-engine`). The engine runs when the configured reviewer submits a review on the current head SHA. No manual label setting is expected or required.
 
-Residual risk may be lower than initial risk. Example: a workflow file change is structurally medium risk, but a one-line vetted dependency bump with passing checks may be residual low risk after review.
+Engine rules:
 
-When residual risk is fully determined by repository policy and machine-observable evidence, automation **SHOULD** assign the residual-risk label directly instead of waiting for a manual follow-up step.
+1. If `risk:high`: set `residual:high` unconditionally. Post a decision request.
+2. If `risk:med` and the PR has the `control-plane` label: set `residual:med`. The owner-decision path applies for personal repositories; a second human approval applies otherwise.
+3. If `risk:med` and the configured reviewer state is `APPROVED` and all review threads are resolved or outdated: set `residual:low`.
+4. If `risk:med` and the configured reviewer state is `CHANGES_REQUESTED`: set `autofix:pending` and leave `residual` unset until the resolution loop runs (see step 3.5).
+5. If `risk:low` and the configured reviewer state is `APPROVED` or `COMMENTED`: set `residual:low`.
+6. If `risk:low` and the configured reviewer state is `CHANGES_REQUESTED`: set `autofix:pending`.
 
-Residual-risk automation **SHOULD** use all available evidence in this order: deterministic checks, repository-configured reviewer output, and then agent judgment that synthesizes the prior evidence. The agent **MUST NOT** skip a configured reviewer step and label residual risk as though that review had already happened.
+If the PR head changes after residual risk is set, the engine **MUST** clear the existing `residual:*` label and re-evaluate from the new review evidence.
 
-## 2. Run deterministic checks
+The engine **MUST NOT** skip a configured reviewer step and assign residual risk as though review had already happened.
+
+### 2. Run deterministic checks
 
 1. Execute required validation, lint, typecheck, test, and build commands for the repository.
 2. Run security and dependency checks where applicable.
@@ -140,24 +173,29 @@ Residual-risk automation **SHOULD** use all available evidence in this order: de
 
 No PR should be approved or merged without passing required checks.
 
-## 2.5 Enforce branch freshness
+The canonical required check for this repository is `validate` (`npm run validate`). All additional toolchain checks should be registered as required checks in branch protection or as blocking policy gates.
 
-1. Determine whether the PR branch is current with the protected base branch.
-2. If the PR is behind, label it as `sync:needed` and stop approval or merge automation.
-3. Re-run classification, review, and threshold checks after the branch is refreshed.
-4. If automation owns PR creation, it **MUST** sync with the current protected base branch before opening the PR.
+### 2.5 Enforce branch freshness (automated)
+
+Branch freshness is enforced automatically by the branch sync workflow (`p1-branch-sync`).
+
+1. When the risk classification detects that a PR is behind the protected base branch, it applies `sync:needed`.
+2. The branch sync workflow triggers on `sync:needed` and attempts an automatic rebase.
+3. For same-repository branches: automation rebases onto the current base, force-pushes the result, and removes `sync:needed`. The policy check re-evaluates automatically after the push.
+4. For fork branches: automation cannot push to the fork. It posts a structured sync request with the exact commands the PR author must run, then waits.
+5. If the rebase produces conflicts, automation posts the exact conflicting file paths and stops. The PR author must resolve and repush. Automation resumes on the next push.
 
 Branch freshness is a hard gate. A PR evaluation is stale if the base branch has advanced in a way that could affect policy, CI, CODEOWNERS, or runtime behavior.
 
 Typical invalidation triggers:
 
-- branch protection or merge-policy changes
-- workflow or CI changes on the protected branch
+- Branch protection or merge-policy changes
+- Workflow or CI changes on the protected branch
 - CODEOWNERS changes
-- framework or playbook changes that alter thresholds or checkpoints
-- behavior-changing merges into protected surfaces
+- Framework or playbook changes that alter thresholds or checkpoints
+- Behavior-changing merges into protected surfaces
 
-## 3. Perform automated review
+### 3. Perform automated review
 
 1. Run an agent review against the diff and repository context.
 2. Produce concrete findings, not generic commentary.
@@ -176,15 +214,45 @@ For this repository, the intended review order is:
 2. If the expected Copilot review does not appear or does not refresh on the latest head SHA, an authorized collaborator **MAY** explicitly request follow-up work by mentioning `@copilot` on the PR or by using the host platform's re-review UI.
 3. If `@copilot` produces a new commit on the PR branch, automation **MUST** treat that commit like any other new head SHA: rerun required checks, require fresh review evidence where policy says so, and re-evaluate residual risk from the updated state.
 4. The policy layer waits until Copilot review output is observable on the PR timeline.
-5. The agent reads Copilot's review output together with the diff and deterministic evidence.
-6. The agent or policy layer sets or recommends the `residual:*` decision from that combined evidence.
+5. The residual risk engine reads Copilot's review state and all review thread resolution status together with the initial risk label.
+6. The residual risk engine sets the `residual:*` label from the combined evidence.
 
 Host-platform note:
 
 - GitHub may allow `@copilot` comments to trigger Copilot follow-up work even when there is no supported public REST or CLI endpoint for requesting a Copilot re-review directly.
 - When a bot or app pushes a commit to the PR branch, direct PR-scoped checks may still run normally while some downstream `workflow_run` automation can enter an approval-required or `action_required` state under GitHub's trust model. That host safeguard **MUST NOT** be misinterpreted as a PR policy failure by itself.
 
-## 4. Apply threshold policy
+### 3.5 Agent resolution loop
+
+Before any human escalation, automation **MUST** attempt to resolve blocking findings.
+
+The resolution loop runs when `autofix:pending` is applied:
+
+1. Check out the PR branch.
+2. Run all auto-fixable toolchain commands (e.g., `biome check --write .` for formatting and lint).
+3. Commit any changes and push. Label the PR with `autofix:applied`.
+4. Post a structured resolution comment listing what was fixed and what was not.
+5. If everything is now fixed and `npm run validate` passes: remove `autofix:pending`. The Copilot reviewer re-runs on the new head SHA and the residual risk engine re-evaluates.
+6. If unfixed issues remain after the resolution loop: post a structured decision request (see section 5) for the specific remaining items. Do not run the resolution loop again on the same PR once `autofix:applied` is set.
+
+The resolution loop **MUST NOT** attempt fixes outside the safe autofix set. Changes that require reasoning about business logic, security intent, or product behavior are decision items, not autofix items.
+
+Safe autofix actions:
+
+- Formatting and style (biome, prettier, etc.)
+- Import ordering
+- Lint rule violations with deterministic fixes
+- Whitespace and trailing-newline normalization
+
+Not safe for automated fix:
+
+- Logic changes
+- Security-sensitive code paths
+- Schema migrations
+- Test assertions
+- Anything that changes observable runtime behavior
+
+### 4. Apply threshold policy
 
 Decision rules:
 
@@ -192,52 +260,68 @@ Decision rules:
 - Residual risk sets approval and merge authority.
 - Residual low: automation may approve or merge when checks pass and no blocking findings remain.
 - Residual medium: approval and merge follow repository-specific threshold policy.
-- Residual high: human review is mandatory before approval or merge.
+- Residual high: human decision is mandatory before approval or merge.
 - In a personal-repository deployment with a single human operator, threshold policy **MAY** allow the repository owner to act as the final human checkpoint for residual medium after all evidence gates pass, even when no second human reviewer exists.
 
 A threshold policy should include at least:
 
-- affected paths or systems
-- diff size or complexity thresholds
-- branch freshness requirements
-- initial vs residual risk rules
-- required evidence types
-- required human approver roles
-- rollback expectations for risky changes
+- Affected paths or systems
+- Diff size or complexity thresholds
+- Branch freshness requirements
+- Initial vs residual risk rules
+- Required evidence types
+- Required human approver roles
+- Rollback expectations for risky changes
 
-## 5. Resolve or escalate
+### 5. Resolve or escalate
 
-1. If findings are autofixable and within authority, update the branch and rerun checks.
-2. If findings are not autofixable, request changes with explicit reasons.
-3. If the PR crosses a human checkpoint, notify the required approver with the evidence bundle.
-4. If review conversations are already addressed by the latest branch state, an authorized collaborator or automation with host support **MAY** resolve those conversations explicitly after verification.
+1. If findings are autofixable and within authority, run the resolution loop (step 3.5) and rerun checks.
+2. If findings are not autofixable, post a structured decision request (see below) with explicit findings and the exact action required.
+3. If the PR crosses a human decision point, post the decision request with the evidence bundle before stopping.
+4. If review conversations are already addressed by the latest branch state, automation **MAY** resolve those conversations explicitly after verification.
 
-Escalation should be specific about why automation stopped.
+**Decision request format**
+
+When automation must stop for a human, the escalation comment **MUST** follow this structure. The human should be able to act in under two minutes without reading any other document.
+
+```
+**P1 decision request**
+
+[One sentence: the exact decision needed from you.]
+
+**What changed**
+[2–3 sentence summary of what this PR does, derived from the diff and PR description.]
+
+**Why automation stopped**
+[Exact reason: e.g., "`auth/permissions.ts` modified — production auth gate."]
+
+**Automated verification (complete)**
+- ✓ Required checks: all pass
+- ✓ Review: completed by [reviewer] on [head SHA prefix]
+- ✓ Branch: current with main
+
+**Remaining items requiring your decision**
+[Numbered list of specific findings. Each entry: file:line — description — why it cannot be auto-resolved.]
+
+**Your options**
+1. **Approve** — add your GitHub approval; merge proceeds automatically.
+2. **Request changes** — push a commit addressing the items above; automation resumes on the new head.
+3. **Close** — reject this PR.
+```
 
 If residual risk still requires human intervention, automation **MUST** finish every non-human step before stopping. At minimum this means:
 
-- branch freshness resolved or explicitly blocked with `sync:needed`
-- required checks either green or already rerunning for the current head SHA
-- residual-risk label applied
-- automated review summary and escalation rationale posted on the PR
-- safe autofixes already applied when permitted
-- review conversations resolved when their underlying findings are already addressed and the host supports explicit resolution
-- required reviewer or approver requested when the host supports it
-- auto-merge enabled in advance when repository policy allows merge immediately after approval
-
-The goal is a one-click human checkpoint whenever the platform permits it: the human should only need to approve, not reconstruct evidence or perform routine preparation work first.
-
-For personal repositories operated by a single human, "one-click approval-ready" may instead mean "one explicit owner decision ready." In that mode, automation **SHOULD** leave a PR comment that states the exact action needed from the owner:
-
-- merge now
-- request changes
-- close the PR
+- Branch freshness resolved or explicitly blocked with `sync:needed`
+- Required checks either green or already rerunning for the current head SHA
+- Residual risk label applied
+- Resolution loop already run (if applicable)
+- Decision request posted in the format above
+- Required reviewer or approver requested when the host supports it
+- Auto-merge enabled in advance when repository policy allows merge immediately after approval
 
 The workflow **MUST NOT** deadlock indefinitely on an unavailable second human reviewer if repository policy explicitly names the owner as the terminal checkpoint for that risk tier.
 
-If the PR is behind the protected branch, escalation should explicitly request a rebase or branch update before any further approval decision. Automation-owned PRs should treat this as a creation failure and reopen the review loop only after syncing.
-
-## 6. Approve and merge
+### 6. Approve and merge
 
 When the PR is within policy and all required checks have passed:
 
@@ -248,7 +332,7 @@ When the PR is within policy and all required checks have passed:
 Merge must be blocked if required checks are pending, stale, or bypassed.
 Merge must also be blocked if the PR branch is behind the protected base branch.
 
-## 6.5 Convergence rule
+### 6.5 Convergence rule
 
 Automation **MUST** converge without manual label toggling when the only blocker is timing between checks.
 
@@ -262,7 +346,7 @@ Required behavior:
 
 This rule prevents false human escalation caused only by event ordering.
 
-## 6.6 Control-plane changes
+### 6.6 Control-plane changes
 
 PRs that modify the PR automation control plane itself, including workflow files, branch-protection assumptions, or review-policy logic, **MUST** be evaluated under the currently merged policy on the protected branch, not the proposed policy in the PR branch.
 
@@ -270,35 +354,67 @@ Required behavior:
 
 1. Automation changes do not self-validate until they are merged into the protected branch.
 2. The active workflow version on the protected branch is the source of truth for labels, checks, and merge authority during review.
-3. Framework updates should record any bootstrap exception used to merge a control-plane change.
+3. Control-plane PRs are identified by the `control-plane` label applied during risk classification. The residual risk engine **MUST NOT** auto-downgrade a `control-plane` PR to `residual:low` regardless of reviewer state. The minimum residual risk for a control-plane PR is `residual:med`.
+4. Framework updates should record any bootstrap exception used to merge a control-plane change.
 
 On a personal repository with no second human reviewer, implementations **SHOULD** minimize bootstrap exceptions by encoding the owner-decision path directly in policy for the allowed risk tiers, rather than relying on ad hoc manual overrides.
 
-## 7. Record outcomes
+### 7. Record outcomes
 
 Record:
 
-- initial risk tier
-- residual risk tier
-- branch freshness state
-- checks executed
-- findings summary
-- approval source
-- merge decision
-- escalation reason if applicable
+- Initial risk tier
+- Residual risk tier
+- Branch freshness state
+- Checks executed
+- Findings summary
+- Resolution loop outcome (applied / not needed / escalated)
+- Approval source
+- Merge decision
+- Escalation reason if applicable
 
 These records should be queryable from GitHub or emitted as framework events.
 
+## Human decision points
+
+Human involvement is required when any of the following apply:
+
+- Residual high risk (auth, billing, migrations, production infrastructure, secrets)
+- Control-plane change that cannot be auto-downgraded to `residual:low`
+- Residual medium risk when repository policy requires a human checkpoint
+- Agent resolution loop exhausted (all autofix attempts completed; non-fixable issues remain)
+- Rebase conflict on a fork branch (automation cannot push; author must resolve)
+- Confidence below the configured threshold
+
+Human involvement is **NOT** required for:
+
+- Verifying that checks pass — the check status is machine-observable
+- Confirming that Copilot approved — review state is machine-observable
+- Resolving lint or formatting issues — the resolution loop handles these
+- Confirming branch freshness — the sync workflow handles this
+- Setting `residual:*` labels — the residual risk engine handles this
+
+When a human does act, they receive a decision request (section 5) with the full evidence bundle. Their action is one of: approve, request changes, or close.
+
 ## Recommended implementation layers
 
-The first implementation should use:
+The primary implementation uses:
 
-- GitHub Actions for deterministic checks and PR metadata workflows
-- Branch protection and auto-merge for merge enforcement
-- An AI reviewer backend for code review and safe autofix proposals
-- Labels or check runs for risk classification
-- A required policy check that decides whether human approval is still necessary
-- Labels or checks for branch freshness and update requirements
+- **GitHub Actions** for deterministic checks and PR metadata workflows
+- **Branch protection and auto-merge** for merge enforcement
+- **AI reviewer backend** for code review and safe autofix proposals
+- **Labels and check runs** for risk classification and residual risk state
+- **Required policy check** (`decide`) that decides whether human approval is still necessary
+- **Labels and checks** for branch freshness and update requirements
+
+Implemented workflows:
+
+- `p1-risk-classification` — Classifies changed paths; applies `risk:*`, `sync:needed`, `control-plane` labels
+- `p1-residual-risk-engine` — Triggers on Copilot review submission; auto-assigns `residual:*` or `autofix:pending`
+- `p1-branch-sync` — Triggers on `sync:needed`; auto-rebases same-repo branches; posts sync command for forks
+- `p1-autofix` — Triggers on `autofix:pending`; runs tool-based fixes, commits, and posts resolution summary
+- `p1-policy` — Required check `decide`; reads labels and evidence; passes or emits a structured decision request
+- `p1-low-risk-automation` — Enables auto-merge when `residual:low` and all checks pass
 
 Optional later layers:
 
@@ -306,45 +422,8 @@ Optional later layers:
 - Preview environments
 - Policy engine for path-based authority
 - Structured workflow state outside GitHub
-
-Initial backend for this repository:
-
-- GitHub Copilot automatic code review via a repository ruleset targeting `~DEFAULT_BRANCH` with review on new pushes
-- Repository custom instructions in `.github/copilot-instructions.md`
-- GitHub Actions for classification, residual-risk application after review, low-risk approval, and auto-merge orchestration
-
-## Human checkpoints
-
-Human involvement is required when any of the following apply:
-
-- residual high risk
-- residual medium risk when repository policy requires a human checkpoint
-- unclear ownership
-- branch is behind the protected base branch and cannot be refreshed automatically
-- failing or flaky required checks
-- unresolved blocking review findings
-- security-sensitive paths
-- broad cross-cutting refactors
-- confidence below the configured threshold
-
-## Baseline target for this repository
-
-Recommended first implementation for this repository:
-
-- Auto-classify PR risk from changed paths and labels.
-- Distinguish initial risk from residual risk after review.
-- Label outdated PRs with `sync:needed` and block automation until they are refreshed.
-- Run `npm run validate` as the canonical required check.
-- Run repository-configured automated review on every PR, for example through a repository ruleset that requests GitHub Copilot review.
-- Treat the absence of the expected Copilot review artifact as a blocking state rather than silently proceeding.
-- Use the repository reviewer output as input to the agent's residual-risk decision instead of treating agent labeling as a separate first-pass review.
-- Allow automation to merge residual-low PRs.
-- Require a policy decision check before merge instead of a blanket GitHub review gate.
-- Allow auto-merge only after required checks pass and policy allows approval.
-- Require human review only when residual risk and policy thresholds still warrant it, and leave those PRs in an approval-ready state before stopping.
-- For a personal repository with one human operator, allow the owner-decision path for residual medium when policy explicitly permits it and all required evidence is present.
-- Re-run policy automatically after fresh validation lands on the same head SHA when earlier policy runs failed only because validation was not ready yet.
-- Keep approval and merge authority in GitHub policy and workflows, not in the AI reviewer backend itself.
+- AI-driven semantic autofix (extends `p1-autofix` with an LLM backend for logic-level fixes)
+- Coverage and performance regression gates
 
 ## Events
 
@@ -354,9 +433,12 @@ Example event names:
 - `pr.risk_classified`
 - `pr.residual_risk_set`
 - `pr.branch_outdated`
-- `pr.branch_refreshed`
+- `pr.branch_synced`
+- `pr.branch_sync_failed`
 - `pr.validation_completed`
 - `pr.review_completed`
+- `pr.autofix_applied`
+- `pr.autofix_escalated`
 - `pr.escalated`
 - `pr.approved`
 - `pr.auto_merge_enabled`
@@ -365,8 +447,10 @@ Example event names:
 ## Notes for future variants
 
 - P1 should eventually be encoded in machine-readable process definitions under `spec/processes/`.
-- Risk tiering should evolve from simple path rules toward evidence-based thresholds.
+- Risk tiering should evolve from simple path rules toward evidence-based thresholds incorporating security scanner output, coverage delta, and diff complexity scores.
 - Approval policy should remain stricter than review policy.
 - The reviewer backend may change over time; the threshold policy should not depend on a single provider.
 - Branch freshness rules should remain policy-owned even if the repository changes reviewer backends or CI providers.
 - Event ordering between validation and policy checks should be treated as an automation-convergence concern, not as a human-review concern.
+- The resolution loop should be extended with an LLM-driven semantic fix layer once the safe autofix boundary is well-established. The tool interface for this is defined in `agents/interfaces.yaml`.
+- The decision request format in section 5 is machine-generatable. Future versions should produce it from structured finding objects rather than free-form text.


### PR DESCRIPTION
## Summary

Implements additional P1 automation paths: residual risk from Copilot reviews, branch sync when `sync:needed` is applied, an autofix loop when `autofix:pending` is applied, and tighter orchestration in `p1-policy` (including `workflow_run` triggers). Updates `docs/P1_PR_EXECUTION_LOOP.md` so the written playbook matches the workflows.

## P1 agent self-verification (pre-open)

Per `docs/P1_PR_EXECUTION_LOOP.md` § Agent self-verification toolchain, the opening agent ran:

| Gate | Result |
|------|--------|
| `npm run validate` | **Passed** (schema / example spec validation) |

**Not yet available at PR open (expected):** Copilot review on the PR head SHA, full GitHub required-check matrix, and branch freshness relative to `main` after CI — these are enforced by repository automation and branch protection after this PR is opened.

## Change type / risk

- **Area:** GitHub Actions (control plane), P1 policy orchestration, documentation.
- **Initial risk (expected):** medium — workflow and policy surface changes fall under P1 “medium risk” and control-plane rules until residual risk is evaluated after review.

## Files

- **New:** `.github/workflows/p1-residual-risk-engine.yml`, `p1-branch-sync.yml`, `p1-autofix.yml`
- **Updated:** `p1-policy.yml`, `p1-risk-classification.yml`, `p1-low-risk-automation.yml`
- **Docs:** `docs/P1_PR_EXECUTION_LOOP.md`

## Merge authority

Merge only when P1 gates and branch protection are satisfied (validate, classification, residual path, policy `decide` check, and configured reviewer evidence as defined in repo rules).
