### PR TITLE
Add Framework Keeper skill and framework review playbook

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,6 @@
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: low-risk
     autoqueue: true
@@ -13,6 +16,10 @@ queue_rules:
       - check-success = CodeRabbit
       - check-success = decide
     merge_conditions:
+      - base = main
+      - label = residual:low
+      - -draft
+      - -label = sync:needed
       - check-success = validate
       - check-success = CodeRabbit
       - check-success = decide

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ Escalate or stop when any of these are true:
 - `ai/playbooks/repository-foundation.md` - governed repository baseline (CI, protection, contributor surfaces)
 - `ai/playbooks/pull-request-execution-loop.md` - pull request automation and merge policy
 - `ai/playbooks/agent-context-bundle.md` - how to install and maintain the `ai/` bundle alongside root `AGENTS.md`
+- `ai/playbooks/framework-review.md` - how to audit the framework itself for consistency, efficiency, and predictability
 - `ai/SKILLS.md` - skill discovery index (role- and task-oriented harnesses)
 - `ai/skills/` - on-demand skill bodies selected from `ai/SKILLS.md`
 - `ai/MEMORY.md` - durable operating memory and open loops

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ The playbooks turn repeated operational work into reusable procedures:
 - [Repository foundation](ai/playbooks/repository-foundation.md) — CI, branch protection, merge policy, security defaults, governance files, and repository settings so the repo is safe before routine feature work.
 - [Pull request execution loop](ai/playbooks/pull-request-execution-loop.md) — classification, review, residual-risk decisions, branch freshness, safe autofix, policy checks, and low-risk merge flow.
 - [Agent context bundle](ai/playbooks/agent-context-bundle.md) — how to install and maintain root `AGENTS.md` and the `ai/` bundle (skills, playbooks, memory).
+- [Framework review](ai/playbooks/framework-review.md) — how to audit the framework itself for contradiction, duplication, unnecessary complexity, and missing decision rules.
 
-Together they cover governed collaboration, automatable PR policy, and portable agent bootstrap. None of them replaces schema or policy; each is written to stand alone, though **materializing a new repo** usually applies repository foundation first so later automation matches reality.
+Together they cover governed collaboration, automatable PR policy, portable agent bootstrap, and framework self-review. None of them replaces schema or policy; each is written to stand alone, though **materializing a new repo** usually applies repository foundation first so later automation matches reality.
 
 See [`ai/PLAYBOOKS.md`](ai/PLAYBOOKS.md) for the full playbook discovery index.
 

--- a/ai/MEMORY.md
+++ b/ai/MEMORY.md
@@ -10,13 +10,14 @@ This file stores durable repository memory for agents. It is not a transcript an
   - `ai/playbooks/repository-foundation.md`
   - `ai/playbooks/pull-request-execution-loop.md`
   - `ai/playbooks/agent-context-bundle.md`
+  - `ai/playbooks/framework-review.md`
 - The canonical validation command is `npm run validate`.
 - The framework is explicitly provider-agnostic at the core layer.
 - For this repository, pull requests should be opened ready for review by default unless the user explicitly asks for a draft PR.
 - For this repository, agents must wait for every configured merge gate on the current head SHA to complete successfully before merging, even if host branch protection is missing or misconfigured.
 - For this repository, CodeRabbit should be allowed to start automatically; manual `@coderabbitai review` comments are only for two cases: no reviewer signal appears after roughly 15 seconds on a new head SHA, or the reviewer is still in progress after 5 minutes and the user explicitly agrees to trigger recovery.
 - Agent runtime layout: root `AGENTS.md` only; `ai/SKILLS.md` and `ai/skills/` for skills; `ai/PLAYBOOKS.md` and `ai/playbooks/` for unitary procedures; `ai/MEMORY.md` for durable memory.
-- The first top-level repository-local skills are `Designer`, `PM`, and `Developer`.
+- The top-level repository-local skills are `Designer`, `PM`, `Developer`, and `Framework Keeper`.
 
 ## Current Bundle State
 
@@ -47,6 +48,7 @@ This file stores durable repository memory for agents. It is not a transcript an
 - 2026-04-11: CodeRabbit finding closure should be recorded in the review thread itself when possible, and stale or cancelled required jobs should be rerun on the current head before considering control-plane changes.
 - 2026-04-11: `p1-policy` `decide` polls required reviewer commit statuses (shared wait budget across contexts; `P1_POLICY_REVIEWER_STATUS_*` vars) so the check stays in progress while CodeRabbit is pending instead of failing immediately.
 - 2026-04-11: `decide` refreshes issue labels after earlier gates and polls for a `residual:*` label (`P1_POLICY_RESIDUAL_LABEL_*` vars) so the residual risk engine can land slightly after `decide` starts without failing red on a stale label read.
+- 2026-04-12: Added `Framework Keeper` as a repository-local skill and `ai/playbooks/framework-review.md` as the canonical procedure for auditing the framework itself for consistency, efficiency, and predictability.
 
 ## Update Rules
 

--- a/ai/MEMORY.md
+++ b/ai/MEMORY.md
@@ -29,7 +29,7 @@ This file stores durable repository memory for agents. It is not a transcript an
 
 ## Active Open Loops
 
-- Encode the three framework playbooks as machine-readable process artifacts under future `spec/processes/`.
+- Encode the current framework playbooks as machine-readable process artifacts under future `spec/processes/`.
 
 ## Recent Decisions
 
@@ -48,7 +48,7 @@ This file stores durable repository memory for agents. It is not a transcript an
 - 2026-04-11: CodeRabbit finding closure should be recorded in the review thread itself when possible, and stale or cancelled required jobs should be rerun on the current head before considering control-plane changes.
 - 2026-04-11: `p1-policy` `decide` polls required reviewer commit statuses (shared wait budget across contexts; `P1_POLICY_REVIEWER_STATUS_*` vars) so the check stays in progress while CodeRabbit is pending instead of failing immediately.
 - 2026-04-11: `decide` refreshes issue labels after earlier gates and polls for a `residual:*` label (`P1_POLICY_RESIDUAL_LABEL_*` vars) so the residual risk engine can land slightly after `decide` starts without failing red on a stale label read.
-- 2026-04-12: Added `Framework Keeper` as a repository-local skill and `ai/playbooks/framework-review.md` as the canonical procedure for auditing the framework itself for consistency, efficiency, and predictability.
+- 2026-04-11: Added `Framework Keeper` as a repository-local skill and `ai/playbooks/framework-review.md` as the canonical procedure for auditing the framework itself for consistency, efficiency, and predictability.
 
 ## Update Rules
 

--- a/ai/PLAYBOOKS.md
+++ b/ai/PLAYBOOKS.md
@@ -55,6 +55,14 @@ That sequence is **practical**, not a ranking of importance: mature repos often 
 - **Load:** [`playbooks/agent-context-bundle.md`](playbooks/agent-context-bundle.md)
 - **Constraints:** keep the bundle subordinate to schema and policy; do not duplicate full playbooks inside the root index files.
 
+### Framework review
+
+- **When to use:** auditing the framework itself for contradiction, duplication, unnecessary complexity, or missing decision rules.
+- **Inputs:** audit scope, authoritative sources in ladder order, recent framework changes, and known friction points.
+- **Outputs:** structured findings, remediation recommendations, and explicit keep-as-is decisions for stable areas.
+- **Load:** [`playbooks/framework-review.md`](playbooks/framework-review.md)
+- **Constraints:** audit the framework, not ordinary feature code; follow the authority ladder and do not weaken higher-order artifacts to satisfy lower-order drift.
+
 ## Adding A New Playbook
 
 Add a new playbook document under `ai/playbooks/` when all of these are true:

--- a/ai/SKILLS.md
+++ b/ai/SKILLS.md
@@ -42,6 +42,13 @@ Discovery should stay broad and cheap. Execution should stay narrow and deep.
 - **Outputs:** implementation, verification evidence, review closure, published PR state
 - **Load:** `skills/developer.md`
 
+### Framework Keeper
+
+- **When to use:** auditing the framework itself for contradiction, duplication, unnecessary complexity, or underspecified decision paths
+- **Inputs:** audit scope, relevant authoritative artifacts, known operator pain points, recent framework changes
+- **Outputs:** structured findings, recommended remediations, and explicit decisions on what should remain unchanged
+- **Load:** `skills/framework-keeper.md`
+
 ### Repository foundation (playbook)
 
 - **When to use:** establishing or auditing repository governance, CI, branch protection, security defaults, and contributor surfaces

--- a/ai/playbooks/framework-review.md
+++ b/ai/playbooks/framework-review.md
@@ -1,0 +1,116 @@
+# Framework review
+
+## Objective
+
+Audit the framework itself for consistency, efficiency, and predictability so the operating system remains coherent, lean, and reproducible for both humans and agents.
+
+This playbook exists for framework review work only. It is not a generic code review procedure.
+
+## When to run
+
+Run it when:
+
+- a change adds or materially alters a playbook, skill, authority rule, routing surface, or framework policy
+- repeated agent confusion suggests the framework is underspecified or contradictory
+- the repository needs a periodic framework health check
+- a human explicitly asks whether the framework has accumulated ambiguity, duplication, or unnecessary complexity
+
+## Outcomes
+
+At the end of this playbook, the repository should have:
+
+- a clear audit boundary
+- findings categorized by contradiction, duplication, unnecessary complexity, ambiguity, or routing gap
+- concrete remediation options tied to the right artifact layer
+- explicit no-change decisions where the current framework is already sufficient
+
+## Inputs
+
+- target scope or changed files
+- authoritative sources in ladder order
+- recent framework decisions or bundle changes
+- known operator or agent pain points
+
+## Procedure
+
+### 1. Define the audit boundary
+
+State exactly what is being audited before reading widely:
+
+- a specific workflow
+- a specific surface such as the `ai/` bundle
+- a cross-cutting framework concern such as merge authority, routing, or bootstrap behavior
+
+If the scope is too broad to evaluate concretely, reduce it to the smallest coherent framework slice.
+
+### 2. Gather governing sources in authority order
+
+Read the relevant sources from highest to lowest authority:
+
+1. `spec/schema/*`
+2. validated artifacts under `spec/examples/*` and future `spec/processes/*`
+3. `spec/policy/*`
+4. `agents/interfaces.yaml`
+5. `ai/playbooks/*.md`
+6. `docs/*`
+7. `AGENTS.md`, `ai/PLAYBOOKS.md`, `ai/SKILLS.md`, `ai/skills/*.md`, `ai/MEMORY.md`
+
+Do not start from lower-order summaries and then rationalize contradictions upward.
+
+### 3. Check consistency
+
+Inspect whether:
+
+- lower-order artifacts contradict higher-order ones
+- the same workflow is described differently in different files
+- important terms are used with inconsistent meaning
+- routing files point to artifacts that no longer match reality
+
+Consistency findings should identify both the source of truth and the drift location.
+
+### 4. Check efficiency
+
+Inspect whether:
+
+- instructions are duplicated across multiple files without adding value
+- agents are forced to read more than necessary to act correctly
+- the framework repeats the same reconciliation work in multiple surfaces
+- a lower-value artifact should instead be replaced with a pointer to a higher-value one
+
+Efficiency findings should focus on reducing operating cost, not on prose preferences.
+
+### 5. Check predictability
+
+Inspect whether:
+
+- triggers are explicit enough that agents will choose the same workflow
+- decision rules are explicit enough that agents will reach the same conclusion
+- escalation points are clear instead of inferred
+- completion criteria are concrete instead of rhetorical
+
+If two competent agents could reasonably produce different behavior from the same inputs, treat that as a predictability gap.
+
+### 6. Report findings and remediation paths
+
+For each finding, record:
+
+- category
+- severity
+- governing source
+- affected artifact
+- why the current state creates risk or drag
+- the smallest coherent remediation
+
+Prefer remediation at the durable operating-system layer: schema, policy, interfaces, or playbooks before memory or ad hoc instructions.
+
+## Constraints
+
+- Audit the framework only; do not let this playbook expand into generic repository review.
+- Follow the authority ladder for every conclusion.
+- Do not weaken a higher-order artifact to accommodate lower-order drift.
+- Treat memory and routing indices as supporting surfaces, not the primary source of policy.
+
+## Notes for future variants
+
+- This playbook should eventually gain a machine-readable process artifact under `spec/processes/`.
+- If the framework later introduces additional governance capabilities, this playbook should stay focused on framework integrity rather than absorbing their full operating logic.

--- a/ai/skills/framework-keeper.md
+++ b/ai/skills/framework-keeper.md
@@ -1,0 +1,68 @@
+# Framework Keeper
+
+## Purpose
+
+Audit the framework itself for consistency, efficiency, and predictability so the operating system stays coherent as it evolves.
+
+## Use When
+
+- a change adds or modifies a playbook, skill, routing surface, or framework rule
+- the framework appears to contain contradiction, duplication, or procedural drag
+- repeated agent confusion suggests an important decision path is still implicit
+- a periodic framework health check is needed
+
+## Do Not Use When
+
+- the task is ordinary feature implementation inside an already-defined workflow
+- the issue is a one-off bug with no framework-level implications
+- higher-authority artifacts already fully determine the correct behavior
+
+## Inputs
+
+- audit scope and target artifacts
+- relevant sources in authority order
+- any known operator pain points, ambiguity, or repeated agent failures
+- recent framework changes that may have introduced drift
+
+## Outputs
+
+- a concise audit summary
+- prioritized findings with rationale
+- recommended remediation paths tied to concrete artifacts
+- explicit no-change conclusions where the framework is already adequate
+
+## Workflow
+
+1. Define the audit boundary before collecting evidence.
+2. Read the governing sources in authority order instead of starting from lower-order summaries.
+3. Check consistency top-down: schema and policy first, then interfaces, playbooks, docs, and the `ai/` bundle.
+4. Check efficiency: duplicated instructions, dead routing, unnecessary reading cost, or avoidable procedural steps.
+5. Check predictability: whether two competent agents would likely make the same decision from the same inputs.
+6. Report findings as concrete framework work items, not as abstract criticism.
+
+## Decision Rules
+
+- Prefer contradiction findings over style opinions.
+- Prefer recurring operator or agent friction over isolated awkwardness.
+- Prefer explicit decision rules over prose that depends on interpretation.
+- Do not invent new policy when the current authority ladder already answers the question.
+
+## Escalate When
+
+- fixing a finding would change governance authority or merge policy
+- the framework lacks a canonical source for a disputed behavior
+- a proposed fix would grant new automation authority without explicit support
+
+## Completion Criteria
+
+- the audit scope is explicit
+- findings are tied to concrete artifacts
+- recommended remediations are actionable
+- unresolved governance questions are called out clearly
+
+## Canonical References
+
+- `AGENTS.md`
+- `README.md`
+- `docs/AI_NATIVE_FRAMEWORK.md`
+- `ai/playbooks/framework-review.md`

--- a/docs/AI_NATIVE_FRAMEWORK.md
+++ b/docs/AI_NATIVE_FRAMEWORK.md
@@ -401,6 +401,16 @@ For deployments targeting **solo founders or minimal teams** in **B2B SaaS**, th
 - **Playbook:** `ai/playbooks/agent-context-bundle.md`
 - **Events (examples):** `agent.context_bundle_installed`, `agent.skill_registered`, `agent.memory_updated`.
 
+#### Framework review
+
+- **Objective:** Audit the framework itself for contradiction, duplication, unnecessary complexity, and missing decision rules.
+- **Inputs:** Audit scope, authoritative sources in ladder order, recent framework changes, and known operator or agent friction.
+- **Outputs:** Structured findings, remediation recommendations, and explicit keep-as-is decisions for stable areas.
+- **Capabilities:** Researcher, Product, Ops.
+- **Checkpoints:** Human review when proposed remediation would change governance authority, merge policy, or automation power.
+- **Playbook:** `ai/playbooks/framework-review.md`
+- **Events (examples):** `framework.review_started`, `framework.contradiction_found`, `framework.remediation_proposed`.
+
 After pull request execution is in place, the library **SHOULD** contain encoded workflows for the following six operating processes.
 
 #### W1 — Opportunity research


### PR DESCRIPTION
## Summary
- add the new Framework Keeper repository-local skill
- add ai/playbooks/framework-review.md as the canonical framework-audit procedure
- update the agent bundle indices, framework docs, and memory so the new role is discoverable

## Validation
- npm run validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Framework Keeper" skill and a "Framework review" playbook to audit framework consistency, efficiency, and predictability.
  * Introduced structured audit procedures: scope definition, authoritative-source checks, consistency/efficiency/predictability reviews, and prioritized remediation recommendations.
  * Added governance-oriented workflow elements and example events to support review lifecycle and reporting.

* **Chores**
  * Enabled queued merges with single parallel check and tightened merge conditions for low-risk queues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->