### PR TITLE
Clarify framework doc structure and terminology

### DIFF
--- a/ai/MEMORY.md
+++ b/ai/MEMORY.md
@@ -52,6 +52,7 @@ This file stores durable repository memory for agents. It is not a transcript an
 - 2026-04-11: Added `Framework Keeper` as a repository-local skill and `ai/playbooks/framework-review.md` as the canonical procedure for auditing the framework itself for consistency, efficiency, and predictability.
 - 2026-04-12: Renamed `agents/` to `interfaces/` so provider-agnostic logical tool contracts are named for their actual role and remain distinct from the runtime bootstrap bundle under `ai/`.
 - 2026-04-12: When repository work is requested “via PR” or to “open a PR,” default execution should follow the pull request execution loop playbook rather than treating PR creation as a standalone publication step.
+- 2026-04-12: Tightened `docs/AI_NATIVE_FRAMEWORK.md` to prefer summary-level routing in large framework sections, keep detailed operating logic in canonical playbooks, pair `ai/SKILLS.md` with `ai/PLAYBOOKS.md` as adjacent but distinct surfaces, and use `skill layer` / `workflow library` terminology instead of the older `capability layer` / `process library` wording.
 
 ## Update Rules
 

--- a/docs/AI_NATIVE_FRAMEWORK.md
+++ b/docs/AI_NATIVE_FRAMEWORK.md
@@ -10,7 +10,7 @@
 ### 0.1 Audience
 
 - **Agents:** Primary executors of this framework—configuration, retrieval, and actions **MUST** align with normative sections below and with validated artifacts where present.
-- **Human operators:** Governance, approvals, strategy, and override—**MUST** retain authority defined in §3 and §10.
+- **Human operators:** Governance, approvals, strategy, and override—**MUST** retain authority defined in §3 and §11.
 
 ### 0.2 Authority ladder
 
@@ -80,7 +80,7 @@ An **AI-native operating system** for building and running **product-led compani
 
 ### 3.2 Leverage target (non-normative ratio)
 
-A **~90% automated execution / ~10% human judgment** split is an **aspirational leverage target**, not proof of autonomy. Actual ratios **MUST** be governed by machine-readable **judgment policy** (§10): checkpoints, confidence thresholds, escalation.
+A **~90% automated execution / ~10% human judgment** split is an **aspirational leverage target**, not proof of autonomy. Actual ratios **MUST** be governed by machine-readable **judgment policy** (§11): checkpoints, confidence thresholds, escalation.
 
 ### 3.3 Mandatory human involvement
 
@@ -131,10 +131,10 @@ flowchart LR
 ### 5.1 Layer stack
 
 1. **Provider abstraction** — Model routing, tool adapters, secrets boundaries; vendors **MAY** be swapped without rewriting orchestration semantics.  
-2. **Agent capability layer** — Units with goals, tool allowlists, context policy, constraints, escalation. **Capabilities, not mascots:** no vendor names in business rules.  
+2. **Agent skill layer** — Units with goals, tool allowlists, context policy, constraints, escalation. **Skills, not mascots:** no vendor names in business rules.  
 3. **Orchestration layer** — Decomposition, assignment, handoffs, dependencies, durable workflow state. **Not** equivalent to a single free-form model thread.  
-4. **Process library** — Versioned workflows (§11); primary encoded operating knowledge.  
-5. **Human judgment layer** — Approvals, thresholds, audit, rollback (§10).  
+4. **Workflow library** — Versioned workflows (§7); primary encoded operating knowledge.  
+5. **Human judgment layer** — Approvals, thresholds, audit, rollback (§11).  
 6. **Feedback & learning** — Signal ingestion; proposed spec/process updates; **MUST NOT** silently overwrite human-approved truth without policy.
 
 ### 5.2 Reference diagram
@@ -149,10 +149,10 @@ flowchart TB
     DEC[decompose assign]
     HO[handoffs deps]
   end
-  subgraph caps [Agent_capabilities]
+  subgraph caps [Agent_skills]
     EX[execute analyze]
   end
-  subgraph lib [Process_library]
+  subgraph lib [Workflow_library]
     WF[workflows]
   end
   subgraph prov [Provider_abstraction]
@@ -174,81 +174,75 @@ flowchart TB
 
 ---
 
-## 6. Tooling reference (default stack)
+## 6. Skills in the AI layer
 
-Bindings below are **recommended defaults** for greenfield implementations; the framework **MUST** remain valid if individual components are substituted behind the abstraction layer.
+### 6.1 Executors
 
-| Concern | Default choice | Role |
-|---------|----------------|------|
-| **Source control / PR governance** | GitHub + branch protection + configurable AI code review (or equivalent) | Reviews, approvals, merge policy, audit trail |
-| **Frontend** | Next.js + Tailwind + shadcn/ui | Product UI, marketing surfaces |
-| **Application API** | Next.js route handlers or Node / FastAPI | Business logic, auth integration |
-| **Data** | PostgreSQL; Supabase for auth/storage/APIs | System of record |
-| **AI execution** | Multiple LLM APIs + coding agents as tools | Generation, analysis, implementation |
-| **Orchestration (maturity 3+)** | LangGraph or equivalent | Stateful workflows behind §5.1 layer 3 |
-| **Product analytics** | PostHog (or equivalent) | Funnels, experiments, feature usage |
-| **Errors** | Sentry (or equivalent) | Exceptions, regressions |
-| **Hosting** | Vercel + managed DB / Supabase | Deploy and scale |
-| **Validation CI** | Node + AJV + YAML parser | Schema validation on `spec/examples/*` |
+Task runners—LLM-backed or deterministic—**MUST** operate inside skill constraints.
 
-### 6.1 Repository tooling (reference layout)
+### 6.2 Skill types (non-exhaustive catalog)
 
-Typical layout for a framework-aligned repo:
+Strategist, Researcher, Product, Builder (engineering), Designer, Growth, Sales ops, Support, Finance/Ops. Each skill **MUST** eventually declare in machine form: tools, data access, escalation paths, forbidden actions.
 
-| Path | Function |
-|------|----------|
-| `spec/schema/` | JSON Schema definitions |
-| `spec/examples/` | Validated product/slice instances |
-| `spec/policy/` | Event taxonomy and related policy YAML |
-| `spec/processes/` | *(Introduce)* validated process/workflow instances |
-| `templates/` | Generators and empty templates (e.g. slice spec) |
-| `interfaces/interfaces.yaml` | Logical tool contracts |
-| `AGENTS.md` | Repository-local bootstrap instructions at repo root; authority map and execution rules for agents |
-| `ai/SKILLS.md` | Skill discovery index under `ai/`; maps recurring work to skills, playbooks, and artifacts |
-| `ai/skills/` | On-demand skill bodies loaded only when selected from `ai/SKILLS.md` |
-| `ai/MEMORY.md` | Durable working memory: current state, constraints, glossary, decisions, open loops |
-| `scripts/validate-spec.mjs` | Local and CI validation |
-| `.github/workflows/` | CI pipelines |
-| `ai/PLAYBOOKS.md` | Playbook discovery index under `ai/`; links into `ai/playbooks/` |
-| `ai/playbooks/` | On-demand procedure playbooks loaded from `ai/PLAYBOOKS.md` |
-
----
-
-## 7. Roles in the AI layer
-
-### 7.1 Executors
-
-Task runners—LLM-backed or deterministic—**MUST** operate inside capability constraints.
-
-### 7.2 Capability types (non-exhaustive catalog)
-
-Strategist, Researcher, Product, Builder (engineering), Designer, Growth, Sales ops, Support, Finance/Ops. Each capability **MUST** eventually declare in machine form: tools, data access, escalation paths, forbidden actions.
-
-### 7.2.1 Repository-local context bundle
+### 6.2.1 Repository-local context bundle
 
 Framework-aligned repositories **SHOULD** expose a lightweight agent context surface: **root `AGENTS.md`** as the common first-read entry point, plus an **`ai/` directory** for everything else agents load progressively:
 
 - `AGENTS.md` — bootstrap contract for agents entering the repository (typically the only agent file at repo root).
-- `ai/PLAYBOOKS.md` — low-cost playbook discovery index; points to unitary procedures under `ai/playbooks/`.
-- `ai/playbooks/` — on-demand procedure playbooks for recurring governance and automation loops.
 - `ai/SKILLS.md` — low-cost skill discovery index and routing surface for role- and task-oriented harnesses.
 - `ai/skills/` — on-demand skill bodies for workflows that need more than index-level guidance.
+- `ai/PLAYBOOKS.md` — low-cost playbook discovery index; points to unitary procedures under `ai/playbooks/`.
+- `ai/playbooks/` — on-demand procedure playbooks for recurring governance and automation loops.
 - `ai/MEMORY.md` — durable repository memory with update rules.
 
-This surface is the provider-agnostic replacement for hidden system prompts or IDE-only conventions. It gives agents a shared, versioned operating map while keeping the normative source of truth in schemas, policy, interfaces, and playbook files under `ai/playbooks/`.
+This surface is the provider-agnostic replacement for hidden system prompts or IDE-only conventions. It gives agents a shared, versioned operating map while keeping the distinction clear: skills route and shape agent execution, while playbooks hold the canonical procedures for recurring workflows. The normative source of truth remains in schemas, policy, interfaces, and playbook files under `ai/playbooks/`.
 
 Minimum requirements:
 
 - `AGENTS.md` **MUST** define the repo authority ladder, canonical commands, change discipline, and escalation conditions (including where `ai/` lives).
-- `ai/PLAYBOOKS.md` **SHOULD** list each versioned procedure playbook with triggers, inputs, outputs, and a link into `ai/playbooks/*.md`.
 - `ai/SKILLS.md` **SHOULD** map recurring workflows to named skills or procedures, each with triggers, inputs, outputs, and links to deeper docs, `ai/playbooks/*.md`, or `ai/skills/*.md`.
 - `ai/skills/` **SHOULD** hold the deeper skill bodies so agents load only the skill they selected instead of the whole catalog.
+- `ai/PLAYBOOKS.md` **SHOULD** list each versioned procedure playbook with triggers, inputs, outputs, and a link into `ai/playbooks/*.md`.
 - `ai/MEMORY.md` **MUST** distinguish stable facts from temporary working state and **MUST NOT** become an unbounded log dump.
 - Changes to these files **SHOULD** be reviewed whenever repo policy, architecture, workflows, or terminology changes.
 
-### 7.3 Orchestrator
+### 6.3 Orchestrator
 
 The **orchestrator** is **infrastructure** (workflow engine, graph runtime, queue worker graph, etc.), **not** a chat persona. It **MUST** implement: decomposition, state, retries, handoffs per `interfaces/interfaces.yaml` and future orchestration schemas.
+
+---
+
+## 7. Workflow library
+
+### 7.1 Normative role
+
+The Workflow Library is the **encoded moat**: reusable, versioned procedures—treated with the same rigor as code (review, test, changelog).
+
+### 7.2 Categories
+
+| Category | Typical contents |
+|----------|------------------|
+| **Discovery** | Market research, opportunity mapping, ICP, positioning |
+| **Product** | MVP scoping, PRD-style outputs, prioritization, QA flows |
+| **Build** | Implementation loops, testing, release |
+| **Go-to-market** | Launch, landing pages, content, outbound |
+| **Operations** | Onboarding, support, reporting, pricing experiments, internal ops |
+
+The repository-local `ai/PLAYBOOKS.md` and `ai/playbooks/` files are the procedure side of this library; `ai/SKILLS.md` and `ai/skills/` are the adjacent routing side for agents. Both surfaces are operator-facing indices into the same operating system, but they serve different roles: playbooks hold canonical procedures, while skills help agents choose and execute the right workflow. Workflow definitions may remain in Markdown initially, but each index **SHOULD** point to the canonical playbook file or schema-backed process artifact for each recurring workflow.
+
+The canonical workflow inventory for a repository-local agent bundle **SHOULD** live in `ai/PLAYBOOKS.md`. This framework document defines what a workflow library is and how it fits the operating system; it should not duplicate the repository's playbook catalog.
+
+### 7.3 Workflow record shape (each entry SHOULD declare)
+
+- **Inputs** and **outputs** (artifact types).  
+- **Steps** and **dependencies**.  
+- **Skills** invoked per step.  
+- **Tools** and data sources.  
+- **Events** emitted.  
+- **Metrics** affected.  
+- **Human checkpoints** and threshold references.
+
+*Process and workflow schemas **MAY** be introduced after product-spec schemas, but once they exist they **MUST** follow the same validation discipline.*
 
 ---
 
@@ -304,7 +298,47 @@ Slice instances **MUST** include `slice_id` and `parent_product_id` per schema.
 
 ---
 
-## 10. Human judgment layer
+## 10. Tooling reference (default stack)
+
+Bindings below are **recommended defaults** for greenfield implementations; the framework **MUST** remain valid if individual components are substituted behind the abstraction layer.
+
+| Concern | Default choice | Role |
+|---------|----------------|------|
+| **Source control / PR governance** | GitHub + branch protection + configurable AI code review (or equivalent) | Reviews, approvals, merge policy, audit trail |
+| **Frontend** | Next.js + Tailwind + shadcn/ui | Product UI, marketing surfaces |
+| **Application API** | Next.js route handlers or Node / FastAPI | Business logic, auth integration |
+| **Data** | PostgreSQL; Supabase for auth/storage/APIs | System of record |
+| **AI execution** | Multiple LLM APIs + coding agents as tools | Generation, analysis, implementation |
+| **Orchestration (maturity 3+)** | LangGraph or equivalent | Stateful workflows behind §5.1 layer 3 |
+| **Product analytics** | PostHog (or equivalent) | Funnels, experiments, feature usage |
+| **Errors** | Sentry (or equivalent) | Exceptions, regressions |
+| **Hosting** | Vercel + managed DB / Supabase | Deploy and scale |
+| **Validation CI** | Node + AJV + YAML parser | Schema validation on `spec/examples/*` |
+
+### 10.1 Repository tooling (reference layout)
+
+Typical layout for a framework-aligned repo:
+
+| Path | Function |
+|------|----------|
+| `spec/schema/` | JSON Schema definitions |
+| `spec/examples/` | Validated product/slice instances |
+| `spec/policy/` | Event taxonomy and related policy YAML |
+| `spec/processes/` | *(Introduce)* validated process/workflow instances |
+| `templates/` | Generators and empty templates (e.g. slice spec) |
+| `interfaces/interfaces.yaml` | Logical tool contracts |
+| `AGENTS.md` | Repository-local bootstrap instructions at repo root; authority map and execution rules for agents |
+| `ai/PLAYBOOKS.md` | Playbook discovery index under `ai/`; links into `ai/playbooks/` |
+| `ai/playbooks/` | On-demand procedure playbooks loaded from `ai/PLAYBOOKS.md` |
+| `ai/SKILLS.md` | Skill discovery index under `ai/`; maps recurring work to skills, playbooks, and artifacts |
+| `ai/skills/` | On-demand skill bodies loaded only when selected from `ai/SKILLS.md` |
+| `ai/MEMORY.md` | Durable working memory: current state, constraints, glossary, decisions, open loops |
+| `scripts/validate-spec.mjs` | Local and CI validation |
+| `.github/workflows/` | CI pipelines |
+
+---
+
+## 11. Human judgment layer
 
 Implementations **MUST** provide:
 
@@ -317,170 +351,16 @@ Renaming a step **MUST NOT** bypass a checkpoint.
 
 ---
 
-## 11. Process library
-
-### 11.1 Normative role
-
-The Process Library is the **encoded moat**: reusable, versioned procedures—treated with the same rigor as code (review, test, changelog).
-
-### 11.2 Categories
-
-| Category | Typical contents |
-|----------|------------------|
-| **Discovery** | Market research, opportunity mapping, ICP, positioning |
-| **Product** | MVP scoping, PRD-style outputs, prioritization, QA flows |
-| **Build** | Implementation loops, testing, release |
-| **Go-to-market** | Launch, landing pages, content, outbound |
-| **Operations** | Onboarding, support, reporting, pricing experiments, internal ops |
-
-The repository-local `ai/PLAYBOOKS.md` and `ai/SKILLS.md` files are operator-facing indices into this library. Deeper procedure bodies may live under `ai/playbooks/` and `ai/skills/`, and process definitions may remain in Markdown initially, but each index **SHOULD** point to the canonical playbook file or schema-backed process artifact for each recurring workflow.
-
-### 11.3 Workflow record shape (each entry SHOULD declare)
-
-- **Inputs** and **outputs** (artifact types).  
-- **Steps** and **dependencies**.  
-- **Capabilities** invoked per step.  
-- **Tools** and data sources.  
-- **Events** emitted.  
-- **Metrics** affected.  
-- **Human checkpoints** and threshold references.
-
-### 11.4 V1 default workflow set (B2B SaaS, small team)
-
-For deployments targeting **solo founders or minimal teams** in **B2B SaaS**, the library **SHOULD** contain encoded workflows for the following baseline set (often adopted in dependency order when materializing a new repository; each entry is still an atomic playbook).
-
-#### Repository foundation
-
-- **Objective:** Make the repository safe for parallel human and agent execution before normal product work starts.
-- **Inputs:** Repository owner, default branch, maintainer handle, and at least one validation command.
-- **Outputs:** Protected default branch, CI baseline, merge policy, security defaults, and governance files.
-- **Capabilities:** Builder, Product, Ops.
-- **Checkpoints:** Human confirmation of repository owner, visibility, and merge policy before protection is enforced.
-- **Playbook:** `ai/playbooks/repository-foundation.md`
-- **Events (examples):** `ops.repo_published`, `ops.branch_protection_enabled`, `ops.security_automation_enabled`.
-
-#### Pull request execution loop
-
-- **Objective:** Automate PR review, testing, approval, and merge within explicit human-governed thresholds.
-- **Inputs:** PR metadata, diff, branch protection rules, required checks, threshold policy, branch freshness state, and residual-risk decision.
-- **Outputs:**
-  - Initial risk classification.
-  - Residual-risk decision.
-  - Branch freshness decision.
-  - Validation evidence.
-  - Review outcome.
-  - Approval decision.
-  - Merge or escalation state.
-  - When automation is authorized for the residual-risk tier and all merge gates are green, the executing agent **MUST** finish the loop—merge directly or verify the configured merge executor (for example a queue) merged—rather than stopping at an open PR.
-- **Capabilities:** Builder, Ops, Researcher, AI reviewer backend.
-- **Checkpoints:**
-  - Human approval **MUST** be required for high-risk changes and **SHOULD** be required whenever confidence or evidence falls below policy thresholds.
-  - Event-ordering failures between automation steps **MUST NOT** by themselves force human review.
-  - Automation-owned PRs **MUST** be synced with the current protected branch before review authority is exercised.
-  - Deterministic PR state such as residual-risk labels **MUST** be set automatically when policy can infer it.
-  - Control-plane PRs **MUST** be judged by the policy currently merged on the protected branch until the update itself lands.
-  - Repository-level auto-review configuration such as GitHub rulesets or app integrations **MAY** request an AI review automatically, but **MUST NOT** itself be treated as approval authority.
-  - When a repository-configured reviewer exists, both its status context and its current-head review output **SHOULD** be consumed before the agent assigns residual risk; acceptable output is either a formal review on that SHA or a configured-reviewer timeline comment that explicitly references it.
-  - Missing or pending reviewer evidence on the current head SHA **MUST** remain a blocking state rather than an implicit pass.
-  - Agents **MUST NOT** merge while any configured merge gate is still pending, even if host branch protection is missing or misconfigured.
-  - If reviewer follow-up is needed, an authorized collaborator **MAY** request it through host-supported mechanisms such as reviewer commands or the repository UI.
-  - If that follow-up causes a bot or app to push a new PR commit, required checks and review freshness **MUST** be re-evaluated on the new head SHA.
-  - Host-platform approval prompts on privileged downstream automation **MUST** be interpreted as trust-boundary safeguards unless the required PR-scoped checks themselves fail.
-  - If a human checkpoint remains, automation **MUST** complete all non-human preparation work first and leave the PR approval-ready wherever the host platform allows it.
-  - In personal-repository single-human mode, the owner **MAY** be the final checkpoint for allowed medium-risk changes, provided policy explicitly says so and the agent states the exact action required from the owner.
-- **Playbook:** `ai/playbooks/pull-request-execution-loop.md`
-- **Events (examples):** `pr.risk_classified`, `pr.residual_risk_set`, `pr.branch_outdated`, `pr.review_completed`, `pr.escalated`, `pr.merged`.
-
-#### Agent context bundle
-
-- **Objective:** Install and maintain the repository-local runtime standard that lets agents bootstrap correctly without relying on hidden prompt state.
-- **Inputs:** Repository purpose, authority ladder, canonical commands, playbooks, glossary, and current operating constraints.
-- **Outputs:** Versioned root `AGENTS.md`, plus `ai/SKILLS.md`, optional `ai/skills/`, `ai/PLAYBOOKS.md`, `ai/playbooks/`, and `ai/MEMORY.md` linked to the framework.
-- **Capabilities:** Builder, Product, Ops.
-- **Checkpoints:** Human review when the bundle changes agent authority, escalation rules, or durable memory policy.
-- **Playbook:** `ai/playbooks/agent-context-bundle.md`
-- **Events (examples):** `agent.context_bundle_installed`, `agent.skill_registered`, `agent.memory_updated`.
-
-#### Framework review
-
-- **Objective:** Audit the framework itself for contradiction, duplication, unnecessary complexity, and missing decision rules.
-- **Inputs:** Audit scope, authoritative sources in ladder order, recent framework changes, and known operator or agent friction.
-- **Outputs:** Structured findings, remediation recommendations, and explicit keep-as-is decisions for stable areas.
-- **Capabilities:** Researcher, Product, Ops.
-- **Checkpoints:** Human review when proposed remediation would change governance authority, merge policy, or automation power.
-- **Playbook:** `ai/playbooks/framework-review.md`
-- **Events (examples):** `framework.review_started`, `framework.contradiction_found`, `framework.remediation_proposed`.
-
-After pull request execution is in place, the library **SHOULD** contain encoded workflows for the following six operating processes.
-
-#### W1 — Opportunity research
-
-- **Objective:** Rank plausible opportunities from a defined idea or market space.  
-- **Inputs:** Constraints, budget signals, time horizon, any prior hypotheses.  
-- **Outputs:** Ranked opportunity list, kill/keep rationale, assumptions to validate.  
-- **Capabilities:** Researcher, Strategist.  
-- **Checkpoints:** Human confirmation before committing to a single opportunity thread.  
-- **Events (examples):** `discovery.opportunity_ranked`, `discovery.research_completed`.
-
-#### W2 — ICP and positioning
-
-- **Objective:** Define ideal customer profile and market positioning.  
-- **Inputs:** Chosen opportunity, competitive landscape notes.  
-- **Outputs:** ICP document, positioning statement, anti-ICP.  
-- **Capabilities:** Strategist, Product.  
-- **Checkpoints:** Human approval of positioning before external launch materials.  
-- **Events (examples):** `positioning.icp_defined`, `positioning.statement_finalized`.
-
-#### W3 — MVP scoping
-
-- **Objective:** Minimal lovable scope for first validated learning.  
-- **Inputs:** ICP, positioning, technical constraints.  
-- **Outputs:** MVP spec linked to product/slice schema, success metrics, out-of-scope list.  
-- **Capabilities:** Product, Builder.  
-- **Checkpoints:** Human sign-off on scope and metrics.  
-- **Events (examples):** `product.mvp_scoped`, `product.requirement_added`.
-
-#### W4 — Launch asset creation
-
-- **Objective:** Produce launch-ready assets (site copy, decks, emails, etc., per plan).  
-- **Inputs:** MVP spec, brand constraints.  
-- **Outputs:** Asset bundle, distribution checklist.  
-- **Capabilities:** Designer, Growth, Builder.  
-- **Checkpoints:** Human review of public-facing claims and compliance-sensitive copy.  
-- **Events (examples):** `gtm.asset_published`, `gtm.launch_checklist_completed`.
-
-#### W5 — Growth experimentation
-
-- **Objective:** Run structured experiments on acquisition and activation.  
-- **Inputs:** Baseline metrics, hypotheses, channel constraints.  
-- **Outputs:** Experiment designs, results, recommendations.  
-- **Capabilities:** Growth, Researcher.  
-- **Checkpoints:** Human approval for spend and brand-risk experiments.  
-- **Events (examples):** `growth.experiment_started`, `growth.experiment_completed`.
-
-#### W6 — Customer feedback synthesis
-
-- **Objective:** Consolidate qualitative and quantitative feedback into actionable spec changes.  
-- **Inputs:** Support data, interviews, usage analytics.  
-- **Outputs:** Prioritized insight list, proposed spec deltas, assumption updates.  
-- **Capabilities:** Support (analytics), Product.  
-- **Checkpoints:** Human triage for roadmap commitment.  
-- **Events (examples):** `feedback.synthesis_completed`, `product.roadmap_proposed`.
-
-*Schemas for process instances **MAY** trail the product spec schema; when introduced, they **MUST** follow the same validation discipline.*
-
----
-
 ## 12. Operating loop (runtime procedure)
 
 For each significant initiative:
 
 1. Instantiate or select goal from spec.  
 2. Decompose into tasks with explicit dependencies.  
-3. Bind **Process Library** templates and **capabilities**.  
+3. Bind **Workflow Library** templates and **skills**.  
 4. Execute; emit events and metrics.  
 5. Collect evidence (artifacts, URLs, eval results).  
-6. Run automated checks; route to human judgment per §10.  
+6. Run automated checks; route to human judgment per §11.  
 7. Merge learnings into specs (assumptions ↔ facts).
 
 ---


### PR DESCRIPTION
## Summary
- rename the framework narrative from capability/process terminology to skill/workflow terminology
- reorder the main framework sections so Skills and Workflow library appear before lifecycle, spec, and tooling sections
- reduce the workflow-library chapter to framework-level guidance and pointers instead of duplicating workflow catalogs

## Testing
- not run (docs and ai/MEMORY.md only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI framework documentation with revised terminology for core architecture components and reorganized governance procedures for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->