### PR TITLE
memory: note decide polls reviewer commit statuses

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -38,6 +38,7 @@ This file stores durable repository memory for agents. It is not a transcript an
 - 2026-04-11: Standardized CodeRabbit handling so automatic review is the default path and manual `@coderabbitai review` comments are only for stalled-review recovery.
 - 2026-04-11: Refined CodeRabbit recovery policy: auto-trigger only if no reviewer signal appears after about 15 seconds; once review has clearly started, poll up to 5 minutes and then ask the user before posting `@coderabbitai review`.
 - 2026-04-11: CodeRabbit `request_changes_workflow` enabled; P1/AGENTS require visible per-finding closure (fix or stated decision) before merge—green status alone is not enough.
+- 2026-04-11: `p1-policy` `decide` polls required reviewer commit statuses (shared wait budget across contexts; `P1_POLICY_REVIEWER_STATUS_*` vars) so the check stays in progress while CodeRabbit is pending instead of failing immediately.
 
 ## Update Rules
 


### PR DESCRIPTION
## Change

Record in `MEMORY.md` that `p1-policy` `decide` polls required reviewer statuses with a shared wait budget (`P1_POLICY_REVIEWER_STATUS_*`).

## Validation

- `npm run validate` — OK

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced policy decision logic to better handle pending code review statuses. Checks now remain active in progress while awaiting required reviewer status updates, rather than failing immediately. This provides more reliable behavior during code reviews and prevents unnecessary check failures when reviews are still being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->