### PR TITLE
[codex] Add governed orchestration brand assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![AI-Native Framework banner](assets/brand/governed-orchestration-banner.svg)
-
 # AI-Native Framework
+
+![AI-Native Framework banner](assets/brand/governed-orchestration-banner.svg)
 
 This repository is an AI-native operating system for building and running product-led companies. It is spec-driven, event-observable, human-governed, and provider-agnostic at the core.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![AI-Native Framework banner](assets/brand/governed-orchestration-banner.svg)
+
 # AI-Native Framework
 
 This repository is an AI-native operating system for building and running product-led companies. It is spec-driven, event-observable, human-governed, and provider-agnostic at the core.

--- a/assets/brand/governed-orchestration-banner.svg
+++ b/assets/brand/governed-orchestration-banner.svg
@@ -1,0 +1,21 @@
+<svg width="760" height="180" viewBox="0 0 760 180" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">AI-Native Framework Governed Orchestration banner</title>
+  <desc id="desc">Horizontal lockup from the Governed Orchestration concept in Figma Make.</desc>
+  <rect width="760" height="180" fill="#F9FAFB"/>
+  <g transform="translate(40 30)">
+    <path d="M30 15 L15 15 L15 105 L30 105" stroke="#000" stroke-width="3.5" fill="none" stroke-linecap="square" />
+    <path d="M90 15 L105 15 L105 105 L90 105" stroke="#000" stroke-width="3.5" fill="none" stroke-linecap="square" />
+    <rect x="35" y="35" width="50" height="50" stroke="#000" stroke-width="2.5" fill="none" />
+    <line x1="60" y1="60" x2="48" y2="48" stroke="#000" stroke-width="1.5" opacity="0.4" />
+    <line x1="60" y1="60" x2="72" y2="48" stroke="#000" stroke-width="1.5" opacity="0.4" />
+    <line x1="60" y1="60" x2="48" y2="72" stroke="#000" stroke-width="1.5" opacity="0.4" />
+    <line x1="60" y1="60" x2="72" y2="72" stroke="#000" stroke-width="1.5" opacity="0.4" />
+    <line x1="48" y1="48" x2="72" y2="48" stroke="#000" stroke-width="1.5" opacity="0.4" />
+    <circle cx="60" cy="60" r="5" fill="#000" />
+    <circle cx="48" cy="48" r="5" fill="#000" />
+    <circle cx="72" cy="48" r="5" fill="#000" />
+    <circle cx="48" cy="72" r="5" fill="#000" />
+    <circle cx="72" cy="72" r="5" fill="#000" />
+  </g>
+  <text x="190" y="98" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="38" font-weight="700" letter-spacing="-0.03em">AI-Native Framework</text>
+</svg>

--- a/assets/brand/governed-orchestration-logo.svg
+++ b/assets/brand/governed-orchestration-logo.svg
@@ -1,0 +1,17 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">AI-Native Framework Governed Orchestration logo</title>
+  <desc id="desc">Symbol-only logo from the Governed Orchestration concept in Figma Make.</desc>
+  <path d="M30 15 L15 15 L15 105 L30 105" stroke="#000" stroke-width="3.5" fill="none" stroke-linecap="square" />
+  <path d="M90 15 L105 15 L105 105 L90 105" stroke="#000" stroke-width="3.5" fill="none" stroke-linecap="square" />
+  <rect x="35" y="35" width="50" height="50" stroke="#000" stroke-width="2.5" fill="none" />
+  <line x1="60" y1="60" x2="48" y2="48" stroke="#000" stroke-width="1.5" opacity="0.4" />
+  <line x1="60" y1="60" x2="72" y2="48" stroke="#000" stroke-width="1.5" opacity="0.4" />
+  <line x1="60" y1="60" x2="48" y2="72" stroke="#000" stroke-width="1.5" opacity="0.4" />
+  <line x1="60" y1="60" x2="72" y2="72" stroke="#000" stroke-width="1.5" opacity="0.4" />
+  <line x1="48" y1="48" x2="72" y2="48" stroke="#000" stroke-width="1.5" opacity="0.4" />
+  <circle cx="60" cy="60" r="5" fill="#000" />
+  <circle cx="48" cy="48" r="5" fill="#000" />
+  <circle cx="72" cy="48" r="5" fill="#000" />
+  <circle cx="48" cy="72" r="5" fill="#000" />
+  <circle cx="72" cy="72" r="5" fill="#000" />
+</svg>


### PR DESCRIPTION
## Summary
- add the selected Governed Orchestration logo and banner SVG assets
- point the README header banner at the selected banner asset
- discard the prior exploratory logo directions from the working tree

## Why
This publishes the selected brand direction from the Figma Make exploration as the repo's current README/header identity.

## Validation
- not run (`npm run validate` is not required for asset-only and README-only changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Markdown banner image immediately below the top-level project heading.
  * Minor README layout update: two lines inserted to include the new banner.
  * No changes to public APIs or exported declarations; low review effort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->