### PR TITLE
docs: P2 agent context bundle (AGENTS, SKILLS, MEMORY)

### DIFF
--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -199,6 +199,15 @@ jobs:
               core.info(
                 `Required check '${requiredCheck}' is not registered yet on ${pr.headRefOid.slice(0, 7)}; deferring (validate gate still blocks merge).`,
               );
+              await upsertPolicyComment([
+                '**P1 policy:** waiting — validation not registered yet',
+                '',
+                `Head \`${pr.headRefOid.slice(0, 7)}\`: no \`${requiredCheck}\` check run is visible on this SHA yet.`,
+                '',
+                'This `decide` job exits **success** so it does not race `validate-spec` on the same push. Branch protection still requires `validate` before merge.',
+                '',
+                'A full policy decision will replace this comment after `validate` completes and this check re-evaluates (including via `workflow_run`).',
+              ].join('\n'));
               return;
             }
 
@@ -206,6 +215,15 @@ jobs:
               core.info(
                 `Required check '${requiredCheck}' is still ${validateCheck.status} on ${pr.headRefOid.slice(0, 7)}; deferring.`,
               );
+              await upsertPolicyComment([
+                '**P1 policy:** waiting — validation in progress',
+                '',
+                `Head \`${pr.headRefOid.slice(0, 7)}\`: \`${requiredCheck}\` is \`${validateCheck.status}\` (not completed yet).`,
+                '',
+                'This `decide` job exits **success** to avoid failing while validation is still running. Merge remains blocked until `validate` completes successfully.',
+                '',
+                'This comment updates on every evaluation so it always reflects the **current** head SHA.',
+              ].join('\n'));
               return;
             }
 

--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -7,8 +7,11 @@ name: p1-policy
 # a structured decision request for the human.
 #
 # Humans receive a specific, bounded decision request — not an open-ended review task.
-# The check fails both when a genuine human decision is required and when required
-# evidence gates are incomplete (e.g., validate still running, review not yet present).
+# The check fails when a genuine human decision is required or when required evidence
+# is conclusively missing/failed (e.g., validate finished with failure, no Copilot review).
+# When validate has not started or is still running, this job exits success and defers —
+# branch protection still requires the validate check, and workflow_run re-triggers this
+# job after validate-spec completes (see getPrNumber fallback for empty pull_requests).
 
 on:
   pull_request_target:
@@ -36,7 +39,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            function getPrNumber() {
+            async function getPrNumber() {
               if (context.eventName === 'pull_request_target') {
                 return context.payload.pull_request.number;
               }
@@ -45,12 +48,26 @@ jobs:
               }
               if (context.eventName === 'workflow_run') {
                 const prs = context.payload.workflow_run.pull_requests || [];
-                return prs.length > 0 ? prs[0].number : null;
+                if (prs.length > 0) {
+                  return prs[0].number;
+                }
+                // GitHub often omits pull_requests on workflow_run; resolve via the head commit.
+                const headSha = context.payload.workflow_run.head_sha;
+                if (!headSha) {
+                  return null;
+                }
+                const { data: associated } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner,
+                  repo,
+                  commit_sha: headSha,
+                });
+                const openPr = associated.find((p) => p.state === 'open');
+                return openPr ? openPr.number : null;
               }
               return null;
             }
 
-            const prNumber = getPrNumber();
+            const prNumber = await getPrNumber();
             if (!prNumber) {
               core.info('No pull request is associated with this event.');
               return;
@@ -179,12 +196,16 @@ jobs:
             );
 
             if (!validateCheck) {
-              core.setFailed(`Required check '${requiredCheck}' has not started yet on ${pr.headRefOid.slice(0, 7)}. Policy will re-evaluate when it completes.`);
+              core.info(
+                `Required check '${requiredCheck}' is not registered yet on ${pr.headRefOid.slice(0, 7)}; deferring (validate gate still blocks merge).`,
+              );
               return;
             }
 
             if (validateCheck.status !== 'completed') {
-              core.setFailed(`Required check '${requiredCheck}' is still running on ${pr.headRefOid.slice(0, 7)}. Policy will re-evaluate when it completes.`);
+              core.info(
+                `Required check '${requiredCheck}' is still ${validateCheck.status} on ${pr.headRefOid.slice(0, 7)}; deferring.`,
+              );
               return;
             }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md
+
+## Purpose
+
+This repository defines an AI-native operating framework for product-led companies. The canonical system lives in schema, policy, interfaces, and playbooks. Markdown at the repo root exists to help agents bootstrap accurately and act consistently inside that system.
+
+## Read Order
+
+Read these in order before making non-trivial changes:
+
+1. `README.md`
+2. `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md`
+3. `docs/PLAYBOOKS.md`
+4. The specific playbook or spec files relevant to the task
+5. `SKILLS.md`
+6. `MEMORY.md`
+
+## Authority Ladder
+
+Higher items override lower items:
+
+1. `spec/schema/*`
+2. Validated artifacts under `spec/examples/*` and future `spec/processes/*`
+3. `spec/policy/*`
+4. `agents/interfaces.yaml`
+5. Playbooks under `docs/*`
+6. `AGENTS.md`, `SKILLS.md`, `MEMORY.md`
+
+If two sources conflict, follow the higher source and update the lower one if that is within scope.
+
+## Canonical Commands
+
+- Install: `npm install`
+- Validate framework artifacts: `npm run validate`
+
+If you change schema, examples, policy, templates, or playbooks, run `npm run validate` before concluding work.
+
+## Working Rules
+
+- Keep the framework provider-agnostic. Do not encode a single model vendor or IDE as core policy.
+- Treat specs, policy, and playbooks as the durable operating system. Root markdown files are bootstrap aids, not a replacement for canonical artifacts.
+- Prefer updating the framework and playbooks together when a process change affects repository behavior.
+- Keep repository-local agent instructions concise. Link outward instead of duplicating long prose.
+- Preserve the distinction between stable memory and temporary working notes.
+
+## Change Discipline
+
+- When adding a new recurring workflow, update `docs/PLAYBOOKS.md` and `SKILLS.md`.
+- When changing repo operating rules, check whether `AGENTS.md` and `MEMORY.md` now need updates.
+- When introducing durable process knowledge, prefer a playbook or schema-backed artifact over burying it in memory.
+- Do not treat transient chat as the system of record.
+
+## Escalation Conditions
+
+Escalate or stop when any of these are true:
+
+- the task would contradict schema, policy, or playbook rules
+- a high-stakes governance decision is required
+- repository intent is ambiguous and cannot be resolved from the tracked artifacts
+- a change would grant new authority to automation without explicit policy support
+
+## Important Paths
+
+- `spec/schema/` - canonical machine validation rules
+- `spec/examples/` - validated product and slice examples
+- `spec/policy/` - event and governance policy
+- `agents/interfaces.yaml` - logical tool interfaces for agent workflows
+- `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md` - normative framework prose
+- `docs/PLAYBOOKS.md` - playbook index
+- `docs/P0_REPOSITORY_FOUNDATION.md` - repository bootstrap
+- `docs/P1_PR_EXECUTION_LOOP.md` - PR automation policy
+- `docs/P2_AGENT_CONTEXT_BUNDLE.md` - agent runtime bundle standard
+
+## Definition Of Done
+
+A framework change is not complete if it leaves the runtime bundle stale. If your edit changes how an agent should bootstrap, choose a skill, validate work, or preserve context, update this bundle in the same change.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -23,7 +23,6 @@ This file stores durable repository memory for agents. It is not a transcript an
 
 - Encode P0, P1, and P2 as machine-readable process artifacts under future `spec/processes/`.
 - Decide whether larger future workflow catalogs should live only in `SKILLS.md` or split into a `skills/` directory.
-- Keep `REPO_SCAFFOLD.md` aligned if the repository scaffold should eventually materialize the agent context bundle too.
 
 ## Recent Decisions
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,38 @@
+# MEMORY.md
+
+This file stores durable repository memory for agents. It is not a transcript and it is not a dumping ground for temporary notes.
+
+## Stable Facts
+
+- This repository is the canonical home of an AI-native operating framework for product-led companies.
+- Canonical truth is ordered by the authority ladder in `AGENTS.md`, with schema and policy above explanatory Markdown.
+- The repository currently defines two operating playbooks in active use:
+  - `P0` for repository foundation
+  - `P1` for pull request execution
+- `P2` now defines the repository-local agent context bundle standard.
+- The canonical validation command is `npm run validate`.
+- The framework is explicitly provider-agnostic at the core layer.
+
+## Current Bundle State
+
+- `AGENTS.md` is the bootstrap file for agents entering the repository.
+- `SKILLS.md` is the procedure registry for repeated work in this repo.
+- `MEMORY.md` is reserved for durable facts, dated decisions, and open loops worth carrying across sessions.
+
+## Active Open Loops
+
+- Encode P0, P1, and P2 as machine-readable process artifacts under future `spec/processes/`.
+- Decide whether larger future workflow catalogs should live only in `SKILLS.md` or split into a `skills/` directory.
+- Keep `REPO_SCAFFOLD.md` aligned if the repository scaffold should eventually materialize the agent context bundle too.
+
+## Recent Decisions
+
+- 2026-04-10: Adopted a repository-local agent context bundle built around `AGENTS.md`, `SKILLS.md`, and `MEMORY.md`.
+- 2026-04-10: Added `P2 - Agent context bundle` as a first-class playbook in the framework.
+
+## Update Rules
+
+- Add facts only if they are likely to matter in future sessions.
+- Remove or rewrite facts when they become stale.
+- Close open loops instead of letting this file grow indefinitely.
+- If a memory item becomes normative policy, move it into schema, playbook, or framework docs and leave only a short pointer here.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,10 +6,10 @@ This file stores durable repository memory for agents. It is not a transcript an
 
 - This repository is the canonical home of an AI-native operating framework for product-led companies.
 - Canonical truth is ordered by the authority ladder in `AGENTS.md`, with schema and policy above explanatory Markdown.
-- The repository currently defines two operating playbooks in active use:
+- The repository currently defines the following first-class operating playbooks:
   - `P0` for repository foundation
   - `P1` for pull request execution
-- `P2` now defines the repository-local agent context bundle standard.
+  - `P2` for the repository-local agent context bundle standard
 - The canonical validation command is `npm run validate`.
 - The framework is explicitly provider-agnostic at the core layer.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 **Agent tool contracts:** [`agents/interfaces.yaml`](agents/interfaces.yaml).  
 **Operating framework (normative prose, v0.1):** [`docs/AI_NATIVE_FRAMEWORK_COMPLETE.md`](docs/AI_NATIVE_FRAMEWORK_COMPLETE.md) - read after `spec/` when bootstrapping company-wide behavior.  
 **Playbooks:** [`docs/PLAYBOOKS.md`](docs/PLAYBOOKS.md) - reusable procedures for bootstrapping and operating framework-aligned repos.  
+**Agent context bundle:** [`AGENTS.md`](AGENTS.md), [`SKILLS.md`](SKILLS.md), and [`MEMORY.md`](MEMORY.md) - repository-local operating context for coding agents and assistants.  
 Optional human-readable mirrors can live under `docs/` (generate or keep in sync).
 
 ## Quick start
@@ -26,6 +27,9 @@ CI runs the same check (see [`.github/workflows/validate.yml`](.github/workflows
 | `templates/`                           | Empty `slice-spec.yaml` template                                     |
 | `agents/`                              | Provider-agnostic logical interfaces                                 |
 | `scripts/`                             | `validate-spec.mjs` (AJV + YAML)                                     |
+| `AGENTS.md`                            | Agent bootstrap contract: authority, workflow, and repo-specific rules |
+| `SKILLS.md`                            | Reusable capability registry and procedure index                     |
+| `MEMORY.md`                            | Durable working memory, current state, and update discipline         |
 | `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md` | Full operating framework (agent-oriented; initial v0.1)              |
 | `docs/PLAYBOOKS.md`                    | Index of reusable playbooks and operating procedures                 |
 | `REPO_SCAFFOLD.md`                     | Full copy-paste bundle + Appendix (keep in sync when editing schema) |
@@ -35,4 +39,5 @@ CI runs the same check (see [`.github/workflows/validate.yml`](.github/workflows
 
 - **Parallel cycle:** each shipped vertical slice updates schemas, examples, and policies together.
 - **Agent-primary:** breaking changes go through schema + policy; docs follow.
+- **Context is infrastructure:** agent runtime guidance belongs in versioned repo artifacts, not only in transient prompts.
 - **`kind: slice`** requires `slice_id` and `parent_product_id` (see schema `allOf`).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ CI runs the same check (see [`.github/workflows/validate.yml`](.github/workflows
 | `spec/schema/`                         | JSON Schema for product and slice specs                              |
 | `spec/examples/`                       | Golden + future validated YAML specs                                 |
 | `spec/policy/`                         | Event naming, PII, idempotency, deprecation rules                    |
-| `templates/`                           | Empty `slice-spec.yaml` template                                     |
+| `templates/`                           | `slice-spec.yaml` plus `agents-template.md`, `skills-template.md`, `memory-template.md` |
 | `agents/`                              | Provider-agnostic logical interfaces                                 |
 | `scripts/`                             | `validate-spec.mjs` (AJV + YAML)                                     |
 | `AGENTS.md`                            | Agent bootstrap contract: authority, workflow, and repo-specific rules |

--- a/REPO_SCAFFOLD.md
+++ b/REPO_SCAFFOLD.md
@@ -55,6 +55,12 @@ node_modules/
 - [Rule]
 - [Rule]
 
+## Change Discipline
+
+- When adding a new recurring workflow, update [playbook index] and `SKILLS.md`.
+- When changing repo operating rules, check whether `AGENTS.md` and `MEMORY.md` now need updates.
+- When introducing durable process knowledge, prefer a playbook or schema-backed artifact over burying it in memory.
+
 ## Escalation Conditions
 
 - [Condition]
@@ -66,6 +72,10 @@ node_modules/
 - `[path]` - [purpose]
 - `[path]` - [purpose]
 - `[path]` - [purpose]
+
+## Definition Of Done
+
+A framework change is not complete if it leaves the runtime bundle stale. If your edit changes how an agent should bootstrap, choose a skill, validate work, or preserve context, update this bundle in the same change.
 ```
 
 ---

--- a/REPO_SCAFFOLD.md
+++ b/REPO_SCAFFOLD.md
@@ -16,6 +16,124 @@ node_modules/
 
 ---
 
+## File: `AGENTS.md`
+
+```md
+# AGENTS.md
+
+## Purpose
+
+[One paragraph: what this repository is for and why agents operate here.]
+
+## Read Order
+
+1. `README.md`
+2. [Primary framework or architecture doc]
+3. [Playbook index]
+4. [Task-specific canonical docs]
+5. `SKILLS.md`
+6. `MEMORY.md`
+
+## Authority Ladder
+
+1. [Machine-validated schema]
+2. [Validated instances]
+3. [Policy files]
+4. [Interface contracts]
+5. [Playbooks and docs]
+6. `AGENTS.md`, `SKILLS.md`, `MEMORY.md`
+
+## Canonical Commands
+
+- Install: `[install command]`
+- Validate: `[validation command]`
+- Test: `[test command if distinct]`
+
+## Working Rules
+
+- [Rule]
+- [Rule]
+- [Rule]
+
+## Escalation Conditions
+
+- [Condition]
+- [Condition]
+- [Condition]
+
+## Important Paths
+
+- `[path]` - [purpose]
+- `[path]` - [purpose]
+- `[path]` - [purpose]
+```
+
+---
+
+## File: `SKILLS.md`
+
+```md
+# SKILLS.md
+
+## How To Use This File
+
+1. Match the task to the closest skill.
+2. Read the linked canonical source.
+3. Follow the listed constraints.
+
+## Skill Registry
+
+### [Skill Name]
+
+- **When to use:** [trigger]
+- **Inputs:** [inputs]
+- **Outputs:** [outputs]
+- **Canonical source:** [path]
+- **Constraints:** [constraints]
+
+### [Skill Name]
+
+- **When to use:** [trigger]
+- **Inputs:** [inputs]
+- **Outputs:** [outputs]
+- **Canonical source:** [path]
+- **Constraints:** [constraints]
+```
+
+---
+
+## File: `MEMORY.md`
+
+```md
+# MEMORY.md
+
+## Stable Facts
+
+- [Fact]
+- [Fact]
+
+## Current State
+
+- [Current durable state]
+
+## Active Open Loops
+
+- [Open loop]
+- [Open loop]
+
+## Recent Decisions
+
+- [YYYY-MM-DD]: [Decision]
+
+## Update Rules
+
+- Add only durable facts.
+- Remove stale entries.
+- Move normative policy into canonical docs.
+```
+
+---
+
 ## File: `package.json`
 
 ```json
@@ -872,4 +990,3 @@ Paste the following as valid JSON (single file):
 - **Slice specs** require `slice_id` and `parent_product_id` (enforced by `allOf` in schema).
 - Update `golden-product.yaml` when you add required fields to the schema.
 - Keep `spec/policy/event-taxonomy.yaml` aligned with runtime emitters.
-

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,77 @@
+# SKILLS.md
+
+This file maps recurring repository work to reusable procedures. Use it to decide how to operate before improvising a new workflow.
+
+## How To Use This File
+
+1. Match the task to the closest skill.
+2. Read the linked canonical source.
+3. Use the prescribed inputs, outputs, and constraints.
+4. If no skill fits, perform the task conservatively and consider whether a new skill should be added after the work is complete.
+
+## Skill Registry
+
+### Framework Bootstrap
+
+- **When to use:** orienting a new agent or starting substantial work in this repository
+- **Inputs:** repository purpose, current task, affected files
+- **Outputs:** correct read order, authority map, and validation plan
+- **Canonical sources:** `AGENTS.md`, `README.md`, `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md`
+- **Notes:** use this before making policy or playbook changes
+
+### P0 - Repository Foundation
+
+- **When to use:** establishing or auditing repository governance, CI, branch protection, security defaults, and contributor surfaces
+- **Inputs:** repository owner, default branch, canonical validation command, maintainer identity
+- **Outputs:** governed repo baseline and recorded settings
+- **Canonical source:** `docs/P0_REPOSITORY_FOUNDATION.md`
+- **Constraints:** do not guess required check names; read real emitted checks
+
+### P1 - Pull Request Execution Loop
+
+- **When to use:** designing, implementing, or reviewing PR automation, risk policy, branch freshness, or merge authority behavior
+- **Inputs:** PR metadata, labels, required checks, review state, branch freshness state, threshold policy
+- **Outputs:** residual-risk decision, merge authority, or structured escalation request
+- **Canonical source:** `docs/P1_PR_EXECUTION_LOOP.md`
+- **Constraints:** machines verify, humans decide; do not convert timing gaps into human-review work
+
+### P2 - Agent Context Bundle
+
+- **When to use:** creating or updating `AGENTS.md`, `SKILLS.md`, `MEMORY.md`, or making agent bootstrap behavior explicit in a repository
+- **Inputs:** authority ladder, canonical commands, playbooks, glossary, durable facts, open loops
+- **Outputs:** maintained agent runtime bundle
+- **Canonical source:** `docs/P2_AGENT_CONTEXT_BUNDLE.md`
+- **Constraints:** keep the bundle concise and subordinate to schema and policy
+
+### Spec Evolution
+
+- **When to use:** changing framework structure, required fields, or examples under `spec/`
+- **Inputs:** desired behavioral change, schema updates, example updates, policy impact
+- **Outputs:** aligned schema, examples, and documentation
+- **Canonical sources:** `spec/schema/product-spec.schema.json`, `spec/examples/`, `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md`
+- **Constraints:** avoid spec theater; machine validation is the source of truth
+
+### Interface Evolution
+
+- **When to use:** changing logical tool contracts or capability boundaries
+- **Inputs:** workflow need, capability boundary, interface change rationale
+- **Outputs:** updated `agents/interfaces.yaml` and aligned docs
+- **Canonical sources:** `agents/interfaces.yaml`, `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md`
+- **Constraints:** express capabilities, not mascots or vendor-specific personas
+
+## Adding A New Skill
+
+Add a skill when all of these are true:
+
+- the workflow recurs
+- the workflow has a stable trigger
+- there is a canonical source worth pointing to
+- reusing the procedure reduces ambiguity or failure rate
+
+For each new skill, include:
+
+- when to use it
+- required inputs
+- expected outputs
+- canonical source
+- constraints or escalation rules

--- a/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
+++ b/docs/AI_NATIVE_FRAMEWORK_COMPLETE.md
@@ -20,6 +20,8 @@
 4. `agents/interfaces.yaml`  
 5. This Markdown file and other `docs/*` (explanatory; **MUST NOT** override 1–4)
 
+Repository-local agent runtime files such as `AGENTS.md`, `SKILLS.md`, and `MEMORY.md` are explanatory operating artifacts unless promoted into machine-validated schema or policy. They **SHOULD** align with items 1–4 and **MUST NOT** contradict them.
+
 ### 0.3 Conformance keywords
 
 - **MUST / MUST NOT:** Hard requirement. Violation blocks release unless a human waiver is recorded in the decision log.  
@@ -200,6 +202,9 @@ Typical layout for a framework-aligned repo:
 | `spec/processes/` | *(Introduce)* validated process/workflow instances |
 | `templates/` | Generators and empty templates (e.g. slice spec) |
 | `agents/interfaces.yaml` | Logical tool contracts |
+| `AGENTS.md` | Repository-local bootstrap instructions, authority map, and execution rules for agents |
+| `SKILLS.md` | Reusable capability registry; maps recurring work to procedures and artifacts |
+| `MEMORY.md` | Durable working memory: current state, constraints, glossary, decisions, open loops |
 | `scripts/validate-spec.mjs` | Local and CI validation |
 | `.github/workflows/` | CI pipelines |
 | `docs/PLAYBOOKS.md` | Human-readable index of reusable playbooks |
@@ -215,6 +220,23 @@ Task runners—LLM-backed or deterministic—**MUST** operate inside capability 
 ### 7.2 Capability types (non-exhaustive catalog)
 
 Strategist, Researcher, Product, Builder (engineering), Designer, Growth, Sales ops, Support, Finance/Ops. Each capability **MUST** eventually declare in machine form: tools, data access, escalation paths, forbidden actions.
+
+### 7.2.1 Repository-local context bundle
+
+Framework-aligned repositories **SHOULD** expose a lightweight agent context bundle at the repo root:
+
+- `AGENTS.md` — first-read bootstrap contract for agents entering the repository.
+- `SKILLS.md` — reusable procedures, capability definitions, and when-to-use guidance.
+- `MEMORY.md` — durable repository memory with update rules.
+
+This bundle is the provider-agnostic replacement for hidden system prompts or IDE-only conventions. It gives agents a shared, versioned operating surface while keeping the normative source of truth in schemas, policy, and interfaces.
+
+Minimum requirements:
+
+- `AGENTS.md` **MUST** define the repo authority ladder, canonical commands, change discipline, and escalation conditions.
+- `SKILLS.md` **SHOULD** map recurring workflows to named skills or procedures, each with triggers, inputs, outputs, and links to deeper docs or playbooks.
+- `MEMORY.md` **MUST** distinguish stable facts from temporary working state and **MUST NOT** become an unbounded log dump.
+- Changes to these files **SHOULD** be reviewed whenever repo policy, architecture, workflows, or terminology changes.
 
 ### 7.3 Orchestrator
 
@@ -303,6 +325,8 @@ The Process Library is the **encoded moat**: reusable, versioned procedures—tr
 | **Go-to-market** | Launch, landing pages, content, outbound |
 | **Operations** | Onboarding, support, reporting, pricing experiments, internal ops |
 
+The repository-local `SKILLS.md` file is the operator-facing index into this library. Process definitions may remain in Markdown initially, but the skill index **SHOULD** point to the canonical playbook or schema-backed process artifact for each recurring workflow.
+
 ### 11.3 Workflow record shape (each entry SHOULD declare)
 
 - **Inputs** and **outputs** (artifact types).  
@@ -336,6 +360,16 @@ For deployments targeting **solo founders or minimal teams** in **B2B SaaS**, th
 - **Checkpoints:** Human approval is **MUST** for high-risk changes and **SHOULD** be required whenever confidence or evidence falls below policy thresholds. Event-ordering failures between automation steps **MUST NOT** by themselves force human review. Automation-owned PRs **MUST** be synced with the current protected branch before review authority is exercised, deterministic PR state such as residual-risk labels **MUST** be set automatically when policy can infer it, and control-plane PRs **MUST** be judged by the policy currently merged on the protected branch until the update itself lands. Repository-level auto-review configuration such as GitHub rulesets **MAY** request an AI review automatically, but **MUST NOT** itself be treated as approval authority. When a repository-configured reviewer exists, its review output **SHOULD** be consumed before the agent assigns residual risk, and missing reviewer output for the current head SHA **MUST** remain a blocking state rather than an implicit pass. If reviewer follow-up is needed, an authorized collaborator **MAY** request it through host-supported mechanisms such as `@copilot` comments or the repository UI. If that follow-up causes a bot or app to push a new PR commit, required checks and review freshness **MUST** be re-evaluated on the new head SHA. Host-platform approval prompts on privileged downstream automation **MUST** be interpreted as trust-boundary safeguards unless the required PR-scoped checks themselves fail. If a human checkpoint remains, automation **MUST** complete all non-human preparation work first and leave the PR approval-ready wherever the host platform allows it. In personal-repository single-human mode, the owner **MAY** be the final checkpoint for allowed medium-risk changes, provided policy explicitly says so and the agent states the exact action required from the owner.
 - **Playbook:** `docs/P1_PR_EXECUTION_LOOP.md`
 - **Events (examples):** `pr.risk_classified`, `pr.residual_risk_set`, `pr.branch_outdated`, `pr.review_completed`, `pr.escalated`, `pr.merged`.
+
+#### P2 - Agent context bundle
+
+- **Objective:** Install and maintain the repository-local runtime standard that lets agents bootstrap correctly without relying on hidden prompt state.
+- **Inputs:** Repository purpose, authority ladder, canonical commands, playbooks, glossary, and current operating constraints.
+- **Outputs:** Versioned `AGENTS.md`, `SKILLS.md`, and `MEMORY.md` files linked to the framework and playbooks.
+- **Capabilities:** Builder, Product, Ops.
+- **Checkpoints:** Human review when the bundle changes agent authority, escalation rules, or durable memory policy.
+- **Playbook:** `docs/P2_AGENT_CONTEXT_BUNDLE.md`
+- **Events (examples):** `agent.context_bundle_installed`, `agent.skill_registered`, `agent.memory_updated`.
 
 After P1, the library **SHOULD** contain encoded workflows for the following six operating processes.
 

--- a/docs/P2_AGENT_CONTEXT_BUNDLE.md
+++ b/docs/P2_AGENT_CONTEXT_BUNDLE.md
@@ -1,0 +1,135 @@
+# P2 - Agent context bundle
+
+## Objective
+
+Install and maintain a repository-local runtime standard for agents using three explicit files:
+
+- `AGENTS.md` for bootstrap and authority
+- `SKILLS.md` for reusable procedures
+- `MEMORY.md` for durable operating memory
+
+P2 makes agent behavior inspectable, versioned, and portable across coding environments. It complements P0 and P1 by defining how an agent enters the repository, how it chooses a procedure, and how it preserves durable context between sessions.
+
+## When to run
+
+Run P2 immediately after P0 in any repository that expects repeated agent participation.
+
+Re-run P2 whenever:
+
+- the authority ladder changes
+- canonical commands change
+- key playbooks are added or retired
+- architecture or terminology changes enough to invalidate current memory
+- an agent repeatedly makes the same bootstrap mistake because repository context is not explicit enough
+
+## Outcomes
+
+At the end of this playbook, the repository should have:
+
+- a root `AGENTS.md` file that tells an agent how to enter and operate in the repo
+- a root `SKILLS.md` file that maps recurring work to reusable procedures
+- a root `MEMORY.md` file that stores stable operational context and current open loops
+- links from the framework docs and README to the bundle
+- lightweight maintenance rules so the bundle stays accurate instead of becoming prompt theater
+
+## Inputs
+
+- Repository purpose and scope
+- Authority ladder and normative sources
+- Canonical setup, validation, test, and release commands
+- Playbook inventory
+- Important glossary and architectural facts
+- Current open loops worth preserving across sessions
+
+## Procedure
+
+### 1. Create `AGENTS.md`
+
+`AGENTS.md` is the first file a new agent should read.
+
+It should include:
+
+- Repository purpose in one paragraph
+- Authority ladder and which files override which
+- Canonical commands the agent should run before and after changes
+- Expected work style for this repository
+- Rules for editing, validation, and escalation
+- A short map of important directories and docs
+
+`AGENTS.md` should stay concise. If it grows into a handbook, move detail into linked docs and keep `AGENTS.md` as the bootstrap surface.
+
+### 2. Create `SKILLS.md`
+
+`SKILLS.md` is the procedure index.
+
+Each skill entry should declare:
+
+- Name
+- Trigger or when to use it
+- Inputs required
+- Outputs expected
+- Canonical references
+- Constraints or escalation rules
+
+Skills should reference the canonical playbook rather than duplicating it. P0 and P1 are default skills in a framework-aligned repository. Add more skills only when the workflow is recurring enough to justify a reusable unit.
+
+### 3. Create `MEMORY.md`
+
+`MEMORY.md` is durable operating memory, not a raw transcript.
+
+It should contain:
+
+- Stable facts about the repository
+- Current framework and playbook status
+- Open loops that matter across sessions
+- Decision notes with dates
+- Glossary terms that an agent is likely to misread without help
+
+It must separate durable memory from temporary notes. Resolved tasks, noisy logs, and transient debugging detail should be removed instead of accumulated indefinitely.
+
+### 4. Link the bundle into the framework
+
+Update README, playbook indexes, and framework docs so the bundle is part of the operating system rather than an undocumented convention.
+
+At minimum:
+
+- README links to `AGENTS.md`, `SKILLS.md`, and `MEMORY.md`
+- `docs/PLAYBOOKS.md` includes P2
+- framework prose recognizes the bundle as repository-local context, subordinate to schema and policy
+
+### 5. Review for contradictions
+
+Before closing P2:
+
+1. Check that `AGENTS.md`, `SKILLS.md`, and `MEMORY.md` do not contradict schema, policy, or playbooks.
+2. Check that canonical commands still work.
+3. Check that every named skill points to a real canonical source.
+4. Remove stale facts and open loops.
+
+## Maintenance rules
+
+- `AGENTS.md` changes when repo authority, commands, workflow, or escalation rules change.
+- `SKILLS.md` changes when a recurring workflow is added, retired, or materially changed.
+- `MEMORY.md` changes when a durable fact changes, a decision is made, or an open loop is closed or created.
+- Temporary working notes should graduate into schema, playbooks, or code comments when they become durable policy.
+
+## Recommended template discipline
+
+Prefer this shape:
+
+- `AGENTS.md`: short and directive
+- `SKILLS.md`: index-shaped and reusable
+- `MEMORY.md`: structured, pruned, and date-aware
+
+Avoid:
+
+- provider-specific hidden prompt assumptions
+- dumping chat transcripts into memory
+- duplicating entire playbooks in the skill registry
+- using memory as a backlog substitute when an issue tracker exists
+
+## Notes for future variants
+
+- P2 should eventually gain a machine-readable schema under `spec/processes/`.
+- Large repositories may split `SKILLS.md` into an index plus a `skills/` directory.
+- Multi-agent systems may also introduce `agents/*.md` capability files, but the root bundle should remain the universal bootstrap surface.

--- a/docs/PLAYBOOKS.md
+++ b/docs/PLAYBOOKS.md
@@ -6,3 +6,4 @@ Start here when bootstrapping a new framework-aligned repository:
 
 1. [`P0_REPOSITORY_FOUNDATION.md`](P0_REPOSITORY_FOUNDATION.md) - establish repository governance, CI, security, and merge policy before feature work begins.
 2. [`P1_PR_EXECUTION_LOOP.md`](P1_PR_EXECUTION_LOOP.md) - automate PR review, testing, approval, and merge within explicit risk thresholds.
+3. [`P2_AGENT_CONTEXT_BUNDLE.md`](P2_AGENT_CONTEXT_BUNDLE.md) - install and maintain the repository-local `AGENTS.md` / `SKILLS.md` / `MEMORY.md` standard that agents use at runtime.

--- a/templates/agents-template.md
+++ b/templates/agents-template.md
@@ -1,0 +1,47 @@
+# AGENTS.md template
+
+## Purpose
+
+[One paragraph: what this repository is for and why agents operate here.]
+
+## Read Order
+
+1. `README.md`
+2. [Primary framework or architecture doc]
+3. [Playbook index]
+4. [Task-specific canonical docs]
+5. `SKILLS.md`
+6. `MEMORY.md`
+
+## Authority Ladder
+
+1. [Machine-validated schema]
+2. [Validated instances]
+3. [Policy files]
+4. [Interface contracts]
+5. [Playbooks and docs]
+6. `AGENTS.md`, `SKILLS.md`, `MEMORY.md`
+
+## Canonical Commands
+
+- Install: `[install command]`
+- Validate: `[validation command]`
+- Test: `[test command if distinct]`
+
+## Working Rules
+
+- [Rule]
+- [Rule]
+- [Rule]
+
+## Escalation Conditions
+
+- [Condition]
+- [Condition]
+- [Condition]
+
+## Important Paths
+
+- `[path]` - [purpose]
+- `[path]` - [purpose]
+- `[path]` - [purpose]

--- a/templates/agents-template.md
+++ b/templates/agents-template.md
@@ -34,6 +34,12 @@
 - [Rule]
 - [Rule]
 
+## Change Discipline
+
+- When adding a new recurring workflow, update [playbook index] and `SKILLS.md`.
+- When changing repo operating rules, check whether `AGENTS.md` and `MEMORY.md` now need updates.
+- When introducing durable process knowledge, prefer a playbook or schema-backed artifact over burying it in memory.
+
 ## Escalation Conditions
 
 - [Condition]
@@ -45,3 +51,7 @@
 - `[path]` - [purpose]
 - `[path]` - [purpose]
 - `[path]` - [purpose]
+
+## Definition Of Done
+
+A framework change is not complete if it leaves the runtime bundle stale. If your edit changes how an agent should bootstrap, choose a skill, validate work, or preserve context, update this bundle in the same change.

--- a/templates/memory-template.md
+++ b/templates/memory-template.md
@@ -1,0 +1,25 @@
+# MEMORY.md template
+
+## Stable Facts
+
+- [Fact]
+- [Fact]
+
+## Current State
+
+- [Current durable state]
+
+## Active Open Loops
+
+- [Open loop]
+- [Open loop]
+
+## Recent Decisions
+
+- [YYYY-MM-DD]: [Decision]
+
+## Update Rules
+
+- Add only durable facts.
+- Remove stale entries.
+- Move normative policy into canonical docs.

--- a/templates/skills-template.md
+++ b/templates/skills-template.md
@@ -1,0 +1,25 @@
+# SKILLS.md template
+
+## How To Use This File
+
+1. Match the task to the closest skill.
+2. Read the linked canonical source.
+3. Follow the listed constraints.
+
+## Skill Registry
+
+### [Skill Name]
+
+- **When to use:** [trigger]
+- **Inputs:** [inputs]
+- **Outputs:** [outputs]
+- **Canonical source:** [path]
+- **Constraints:** [constraints]
+
+### [Skill Name]
+
+- **When to use:** [trigger]
+- **Inputs:** [inputs]
+- **Outputs:** [outputs]
+- **Canonical source:** [path]
+- **Constraints:** [constraints]


### PR DESCRIPTION
## Summary

Adds the P2 agent context bundle: `AGENTS.md`, `SKILLS.md`, `MEMORY.md`, templates, `docs/P2_AGENT_CONTEXT_BUNDLE.md`, and wires these into `README.md`, `REPO_SCAFFOLD.md`, `docs/AI_NATIVE_FRAMEWORK_COMPLETE.md`, and `docs/PLAYBOOKS.md`.

Also updates **`p1-policy`** so the `decide` check defers (success + visible PR comment) while `validate` is not yet visible or still running—avoiding a race with `validate-spec` on the same push—and resolves the PR for `workflow_run` when GitHub omits `pull_requests`.

## P1 agent self-verification (pre-open)

| Gate | Result |
|------|--------|
| `npm run validate` | **Passed** |

## Risk

- **Docs / templates / playbook wiring:** low surface area; no runtime or schema changes in this batch beyond prose and scaffolding.
- **CI / policy (`p1-policy.yml`):** control-plane / automation behavior change (how and when `decide` evaluates relative to `validate`). Intended as a **low-risk correctness fix** (defer + clearer bot comment keyed to current head SHA), but it still touches the policy workflow and should be reviewed with that lens.
