### PR TITLE
docs(framework): load skill before implementation; clarify stale-check rerun

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ If you change schema, examples, policy, templates, or playbooks, run `npm run va
 - Prefer updating the framework and playbooks together when a process change affects repository behavior.
 - Keep repository-local agent instructions concise. Link outward instead of duplicating long prose.
 - Preserve the distinction between stable memory and temporary working notes.
+- Before starting any non-trivial implementation task, match the task to the closest skill in `SKILLS.md` and load the corresponding `skills/*.md` file. Do not begin editing files until the skill's workflow, decision rules, and completion criteria are loaded.
 - After completing any non-trivial workflow, ask whether the work introduced durable learnings that should update `MEMORY.md`, `SKILLS.md`, a specific `skills/*.md`, `AGENTS.md`, or a playbook before considering the task fully closed.
 - Treat repository settings changes as separate control-plane work. Do not use settings changes as the default fix path for an ordinary task or PR blocker.
 - Do not merge a pull request in this repository until every configured merge gate on the current head SHA is complete and green. This rule still applies if GitHub branch protection is missing or misconfigured.

--- a/skills/developer.md
+++ b/skills/developer.md
@@ -36,7 +36,7 @@ Implement the selected change in the repository and carry it through validation,
 3. Run the required validation for the changed artifact class.
 4. Publish through a PR and follow P1 until the current head SHA is converged.
 5. Reply directly on each CodeRabbit thread with the resolution details when a finding is fixed, deferred, or intentionally unchanged.
-6. If host-side required checks are stale or cancelled but the current head otherwise satisfies policy, rerun the required job on the current head before diagnosing deeper causes.
+6. If a required check is stale or cancelled on the current head, rerun that job immediately before diagnosing anything else. A cancelled check on the current head SHA almost always clears with a rerun in under a minute — do not reach for workarounds first.
 7. Before treating the work as fully closed, ask whether the completed workflow revealed durable learnings that should update the framework bundle or a playbook.
 8. Merge only when every configured merge gate for the current head is complete and green.
 


### PR DESCRIPTION
## Summary

Captures two durable learnings from PR #33.

- **`AGENTS.md`**: add working rule to load the matching `skills/*.md` before starting any non-trivial implementation task. Previously implied by SKILLS.md read order but not stated as an explicit rule — easy to skip when starting under pressure.
- **`skills/developer.md` step 6**: sharpen the stale/cancelled check rerun guidance. The existing wording was correct but passive; the concrete experience from #33 (a cancelled `decide` blocking its own merge, cleared in <1 min by a rerun) warrants a more direct instruction.

## Test plan

- [ ] Read `AGENTS.md` Working Rules — new rule appears before the post-task learning rule
- [ ] Read `skills/developer.md` step 6 — rerun guidance is now actionable and unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal process documentation and workflows to enhance operational procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->