### PR TITLE
[codex] Align framework review fixes with policy

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,8 +14,7 @@ reviews:
     - Treat security issues, correctness bugs, and spec/policy contradictions as **must-fix** unless
       the human maintainer explicitly documents a waiver in the PR thread.
     - **Medium** and **low** / style / nit suggestions: the merging agent **SHOULD** fix them when
-      the change is small; otherwise reply on the thread (or in one consolidated PR comment that
-      lists each item) with **fix**, **accept as follow-up** (with brief justification), or **won't change**
+      the change is small; otherwise reply on the thread with **fix**, **accept as follow-up** (with brief justification), or **won't change**
       (with rationale). Silent merges are not acceptable.
     - Prefer concrete patches over commentary when effort is reasonable.
   auto_review:

--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -510,6 +510,14 @@ jobs:
                     labels: ['autofix:pending'],
                   });
                 } else {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: prNumber,
+                    name: 'autofix:pending',
+                  }).catch((error) => {
+                    if (error.status !== 404) throw error;
+                  });
                   await github.rest.issues.addLabels({
                     owner,
                     repo,
@@ -519,6 +527,14 @@ jobs:
                   residual = 'residual:med';
                 }
               } else {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  name: 'autofix:pending',
+                }).catch((error) => {
+                  if (error.status !== 404) throw error;
+                });
                 await github.rest.issues.addLabels({
                   owner,
                   repo,
@@ -594,6 +610,14 @@ jobs:
                       labels: ['autofix:pending'],
                     });
                   } else {
+                    await github.rest.issues.removeLabel({
+                      owner,
+                      repo,
+                      issue_number: prNumber,
+                      name: 'autofix:pending',
+                    }).catch((error) => {
+                      if (error.status !== 404) throw error;
+                    });
                     await github.rest.issues.addLabels({
                       owner,
                       repo,
@@ -603,6 +627,14 @@ jobs:
                     residual = 'residual:med';
                   }
                 } else {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: prNumber,
+                    name: 'autofix:pending',
+                  }).catch((error) => {
+                    if (error.status !== 404) throw error;
+                  });
                   await github.rest.issues.addLabels({
                     owner,
                     repo,

--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -497,16 +497,27 @@ jobs:
               (r) => r.state === 'APPROVED' || r.state === 'COMMENTED',
             );
             const aiReviewerAllowsFallback = !hasChangesRequestedOnHead && hasApprovalLikeOnHead;
+            const autofixApplied = labels.includes('autofix:applied');
 
             if (!residual && risk === 'risk:low' && aiReviewerAllowsFallback) {
               const unresolved = await hasUnresolvedThreads();
               if (unresolved) {
-                await github.rest.issues.addLabels({
-                  owner,
-                  repo,
-                  issue_number: prNumber,
-                  labels: ['autofix:pending'],
-                });
+                if (!autofixApplied) {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: prNumber,
+                    labels: ['autofix:pending'],
+                  });
+                } else {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: prNumber,
+                    labels: ['residual:med'],
+                  });
+                  residual = 'residual:med';
+                }
               } else {
                 await github.rest.issues.addLabels({
                   owner,
@@ -524,7 +535,6 @@ jobs:
               aiOnHead.length === 0;
 
             if (!residual && statusOnlyEvidence && risk) {
-              const autofixApplied = labels.includes('autofix:applied');
               const isControlPlane = labels.includes('control-plane');
 
               if (risk === 'risk:high') {
@@ -576,12 +586,22 @@ jobs:
               } else if (risk === 'risk:low') {
                 const unresolved = await hasUnresolvedThreads();
                 if (unresolved) {
-                  await github.rest.issues.addLabels({
-                    owner,
-                    repo,
-                    issue_number: prNumber,
-                    labels: ['autofix:pending'],
-                  });
+                  if (!autofixApplied) {
+                    await github.rest.issues.addLabels({
+                      owner,
+                      repo,
+                      issue_number: prNumber,
+                      labels: ['autofix:pending'],
+                    });
+                  } else {
+                    await github.rest.issues.addLabels({
+                      owner,
+                      repo,
+                      issue_number: prNumber,
+                      labels: ['residual:med'],
+                    });
+                    residual = 'residual:med';
+                  }
                 } else {
                   await github.rest.issues.addLabels({
                     owner,

--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -490,7 +490,8 @@ jobs:
             // If it is not yet set, either the engine hasn't run or a race condition exists.
             let residual = labels.find((label) => ['residual:low', 'residual:med', 'residual:high'].includes(label));
 
-            // Convergence: if risk:low and a configured AI reviewer approved/commented but residual not yet set, assign it now.
+            // Convergence: if risk:low and a configured AI reviewer approved/commented but residual not yet set,
+            // assign it only after review threads are resolved or outdated.
             // Only applies for APPROVED/COMMENTED — not CHANGES_REQUESTED, which the residual engine must handle.
             const hasApprovalLikeOnHead = freshAiReviews.some(
               (r) => r.state === 'APPROVED' || r.state === 'COMMENTED',
@@ -498,13 +499,23 @@ jobs:
             const aiReviewerAllowsFallback = !hasChangesRequestedOnHead && hasApprovalLikeOnHead;
 
             if (!residual && risk === 'risk:low' && aiReviewerAllowsFallback) {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: prNumber,
-                labels: ['residual:low'],
-              });
-              residual = 'residual:low';
+              const unresolved = await hasUnresolvedThreads();
+              if (unresolved) {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  labels: ['autofix:pending'],
+                });
+              } else {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  labels: ['residual:low'],
+                });
+                residual = 'residual:low';
+              }
             }
 
             const statusOnlyEvidence =
@@ -563,13 +574,23 @@ jobs:
                   }
                 }
               } else if (risk === 'risk:low') {
-                await github.rest.issues.addLabels({
-                  owner,
-                  repo,
-                  issue_number: prNumber,
-                  labels: ['residual:low'],
-                });
-                residual = 'residual:low';
+                const unresolved = await hasUnresolvedThreads();
+                if (unresolved) {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: prNumber,
+                    labels: ['autofix:pending'],
+                  });
+                } else {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: prNumber,
+                    labels: ['residual:low'],
+                  });
+                  residual = 'residual:low';
+                }
               }
             }
 

--- a/.github/workflows/p1-residual-risk-engine.yml
+++ b/.github/workflows/p1-residual-risk-engine.yml
@@ -324,7 +324,7 @@ jobs:
             if (aggregateReviewState === 'APPROVED' || aggregateReviewState === 'COMMENTED') {
               const unresolved = await hasUnresolvedThreads();
 
-              if (unresolved && initialRisk === 'risk:med') {
+              if (unresolved && (initialRisk === 'risk:med' || initialRisk === 'risk:low')) {
                 if (!autofixAlreadyApplied) {
                   await removeLabels([...residualLabels, 'autofix:pending']);
                   await setLabel('autofix:pending');
@@ -336,11 +336,11 @@ jobs:
                     '',
                     'Automation will re-evaluate after the resolution loop completes.',
                   ].join('\n'));
-                  core.info('Unresolved threads on risk:med — autofix:pending set.');
+                  core.info(`Unresolved threads on ${initialRisk} — autofix:pending set.`);
                 } else {
                   await removeLabels(residualLabels);
                   await setLabel('residual:med');
-                  core.info('Unresolved threads on risk:med after autofix — residual:med set.');
+                  core.info(`Unresolved threads on ${initialRisk} after autofix — residual:med set.`);
                 }
                 return;
               }

--- a/ai/playbooks/pull-request-execution-loop.md
+++ b/ai/playbooks/pull-request-execution-loop.md
@@ -161,7 +161,7 @@ Engine rules:
 2. If `risk:med` and the PR has the `control-plane` label: set `residual:med`. The owner-decision path applies for personal repositories; a second human approval applies otherwise.
 3. If `risk:med`, no configured AI reviewer still requests changes on the current head SHA, and the aggregated reviewer state across active configured reviewers is `APPROVED` or `COMMENTED` with all review threads resolved or outdated: set `residual:low`.
 4. If `risk:med` and any configured AI reviewer state is `CHANGES_REQUESTED`: set `autofix:pending` and leave `residual` unset until the resolution loop runs (see step 3.5).
-5. If `risk:low`, no configured AI reviewer still requests changes on the current head SHA, and the aggregated reviewer state across active configured reviewers is `APPROVED` or `COMMENTED`: set `residual:low`.
+5. If `risk:low`, no configured AI reviewer still requests changes on the current head SHA, the aggregated reviewer state across active configured reviewers is `APPROVED` or `COMMENTED`, and all review threads are resolved or outdated: set `residual:low`.
 6. If `risk:low` and any configured AI reviewer state is `CHANGES_REQUESTED`: set `autofix:pending`.
 
 If the PR head changes after residual risk is set, the engine **MUST** clear the existing `residual:*` label and re-evaluate from the new review evidence.

--- a/ai/playbooks/pull-request-execution-loop.md
+++ b/ai/playbooks/pull-request-execution-loop.md
@@ -162,7 +162,9 @@ Engine rules:
 3. If `risk:med`, no configured AI reviewer still requests changes on the current head SHA, and the aggregated reviewer state across active configured reviewers is `APPROVED` or `COMMENTED` with all review threads resolved or outdated: set `residual:low`.
 4. If `risk:med` and any configured AI reviewer state is `CHANGES_REQUESTED`: set `autofix:pending` and leave `residual` unset until the resolution loop runs (see step 3.5).
 5. If `risk:low`, no configured AI reviewer still requests changes on the current head SHA, the aggregated reviewer state across active configured reviewers is `APPROVED` or `COMMENTED`, and all review threads are resolved or outdated: set `residual:low`.
-6. If `risk:low` and any configured AI reviewer state is `CHANGES_REQUESTED`: set `autofix:pending`.
+6. If `risk:low`, no configured AI reviewer still requests changes on the current head SHA, the aggregated reviewer state across active configured reviewers is `APPROVED` or `COMMENTED`, and any review thread remains unresolved and not outdated: set `autofix:pending` and leave `residual` unset until the resolution loop runs.
+7. If `risk:low`, unresolved review threads remain after `autofix:applied` is already present: set `residual:med` and post a decision request instead of re-queuing the one-shot autofix loop.
+8. If `risk:low` and any configured AI reviewer state is `CHANGES_REQUESTED`: set `autofix:pending`.
 
 If the PR head changes after residual risk is set, the engine **MUST** clear the existing `residual:*` label and re-evaluate from the new review evidence.
 

--- a/interfaces/interfaces.yaml
+++ b/interfaces/interfaces.yaml
@@ -25,11 +25,13 @@ interfaces:
   emit_event:
     description: "Emit a structured domain event with envelope fields."
     inputs:
-      name:
+      event_name:
         type: string
       payload:
         type: object
       correlation_id:
+        type: string
+      schema_version:
         type: string
       occurred_at:
         type: string


### PR DESCRIPTION
## Summary
- align `emit_event` with the canonical event-policy envelope by using `event_name` and `schema_version`
- require low-risk PRs to have resolved or outdated review threads before converging to `residual:low`
- remove the consolidated-comment allowance from CodeRabbit instructions so review closure guidance matches merge policy

## Why
A framework review found drift between the event policy, interface contract, PR playbook, CodeRabbit guidance, and the `p1-policy` convergence path. This PR closes the agreed gaps without expanding the validation surface yet.

## Validation
- `npm run validate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event interface now requires schema versioning to improve event compatibility.

* **Chores**
  * Pull request review flow now checks unresolved review threads before assigning residual risk and can trigger pending autofix or escalation when needed.
  * Review guidance updated: AI reviewer must respond on PRs with explicit decisions (fix / accept as follow-up / won't change) instead of silent consolidated comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->