### PR TITLE
Align README authority ladder with canonical sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The framework is designed for agents to execute structured work under explicit c
 
 Higher items override lower items:
 
-1. [`spec/schema/product-spec.schema.json`](spec/schema/product-spec.schema.json)
+1. [`spec/schema/`](spec/schema/)
 2. Validated artifacts under [`spec/examples/`](spec/examples/) and future `spec/processes/`
-3. [`spec/policy/event-taxonomy.yaml`](spec/policy/event-taxonomy.yaml)
+3. [`spec/policy/`](spec/policy/)
 4. [`agents/interfaces.yaml`](agents/interfaces.yaml)
 5. [`ai/playbooks/`](ai/playbooks/) (procedure bodies)
 6. [`docs/AI_NATIVE_FRAMEWORK.md`](docs/AI_NATIVE_FRAMEWORK.md) and other explanatory `docs/*`


### PR DESCRIPTION
## Summary
- align the README authority ladder with the canonical sources in AGENTS.md and docs/AI_NATIVE_FRAMEWORK.md
- broaden the schema and policy references from single files to the canonical directories
- keep the README future-proof as additional schema and policy artifacts are added

## Validation
- npm run validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Authority Ladder override rules documentation to use directory-level references instead of file-specific references, providing a more flexible and maintainable approach to configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->