### PR TITLE
feat(dashboard): add initial product boilerplate and example spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,15 @@ node_modules/
 *.log
 .env
 .env.*
+
+# Next.js (products/dashboard/)
+.next/
+out/
+.vercel
+
+# Local env files — never commit values, only secret names in spec
+.env*.local
+
+# Build output
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ The framework is designed for agents to execute structured work under explicit c
 - Event and governance policy
 - Provider-agnostic agent interface contracts
 - Playbooks for repository governance, pull-request automation, and agent runtime context
-- A repository-local agent surface: root [`AGENTS.md`](AGENTS.md) (first read for most agent tools), plus [`ai/PLAYBOOKS.md`](ai/PLAYBOOKS.md), [`ai/playbooks/`](ai/playbooks/), [`ai/SKILLS.md`](ai/SKILLS.md), [`ai/skills/`](ai/skills/), and [`ai/MEMORY.md`](ai/MEMORY.md)
+- A repository-local agent surface: root `[AGENTS.md](AGENTS.md)` (first read for most agent tools), plus `[ai/PLAYBOOKS.md](ai/PLAYBOOKS.md)`, `[ai/playbooks/](ai/playbooks/)`, `[ai/SKILLS.md](ai/SKILLS.md)`, `[ai/skills/](ai/skills/)`, and `[ai/MEMORY.md](ai/MEMORY.md)`
 
 ## Authority Ladder
 
 Higher items override lower items:
 
-1. [`spec/schema/`](spec/schema/)
-2. Validated artifacts under [`spec/examples/`](spec/examples/) and future `spec/processes/`
-3. [`spec/policy/`](spec/policy/)
-4. [`interfaces/interfaces.yaml`](interfaces/interfaces.yaml)
-5. [`ai/playbooks/`](ai/playbooks/) (procedure bodies)
-6. [`docs/AI_NATIVE_FRAMEWORK.md`](docs/AI_NATIVE_FRAMEWORK.md) and other explanatory `docs/*`
-7. [`AGENTS.md`](AGENTS.md), [`ai/PLAYBOOKS.md`](ai/PLAYBOOKS.md), [`ai/SKILLS.md`](ai/SKILLS.md), [`ai/skills/`](ai/skills/), [`ai/MEMORY.md`](ai/MEMORY.md)
+1. `[spec/schema/](spec/schema/)`
+2. Validated artifacts under `[spec/examples/](spec/examples/)` and future `spec/processes/`
+3. `[spec/policy/](spec/policy/)`
+4. `[interfaces/interfaces.yaml](interfaces/interfaces.yaml)`
+5. `[ai/playbooks/](ai/playbooks/)` (procedure bodies)
+6. `[docs/AI_NATIVE_FRAMEWORK.md](docs/AI_NATIVE_FRAMEWORK.md)` and other explanatory `docs/*`
+7. `[AGENTS.md](AGENTS.md)`, `[ai/PLAYBOOKS.md](ai/PLAYBOOKS.md)`, `[ai/SKILLS.md](ai/SKILLS.md)`, `[ai/skills/](ai/skills/)`, `[ai/MEMORY.md](ai/MEMORY.md)`
 
 Root `AGENTS.md` and the `ai/` bundle are operationally important, but they do not override schema, policy, interface contracts, or playbook procedures.
 
@@ -69,30 +69,32 @@ The playbooks turn repeated operational work into reusable procedures:
 
 Together they cover governed collaboration, automatable PR policy, portable agent bootstrap, and framework self-review. None of them replaces schema or policy; each is written to stand alone, though **materializing a new repo** usually applies repository foundation first so later automation matches reality.
 
-See [`ai/PLAYBOOKS.md`](ai/PLAYBOOKS.md) for the full playbook discovery index.
+See `[ai/PLAYBOOKS.md](ai/PLAYBOOKS.md)` for the full playbook discovery index.
 
 ## Agent entry map
 
-Most agent tools default to **root [`AGENTS.md`](AGENTS.md)**. After that, the layout mirrors skills vs playbooks:
+Most agent tools default to **root `[AGENTS.md](AGENTS.md)`**. After that, the layout mirrors skills vs playbooks:
 
-| Location | Role |
-| --- | --- |
-| [`AGENTS.md`](AGENTS.md) | First read: authority, commands, merge and review rules |
-| [`docs/AI_NATIVE_FRAMEWORK.md`](docs/AI_NATIVE_FRAMEWORK.md) | Full framework narrative (human- and agent-oriented prose) |
-| [`ai/PLAYBOOKS.md`](ai/PLAYBOOKS.md) | Which **unitary procedure** to open under `ai/playbooks/` |
-| [`ai/SKILLS.md`](ai/SKILLS.md) | Which **role/task skill** to open under `ai/skills/` |
-| [`ai/MEMORY.md`](ai/MEMORY.md) | Durable repo facts and open loops |
 
-Procedure bodies: [`ai/playbooks/`](ai/playbooks/). Skill bodies: [`ai/skills/`](ai/skills/). Normative machine rules: `spec/` and `interfaces/`.
+| Location                                                     | Role                                                       |
+| ------------------------------------------------------------ | ---------------------------------------------------------- |
+| `[AGENTS.md](AGENTS.md)`                                     | First read: authority, commands, merge and review rules    |
+| `[docs/AI_NATIVE_FRAMEWORK.md](docs/AI_NATIVE_FRAMEWORK.md)` | Full framework narrative (human- and agent-oriented prose) |
+| `[ai/PLAYBOOKS.md](ai/PLAYBOOKS.md)`                         | Which **unitary procedure** to open under `ai/playbooks/`  |
+| `[ai/SKILLS.md](ai/SKILLS.md)`                               | Which **role/task skill** to open under `ai/skills/`       |
+| `[ai/MEMORY.md](ai/MEMORY.md)`                               | Durable repo facts and open loops                          |
+
+
+Procedure bodies: `[ai/playbooks/](ai/playbooks/)`. Skill bodies: `[ai/skills/](ai/skills/)`. Normative machine rules: `spec/` and `interfaces/`.
 
 ## Agent bundle (`ai/`)
 
-This repository keeps **one agent file at the repo root** and groups the rest under **`ai/`**:
+This repository keeps **one agent file at the repo root** and groups the rest under `**ai/`**:
 
-- [`AGENTS.md`](AGENTS.md) — bootstrap contract, authority map, commands, and escalation rules (root)
-- [`ai/PLAYBOOKS.md`](ai/PLAYBOOKS.md) — playbook discovery index (`ai/playbooks/` bodies)
-- [`ai/SKILLS.md`](ai/SKILLS.md) — skill discovery index (`ai/skills/` bodies)
-- [`ai/MEMORY.md`](ai/MEMORY.md) — durable repository memory, open loops, and recent decisions
+- `[AGENTS.md](AGENTS.md)` — bootstrap contract, authority map, commands, and escalation rules (root)
+- `[ai/PLAYBOOKS.md](ai/PLAYBOOKS.md)` — playbook discovery index (`ai/playbooks/` bodies)
+- `[ai/SKILLS.md](ai/SKILLS.md)` — skill discovery index (`ai/skills/` bodies)
+- `[ai/MEMORY.md](ai/MEMORY.md)` — durable repository memory, open loops, and recent decisions
 
 These files coordinate how agents run. Durable policy still belongs in schema, `ai/playbooks/`, interfaces, and other canonical artifacts. For pull requests the agent that published the change is responsible for **converging to merge** when policy allows (see `ai/playbooks/pull-request-execution-loop.md` section 6 and `AGENTS.md`); humans still own decisions when policy requires escalation.
 
@@ -103,26 +105,28 @@ npm install
 npm run validate
 ```
 
-CI runs the same validation via [`.github/workflows/validate.yml`](.github/workflows/validate.yml).
+CI runs the same validation via `[.github/workflows/validate.yml](.github/workflows/validate.yml)`.
 
 ## Repository Layout
 
-| Path | Role |
-| --- | --- |
-| `spec/schema/` | JSON Schema for product and slice specs |
-| `spec/examples/` | Validated example specifications |
-| `spec/policy/` | Event naming, PII, idempotency, ordering, and deprecation rules |
-| `templates/` | Reusable templates including slice and agent-context bundle templates |
-| `interfaces/` | Provider-agnostic logical interfaces |
-| `scripts/` | Validation tooling |
-| `AGENTS.md` | Agent bootstrap contract (sole agent file at repo root) |
-| `ai/PLAYBOOKS.md` | Playbook discovery index |
-| `ai/playbooks/` | On-demand procedure playbooks |
-| `ai/SKILLS.md` | Skill discovery index |
-| `ai/skills/` | On-demand skill bodies |
-| `ai/MEMORY.md` | Durable operating memory |
-| `docs/AI_NATIVE_FRAMEWORK.md` | Full framework prose |
-| `REPO_SCAFFOLD.md` | Copy-paste scaffold for materializing framework-aligned repos |
+
+| Path                          | Role                                                                  |
+| ----------------------------- | --------------------------------------------------------------------- |
+| `spec/schema/`                | JSON Schema for product and slice specs                               |
+| `spec/examples/`              | Validated example specifications                                      |
+| `spec/policy/`                | Event naming, PII, idempotency, ordering, and deprecation rules       |
+| `templates/`                  | Reusable templates including slice and agent-context bundle templates |
+| `interfaces/`                 | Provider-agnostic logical interfaces                                  |
+| `scripts/`                    | Validation tooling                                                    |
+| `AGENTS.md`                   | Agent bootstrap contract (sole agent file at repo root)               |
+| `ai/PLAYBOOKS.md`             | Playbook discovery index                                              |
+| `ai/playbooks/`               | On-demand procedure playbooks                                         |
+| `ai/SKILLS.md`                | Skill discovery index                                                 |
+| `ai/skills/`                  | On-demand skill bodies                                                |
+| `ai/MEMORY.md`                | Durable operating memory                                              |
+| `docs/AI_NATIVE_FRAMEWORK.md` | Full framework prose                                                  |
+| `REPO_SCAFFOLD.md`            | Copy-paste scaffold for materializing framework-aligned repos         |
+
 
 ## Current Validation Surface
 
@@ -144,12 +148,12 @@ Today that validates example specs against the product schema. As the framework 
 
 ## Recommended Reading Order
 
-**Agents:** start at [`AGENTS.md`](AGENTS.md), then follow its read order (summarized here):
+**Agents:** start at `[AGENTS.md](AGENTS.md)`, then follow its read order (summarized here):
 
-1. [`README.md`](README.md)
-2. [`docs/AI_NATIVE_FRAMEWORK.md`](docs/AI_NATIVE_FRAMEWORK.md)
-3. [`ai/PLAYBOOKS.md`](ai/PLAYBOOKS.md)
-4. The specific files under [`ai/playbooks/`](ai/playbooks/) or `spec/` relevant to the task
-5. [`ai/SKILLS.md`](ai/SKILLS.md)
-6. Only the specific files under [`ai/skills/`](ai/skills/) selected from the index
-7. [`ai/MEMORY.md`](ai/MEMORY.md)
+1. `[README.md](README.md)`
+2. `[docs/AI_NATIVE_FRAMEWORK.md](docs/AI_NATIVE_FRAMEWORK.md)`
+3. `[ai/PLAYBOOKS.md](ai/PLAYBOOKS.md)`
+4. The specific files under `[ai/playbooks/](ai/playbooks/)` or `spec/` relevant to the task
+5. `[ai/SKILLS.md](ai/SKILLS.md)`
+6. Only the specific files under `[ai/skills/](ai/skills/)` selected from the index
+7. `[ai/MEMORY.md](ai/MEMORY.md)`

--- a/REPO_SCAFFOLD.md
+++ b/REPO_SCAFFOLD.md
@@ -1004,3 +1004,4 @@ Paste the following as valid JSON (single file):
 - **Slice specs** require `slice_id` and `parent_product_id` (enforced by `allOf` in schema).
 - Update `golden-product.yaml` when you add required fields to the schema.
 - Keep `spec/policy/event-taxonomy.yaml` aligned with runtime emitters.
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,4 @@ Do not open public issues for vulnerabilities.
 
 Use GitHub's private vulnerability reporting flow for this repository:
 
-https://github.com/andelizondo/ai-native-framework/security/advisories/new
+[https://github.com/andelizondo/ai-native-framework/security/advisories/new](https://github.com/andelizondo/ai-native-framework/security/advisories/new)

--- a/ai/MEMORY.md
+++ b/ai/MEMORY.md
@@ -52,6 +52,7 @@ This file stores durable repository memory for agents. It is not a transcript an
 - 2026-04-11: Added `Framework Keeper` as a repository-local skill and `ai/playbooks/framework-review.md` as the canonical procedure for auditing the framework itself for consistency, efficiency, and predictability.
 - 2026-04-12: Renamed `agents/` to `interfaces/` so provider-agnostic logical tool contracts are named for their actual role and remain distinct from the runtime bootstrap bundle under `ai/`.
 - 2026-04-12: When repository work is requested “via PR” or to “open a PR,” default execution should follow the pull request execution loop playbook rather than treating PR creation as a standalone publication step.
+- 2026-04-12: Tightened `docs/AI_NATIVE_FRAMEWORK.md` to prefer summary-level routing in large framework sections, keep detailed operating logic in canonical playbooks, pair `ai/SKILLS.md` with `ai/PLAYBOOKS.md` as adjacent but distinct surfaces, and use `skill layer` / `workflow library` terminology instead of the older `capability layer` / `process library` wording.
 
 ## Update Rules
 

--- a/docs/AI_NATIVE_FRAMEWORK.md
+++ b/docs/AI_NATIVE_FRAMEWORK.md
@@ -10,7 +10,7 @@
 ### 0.1 Audience
 
 - **Agents:** Primary executors of this framework—configuration, retrieval, and actions **MUST** align with normative sections below and with validated artifacts where present.
-- **Human operators:** Governance, approvals, strategy, and override—**MUST** retain authority defined in §3 and §10.
+- **Human operators:** Governance, approvals, strategy, and override—**MUST** retain authority defined in §3 and §11.
 
 ### 0.2 Authority ladder
 
@@ -80,7 +80,7 @@ An **AI-native operating system** for building and running **product-led compani
 
 ### 3.2 Leverage target (non-normative ratio)
 
-A **~90% automated execution / ~10% human judgment** split is an **aspirational leverage target**, not proof of autonomy. Actual ratios **MUST** be governed by machine-readable **judgment policy** (§10): checkpoints, confidence thresholds, escalation.
+A **~90% automated execution / ~10% human judgment** split is an **aspirational leverage target**, not proof of autonomy. Actual ratios **MUST** be governed by machine-readable **judgment policy** (§11): checkpoints, confidence thresholds, escalation.
 
 ### 3.3 Mandatory human involvement
 
@@ -131,10 +131,10 @@ flowchart LR
 ### 5.1 Layer stack
 
 1. **Provider abstraction** — Model routing, tool adapters, secrets boundaries; vendors **MAY** be swapped without rewriting orchestration semantics.  
-2. **Agent capability layer** — Units with goals, tool allowlists, context policy, constraints, escalation. **Capabilities, not mascots:** no vendor names in business rules.  
+2. **Agent skill layer** — Units with goals, tool allowlists, context policy, constraints, escalation. **Skills, not mascots:** no vendor names in business rules.  
 3. **Orchestration layer** — Decomposition, assignment, handoffs, dependencies, durable workflow state. **Not** equivalent to a single free-form model thread.  
-4. **Process library** — Versioned workflows (§11); primary encoded operating knowledge.  
-5. **Human judgment layer** — Approvals, thresholds, audit, rollback (§10).  
+4. **Workflow library** — Versioned workflows (§7); primary encoded operating knowledge.  
+5. **Human judgment layer** — Approvals, thresholds, audit, rollback (§11).  
 6. **Feedback & learning** — Signal ingestion; proposed spec/process updates; **MUST NOT** silently overwrite human-approved truth without policy.
 
 ### 5.2 Reference diagram
@@ -149,10 +149,10 @@ flowchart TB
     DEC[decompose assign]
     HO[handoffs deps]
   end
-  subgraph caps [Agent_capabilities]
+  subgraph caps [Agent_skills]
     EX[execute analyze]
   end
-  subgraph lib [Process_library]
+  subgraph lib [Workflow_library]
     WF[workflows]
   end
   subgraph prov [Provider_abstraction]
@@ -174,81 +174,75 @@ flowchart TB
 
 ---
 
-## 6. Tooling reference (default stack)
+## 6. Skills in the AI layer
 
-Bindings below are **recommended defaults** for greenfield implementations; the framework **MUST** remain valid if individual components are substituted behind the abstraction layer.
+### 6.1 Executors
 
-| Concern | Default choice | Role |
-|---------|----------------|------|
-| **Source control / PR governance** | GitHub + branch protection + configurable AI code review (or equivalent) | Reviews, approvals, merge policy, audit trail |
-| **Frontend** | Next.js + Tailwind + shadcn/ui | Product UI, marketing surfaces |
-| **Application API** | Next.js route handlers or Node / FastAPI | Business logic, auth integration |
-| **Data** | PostgreSQL; Supabase for auth/storage/APIs | System of record |
-| **AI execution** | Multiple LLM APIs + coding agents as tools | Generation, analysis, implementation |
-| **Orchestration (maturity 3+)** | LangGraph or equivalent | Stateful workflows behind §5.1 layer 3 |
-| **Product analytics** | PostHog (or equivalent) | Funnels, experiments, feature usage |
-| **Errors** | Sentry (or equivalent) | Exceptions, regressions |
-| **Hosting** | Vercel + managed DB / Supabase | Deploy and scale |
-| **Validation CI** | Node + AJV + YAML parser | Schema validation on `spec/examples/*` |
+Task runners—LLM-backed or deterministic—**MUST** operate inside skill constraints.
 
-### 6.1 Repository tooling (reference layout)
+### 6.2 Skill types (non-exhaustive catalog)
 
-Typical layout for a framework-aligned repo:
+Strategist, Researcher, Product, Builder (engineering), Designer, Growth, Sales ops, Support, Finance/Ops. Each skill **MUST** eventually declare in machine form: tools, data access, escalation paths, forbidden actions.
 
-| Path | Function |
-|------|----------|
-| `spec/schema/` | JSON Schema definitions |
-| `spec/examples/` | Validated product/slice instances |
-| `spec/policy/` | Event taxonomy and related policy YAML |
-| `spec/processes/` | *(Introduce)* validated process/workflow instances |
-| `templates/` | Generators and empty templates (e.g. slice spec) |
-| `interfaces/interfaces.yaml` | Logical tool contracts |
-| `AGENTS.md` | Repository-local bootstrap instructions at repo root; authority map and execution rules for agents |
-| `ai/SKILLS.md` | Skill discovery index under `ai/`; maps recurring work to skills, playbooks, and artifacts |
-| `ai/skills/` | On-demand skill bodies loaded only when selected from `ai/SKILLS.md` |
-| `ai/MEMORY.md` | Durable working memory: current state, constraints, glossary, decisions, open loops |
-| `scripts/validate-spec.mjs` | Local and CI validation |
-| `.github/workflows/` | CI pipelines |
-| `ai/PLAYBOOKS.md` | Playbook discovery index under `ai/`; links into `ai/playbooks/` |
-| `ai/playbooks/` | On-demand procedure playbooks loaded from `ai/PLAYBOOKS.md` |
-
----
-
-## 7. Roles in the AI layer
-
-### 7.1 Executors
-
-Task runners—LLM-backed or deterministic—**MUST** operate inside capability constraints.
-
-### 7.2 Capability types (non-exhaustive catalog)
-
-Strategist, Researcher, Product, Builder (engineering), Designer, Growth, Sales ops, Support, Finance/Ops. Each capability **MUST** eventually declare in machine form: tools, data access, escalation paths, forbidden actions.
-
-### 7.2.1 Repository-local context bundle
+### 6.2.1 Repository-local context bundle
 
 Framework-aligned repositories **SHOULD** expose a lightweight agent context surface: **root `AGENTS.md`** as the common first-read entry point, plus an **`ai/` directory** for everything else agents load progressively:
 
 - `AGENTS.md` — bootstrap contract for agents entering the repository (typically the only agent file at repo root).
-- `ai/PLAYBOOKS.md` — low-cost playbook discovery index; points to unitary procedures under `ai/playbooks/`.
-- `ai/playbooks/` — on-demand procedure playbooks for recurring governance and automation loops.
 - `ai/SKILLS.md` — low-cost skill discovery index and routing surface for role- and task-oriented harnesses.
 - `ai/skills/` — on-demand skill bodies for workflows that need more than index-level guidance.
+- `ai/PLAYBOOKS.md` — low-cost playbook discovery index; points to unitary procedures under `ai/playbooks/`.
+- `ai/playbooks/` — on-demand procedure playbooks for recurring governance and automation loops.
 - `ai/MEMORY.md` — durable repository memory with update rules.
 
-This surface is the provider-agnostic replacement for hidden system prompts or IDE-only conventions. It gives agents a shared, versioned operating map while keeping the normative source of truth in schemas, policy, interfaces, and playbook files under `ai/playbooks/`.
+This surface is the provider-agnostic replacement for hidden system prompts or IDE-only conventions. It gives agents a shared, versioned operating map while keeping the distinction clear: skills route and shape agent execution, while playbooks hold the canonical procedures for recurring workflows. The normative source of truth remains in schemas, policy, interfaces, and playbook files under `ai/playbooks/`.
 
 Minimum requirements:
 
 - `AGENTS.md` **MUST** define the repo authority ladder, canonical commands, change discipline, and escalation conditions (including where `ai/` lives).
-- `ai/PLAYBOOKS.md` **SHOULD** list each versioned procedure playbook with triggers, inputs, outputs, and a link into `ai/playbooks/*.md`.
 - `ai/SKILLS.md` **SHOULD** map recurring workflows to named skills or procedures, each with triggers, inputs, outputs, and links to deeper docs, `ai/playbooks/*.md`, or `ai/skills/*.md`.
 - `ai/skills/` **SHOULD** hold the deeper skill bodies so agents load only the skill they selected instead of the whole catalog.
+- `ai/PLAYBOOKS.md` **SHOULD** list each versioned procedure playbook with triggers, inputs, outputs, and a link into `ai/playbooks/*.md`.
 - `ai/MEMORY.md` **MUST** distinguish stable facts from temporary working state and **MUST NOT** become an unbounded log dump.
 - Changes to these files **SHOULD** be reviewed whenever repo policy, architecture, workflows, or terminology changes.
 
-### 7.3 Orchestrator
+### 6.3 Orchestrator
 
 The **orchestrator** is **infrastructure** (workflow engine, graph runtime, queue worker graph, etc.), **not** a chat persona. It **MUST** implement: decomposition, state, retries, handoffs per `interfaces/interfaces.yaml` and future orchestration schemas.
+
+---
+
+## 7. Workflow library
+
+### 7.1 Normative role
+
+The Workflow Library is the **encoded moat**: reusable, versioned procedures—treated with the same rigor as code (review, test, changelog).
+
+### 7.2 Categories
+
+| Category | Typical contents |
+|----------|------------------|
+| **Discovery** | Market research, opportunity mapping, ICP, positioning |
+| **Product** | MVP scoping, PRD-style outputs, prioritization, QA flows |
+| **Build** | Implementation loops, testing, release |
+| **Go-to-market** | Launch, landing pages, content, outbound |
+| **Operations** | Onboarding, support, reporting, pricing experiments, internal ops |
+
+The repository-local `ai/PLAYBOOKS.md` and `ai/playbooks/` files are the procedure side of this library; `ai/SKILLS.md` and `ai/skills/` are the adjacent routing side for agents. Both surfaces are operator-facing indices into the same operating system, but they serve different roles: playbooks hold canonical procedures, while skills help agents choose and execute the right workflow. Workflow definitions may remain in Markdown initially, but each index **SHOULD** point to the canonical playbook file or schema-backed process artifact for each recurring workflow.
+
+The canonical workflow inventory for a repository-local agent bundle **SHOULD** live in `ai/PLAYBOOKS.md`. This framework document defines what a workflow library is and how it fits the operating system; it should not duplicate the repository's playbook catalog.
+
+### 7.3 Workflow record shape (each entry SHOULD declare)
+
+- **Inputs** and **outputs** (artifact types).  
+- **Steps** and **dependencies**.  
+- **Skills** invoked per step.  
+- **Tools** and data sources.  
+- **Events** emitted.  
+- **Metrics** affected.  
+- **Human checkpoints** and threshold references.
+
+*Process and workflow schemas **MAY** be introduced after product-spec schemas, but once they exist they **MUST** follow the same validation discipline.*
 
 ---
 
@@ -304,7 +298,47 @@ Slice instances **MUST** include `slice_id` and `parent_product_id` per schema.
 
 ---
 
-## 10. Human judgment layer
+## 10. Tooling reference (default stack)
+
+Bindings below are **recommended defaults** for greenfield implementations; the framework **MUST** remain valid if individual components are substituted behind the abstraction layer.
+
+| Concern | Default choice | Role |
+|---------|----------------|------|
+| **Source control / PR governance** | GitHub + branch protection + configurable AI code review (or equivalent) | Reviews, approvals, merge policy, audit trail |
+| **Frontend** | Next.js + Tailwind + shadcn/ui | Product UI, marketing surfaces |
+| **Application API** | Next.js route handlers or Node / FastAPI | Business logic, auth integration |
+| **Data** | PostgreSQL; Supabase for auth/storage/APIs | System of record |
+| **AI execution** | Multiple LLM APIs + coding agents as tools | Generation, analysis, implementation |
+| **Orchestration (maturity 3+)** | LangGraph or equivalent | Stateful workflows behind §5.1 layer 3 |
+| **Product analytics** | PostHog (or equivalent) | Funnels, experiments, feature usage |
+| **Errors** | Sentry (or equivalent) | Exceptions, regressions |
+| **Hosting** | Vercel + managed DB / Supabase | Deploy and scale |
+| **Validation CI** | Node + AJV + YAML parser | Schema validation on `spec/examples/*` |
+
+### 10.1 Repository tooling (reference layout)
+
+Typical layout for a framework-aligned repo:
+
+| Path | Function |
+|------|----------|
+| `spec/schema/` | JSON Schema definitions |
+| `spec/examples/` | Validated product/slice instances |
+| `spec/policy/` | Event taxonomy and related policy YAML |
+| `spec/processes/` | *(Introduce)* validated process/workflow instances |
+| `templates/` | Generators and empty templates (e.g. slice spec) |
+| `interfaces/interfaces.yaml` | Logical tool contracts |
+| `AGENTS.md` | Repository-local bootstrap instructions at repo root; authority map and execution rules for agents |
+| `ai/PLAYBOOKS.md` | Playbook discovery index under `ai/`; links into `ai/playbooks/` |
+| `ai/playbooks/` | On-demand procedure playbooks loaded from `ai/PLAYBOOKS.md` |
+| `ai/SKILLS.md` | Skill discovery index under `ai/`; maps recurring work to skills, playbooks, and artifacts |
+| `ai/skills/` | On-demand skill bodies loaded only when selected from `ai/SKILLS.md` |
+| `ai/MEMORY.md` | Durable working memory: current state, constraints, glossary, decisions, open loops |
+| `scripts/validate-spec.mjs` | Local and CI validation |
+| `.github/workflows/` | CI pipelines |
+
+---
+
+## 11. Human judgment layer
 
 Implementations **MUST** provide:
 
@@ -317,170 +351,16 @@ Renaming a step **MUST NOT** bypass a checkpoint.
 
 ---
 
-## 11. Process library
-
-### 11.1 Normative role
-
-The Process Library is the **encoded moat**: reusable, versioned procedures—treated with the same rigor as code (review, test, changelog).
-
-### 11.2 Categories
-
-| Category | Typical contents |
-|----------|------------------|
-| **Discovery** | Market research, opportunity mapping, ICP, positioning |
-| **Product** | MVP scoping, PRD-style outputs, prioritization, QA flows |
-| **Build** | Implementation loops, testing, release |
-| **Go-to-market** | Launch, landing pages, content, outbound |
-| **Operations** | Onboarding, support, reporting, pricing experiments, internal ops |
-
-The repository-local `ai/PLAYBOOKS.md` and `ai/SKILLS.md` files are operator-facing indices into this library. Deeper procedure bodies may live under `ai/playbooks/` and `ai/skills/`, and process definitions may remain in Markdown initially, but each index **SHOULD** point to the canonical playbook file or schema-backed process artifact for each recurring workflow.
-
-### 11.3 Workflow record shape (each entry SHOULD declare)
-
-- **Inputs** and **outputs** (artifact types).  
-- **Steps** and **dependencies**.  
-- **Capabilities** invoked per step.  
-- **Tools** and data sources.  
-- **Events** emitted.  
-- **Metrics** affected.  
-- **Human checkpoints** and threshold references.
-
-### 11.4 V1 default workflow set (B2B SaaS, small team)
-
-For deployments targeting **solo founders or minimal teams** in **B2B SaaS**, the library **SHOULD** contain encoded workflows for the following baseline set (often adopted in dependency order when materializing a new repository; each entry is still an atomic playbook).
-
-#### Repository foundation
-
-- **Objective:** Make the repository safe for parallel human and agent execution before normal product work starts.
-- **Inputs:** Repository owner, default branch, maintainer handle, and at least one validation command.
-- **Outputs:** Protected default branch, CI baseline, merge policy, security defaults, and governance files.
-- **Capabilities:** Builder, Product, Ops.
-- **Checkpoints:** Human confirmation of repository owner, visibility, and merge policy before protection is enforced.
-- **Playbook:** `ai/playbooks/repository-foundation.md`
-- **Events (examples):** `ops.repo_published`, `ops.branch_protection_enabled`, `ops.security_automation_enabled`.
-
-#### Pull request execution loop
-
-- **Objective:** Automate PR review, testing, approval, and merge within explicit human-governed thresholds.
-- **Inputs:** PR metadata, diff, branch protection rules, required checks, threshold policy, branch freshness state, and residual-risk decision.
-- **Outputs:**
-  - Initial risk classification.
-  - Residual-risk decision.
-  - Branch freshness decision.
-  - Validation evidence.
-  - Review outcome.
-  - Approval decision.
-  - Merge or escalation state.
-  - When automation is authorized for the residual-risk tier and all merge gates are green, the executing agent **MUST** finish the loop—merge directly or verify the configured merge executor (for example a queue) merged—rather than stopping at an open PR.
-- **Capabilities:** Builder, Ops, Researcher, AI reviewer backend.
-- **Checkpoints:**
-  - Human approval **MUST** be required for high-risk changes and **SHOULD** be required whenever confidence or evidence falls below policy thresholds.
-  - Event-ordering failures between automation steps **MUST NOT** by themselves force human review.
-  - Automation-owned PRs **MUST** be synced with the current protected branch before review authority is exercised.
-  - Deterministic PR state such as residual-risk labels **MUST** be set automatically when policy can infer it.
-  - Control-plane PRs **MUST** be judged by the policy currently merged on the protected branch until the update itself lands.
-  - Repository-level auto-review configuration such as GitHub rulesets or app integrations **MAY** request an AI review automatically, but **MUST NOT** itself be treated as approval authority.
-  - When a repository-configured reviewer exists, both its status context and its current-head review output **SHOULD** be consumed before the agent assigns residual risk; acceptable output is either a formal review on that SHA or a configured-reviewer timeline comment that explicitly references it.
-  - Missing or pending reviewer evidence on the current head SHA **MUST** remain a blocking state rather than an implicit pass.
-  - Agents **MUST NOT** merge while any configured merge gate is still pending, even if host branch protection is missing or misconfigured.
-  - If reviewer follow-up is needed, an authorized collaborator **MAY** request it through host-supported mechanisms such as reviewer commands or the repository UI.
-  - If that follow-up causes a bot or app to push a new PR commit, required checks and review freshness **MUST** be re-evaluated on the new head SHA.
-  - Host-platform approval prompts on privileged downstream automation **MUST** be interpreted as trust-boundary safeguards unless the required PR-scoped checks themselves fail.
-  - If a human checkpoint remains, automation **MUST** complete all non-human preparation work first and leave the PR approval-ready wherever the host platform allows it.
-  - In personal-repository single-human mode, the owner **MAY** be the final checkpoint for allowed medium-risk changes, provided policy explicitly says so and the agent states the exact action required from the owner.
-- **Playbook:** `ai/playbooks/pull-request-execution-loop.md`
-- **Events (examples):** `pr.risk_classified`, `pr.residual_risk_set`, `pr.branch_outdated`, `pr.review_completed`, `pr.escalated`, `pr.merged`.
-
-#### Agent context bundle
-
-- **Objective:** Install and maintain the repository-local runtime standard that lets agents bootstrap correctly without relying on hidden prompt state.
-- **Inputs:** Repository purpose, authority ladder, canonical commands, playbooks, glossary, and current operating constraints.
-- **Outputs:** Versioned root `AGENTS.md`, plus `ai/SKILLS.md`, optional `ai/skills/`, `ai/PLAYBOOKS.md`, `ai/playbooks/`, and `ai/MEMORY.md` linked to the framework.
-- **Capabilities:** Builder, Product, Ops.
-- **Checkpoints:** Human review when the bundle changes agent authority, escalation rules, or durable memory policy.
-- **Playbook:** `ai/playbooks/agent-context-bundle.md`
-- **Events (examples):** `agent.context_bundle_installed`, `agent.skill_registered`, `agent.memory_updated`.
-
-#### Framework review
-
-- **Objective:** Audit the framework itself for contradiction, duplication, unnecessary complexity, and missing decision rules.
-- **Inputs:** Audit scope, authoritative sources in ladder order, recent framework changes, and known operator or agent friction.
-- **Outputs:** Structured findings, remediation recommendations, and explicit keep-as-is decisions for stable areas.
-- **Capabilities:** Researcher, Product, Ops.
-- **Checkpoints:** Human review when proposed remediation would change governance authority, merge policy, or automation power.
-- **Playbook:** `ai/playbooks/framework-review.md`
-- **Events (examples):** `framework.review_started`, `framework.contradiction_found`, `framework.remediation_proposed`.
-
-After pull request execution is in place, the library **SHOULD** contain encoded workflows for the following six operating processes.
-
-#### W1 — Opportunity research
-
-- **Objective:** Rank plausible opportunities from a defined idea or market space.  
-- **Inputs:** Constraints, budget signals, time horizon, any prior hypotheses.  
-- **Outputs:** Ranked opportunity list, kill/keep rationale, assumptions to validate.  
-- **Capabilities:** Researcher, Strategist.  
-- **Checkpoints:** Human confirmation before committing to a single opportunity thread.  
-- **Events (examples):** `discovery.opportunity_ranked`, `discovery.research_completed`.
-
-#### W2 — ICP and positioning
-
-- **Objective:** Define ideal customer profile and market positioning.  
-- **Inputs:** Chosen opportunity, competitive landscape notes.  
-- **Outputs:** ICP document, positioning statement, anti-ICP.  
-- **Capabilities:** Strategist, Product.  
-- **Checkpoints:** Human approval of positioning before external launch materials.  
-- **Events (examples):** `positioning.icp_defined`, `positioning.statement_finalized`.
-
-#### W3 — MVP scoping
-
-- **Objective:** Minimal lovable scope for first validated learning.  
-- **Inputs:** ICP, positioning, technical constraints.  
-- **Outputs:** MVP spec linked to product/slice schema, success metrics, out-of-scope list.  
-- **Capabilities:** Product, Builder.  
-- **Checkpoints:** Human sign-off on scope and metrics.  
-- **Events (examples):** `product.mvp_scoped`, `product.requirement_added`.
-
-#### W4 — Launch asset creation
-
-- **Objective:** Produce launch-ready assets (site copy, decks, emails, etc., per plan).  
-- **Inputs:** MVP spec, brand constraints.  
-- **Outputs:** Asset bundle, distribution checklist.  
-- **Capabilities:** Designer, Growth, Builder.  
-- **Checkpoints:** Human review of public-facing claims and compliance-sensitive copy.  
-- **Events (examples):** `gtm.asset_published`, `gtm.launch_checklist_completed`.
-
-#### W5 — Growth experimentation
-
-- **Objective:** Run structured experiments on acquisition and activation.  
-- **Inputs:** Baseline metrics, hypotheses, channel constraints.  
-- **Outputs:** Experiment designs, results, recommendations.  
-- **Capabilities:** Growth, Researcher.  
-- **Checkpoints:** Human approval for spend and brand-risk experiments.  
-- **Events (examples):** `growth.experiment_started`, `growth.experiment_completed`.
-
-#### W6 — Customer feedback synthesis
-
-- **Objective:** Consolidate qualitative and quantitative feedback into actionable spec changes.  
-- **Inputs:** Support data, interviews, usage analytics.  
-- **Outputs:** Prioritized insight list, proposed spec deltas, assumption updates.  
-- **Capabilities:** Support (analytics), Product.  
-- **Checkpoints:** Human triage for roadmap commitment.  
-- **Events (examples):** `feedback.synthesis_completed`, `product.roadmap_proposed`.
-
-*Schemas for process instances **MAY** trail the product spec schema; when introduced, they **MUST** follow the same validation discipline.*
-
----
-
 ## 12. Operating loop (runtime procedure)
 
 For each significant initiative:
 
 1. Instantiate or select goal from spec.  
 2. Decompose into tasks with explicit dependencies.  
-3. Bind **Process Library** templates and **capabilities**.  
+3. Bind **Workflow Library** templates and **skills**.  
 4. Execute; emit events and metrics.  
 5. Collect evidence (artifacts, URLs, eval results).  
-6. Run automated checks; route to human judgment per §10.  
+6. Run automated checks; route to human judgment per §11.  
 7. Merge learnings into specs (assumptions ↔ facts).
 
 ---

--- a/products/dashboard/app/api/events/route.ts
+++ b/products/dashboard/app/api/events/route.ts
@@ -1,0 +1,65 @@
+/**
+ * POST /api/events
+ *
+ * V1 event ingestion endpoint. Validates minimal envelope shape and logs
+ * events to stdout as structured JSON. PostHog integration is a V2 concern.
+ *
+ * Spec reference: spec/examples/dashboard-product.yaml → events.catalog
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+const ALLOWED_EVENTS = new Set([
+  "dashboard.shell_viewed",
+  "dashboard.phase_navigated",
+]);
+
+type EventBody = {
+  name: string;
+  payload: {
+    occurred_at: string;
+    [key: string]: unknown;
+  };
+};
+
+export async function POST(req: NextRequest) {
+  let body: EventBody;
+
+  try {
+    body = (await req.json()) as EventBody;
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  // Minimal envelope validation
+  if (!body.name || typeof body.name !== "string") {
+    return NextResponse.json({ error: "missing event name" }, { status: 400 });
+  }
+
+  if (!ALLOWED_EVENTS.has(body.name)) {
+    return NextResponse.json(
+      { error: `unknown event: ${body.name}` },
+      { status: 422 }
+    );
+  }
+
+  if (!body.payload?.occurred_at) {
+    return NextResponse.json(
+      { error: "payload.occurred_at is required" },
+      { status: 400 }
+    );
+  }
+
+  // V1: structured log to stdout
+  const entry = {
+    level: "info",
+    event: body.name,
+    payload: body.payload,
+    received_at: new Date().toISOString(),
+    product_id: "dashboard",
+  };
+
+  console.log(JSON.stringify(entry));
+
+  return NextResponse.json({ ok: true }, { status: 202 });
+}

--- a/products/dashboard/app/design/page.tsx
+++ b/products/dashboard/app/design/page.tsx
@@ -1,0 +1,42 @@
+import { ShellEvents } from "@/components/shell-events";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { PenLine } from "lucide-react";
+
+export default function DesignPage() {
+  return (
+    <>
+      <ShellEvents route="/design" />
+
+      <div className="max-w-2xl space-y-4">
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-violet-100 text-violet-600">
+                <PenLine className="h-5 w-5" />
+              </div>
+              <div>
+                <CardTitle>Design</CardTitle>
+                <CardDescription>
+                  Spec system, requirements, system design, and event catalog
+                </CardDescription>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-slate-500">
+              This phase produces a schema-valid product spec, a stubbed event catalog, and an
+              observability plan. Exit criteria: a spec that passes{" "}
+              <code className="rounded bg-slate-100 px-1 py-0.5 text-xs font-mono">
+                npm run validate
+              </code>{" "}
+              and an approved design brief.
+            </p>
+            <p className="mt-3 text-sm text-slate-400 italic">
+              Slice implementation coming in a future sprint.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -1,0 +1,41 @@
+@import "tailwindcss";
+
+@theme {
+  --color-background: #ffffff;
+  --color-foreground: #0f172a;
+  --color-muted: #f1f5f9;
+  --color-muted-foreground: #64748b;
+  --color-border: #e2e8f0;
+  --color-sidebar: #f8fafc;
+  --color-sidebar-foreground: #0f172a;
+  --color-sidebar-border: #e2e8f0;
+  --color-sidebar-active: #0f172a;
+  --color-sidebar-active-foreground: #ffffff;
+  --color-primary: #0f172a;
+  --color-primary-foreground: #ffffff;
+  --color-card: #ffffff;
+  --color-card-foreground: #0f172a;
+  --color-accent: #f1f5f9;
+  --color-accent-foreground: #0f172a;
+  --color-ring: #94a3b8;
+  --radius: 0.5rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}

--- a/products/dashboard/app/ideation/page.tsx
+++ b/products/dashboard/app/ideation/page.tsx
@@ -1,0 +1,39 @@
+import { ShellEvents } from "@/components/shell-events";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Lightbulb } from "lucide-react";
+
+export default function IdeationPage() {
+  return (
+    <>
+      <ShellEvents route="/ideation" />
+
+      <div className="max-w-2xl space-y-4">
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-amber-100 text-amber-600">
+                <Lightbulb className="h-5 w-5" />
+              </div>
+              <div>
+                <CardTitle>Ideation</CardTitle>
+                <CardDescription>
+                  Problem definition, user goals, constraints, and success metrics
+                </CardDescription>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-slate-500">
+              This phase captures the problem space, the target user, and the bounded scope
+              needed before design begins. Exit criteria: a defined success metric and a
+              bounded scope.
+            </p>
+            <p className="mt-3 text-sm text-slate-400 italic">
+              Slice implementation coming in a future sprint.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/products/dashboard/app/implementation/page.tsx
+++ b/products/dashboard/app/implementation/page.tsx
@@ -1,0 +1,38 @@
+import { ShellEvents } from "@/components/shell-events";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Code2 } from "lucide-react";
+
+export default function ImplementationPage() {
+  return (
+    <>
+      <ShellEvents route="/implementation" />
+
+      <div className="max-w-2xl space-y-4">
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-100 text-emerald-600">
+                <Code2 className="h-5 w-5" />
+              </div>
+              <div>
+                <CardTitle>Implementation</CardTitle>
+                <CardDescription>
+                  Vertical slices: UI + API + persistence + telemetry in one increment
+                </CardDescription>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-slate-500">
+              Each implementation slice ships UI, API, data persistence, and telemetry together.
+              Exit criteria: deployed, observable, and spec updated with implemented facts.
+            </p>
+            <p className="mt-3 text-sm text-slate-400 italic">
+              Slice implementation coming in a future sprint.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/products/dashboard/app/layout.tsx
+++ b/products/dashboard/app/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { Sidebar } from "@/components/sidebar";
+import { TopBar } from "@/components/top-bar";
+
+export const metadata: Metadata = {
+  title: "AI-Native Dashboard",
+  description: "AI-native operating framework dashboard",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="h-screen flex overflow-hidden">
+        {/* Left sidebar — fixed width, full height */}
+        <Sidebar />
+
+        {/* Right column — top bar + scrollable content */}
+        <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+          <TopBar />
+          <main className="flex-1 overflow-y-auto bg-[#f8fafc] p-6">
+            {children}
+          </main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/products/dashboard/app/page.tsx
+++ b/products/dashboard/app/page.tsx
@@ -1,0 +1,15 @@
+import { HelloWorldCard } from "@/components/hello-world-card";
+import { ShellEvents } from "@/components/shell-events";
+
+export default function HomePage() {
+  return (
+    <>
+      {/* Emits dashboard.shell_viewed on mount */}
+      <ShellEvents route="/" />
+
+      <div className="max-w-2xl">
+        <HelloWorldCard />
+      </div>
+    </>
+  );
+}

--- a/products/dashboard/components.json
+++ b/products/dashboard/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/products/dashboard/components/hello-world-card.tsx
+++ b/products/dashboard/components/hello-world-card.tsx
@@ -1,0 +1,67 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Sparkles, ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+export function HelloWorldCard() {
+  return (
+    <Card className="border-slate-200">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-slate-900 text-white">
+            <Sparkles className="h-5 w-5" />
+          </div>
+          <div>
+            <CardTitle className="text-lg">Hello, World</CardTitle>
+            <CardDescription>
+              AI-Native Dashboard · Shell v0.1
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        <p className="text-sm leading-relaxed text-slate-600">
+          The framework shell is running. Left navigation, top bar, and event
+          emission are all wired. Use the sidebar to explore the three product
+          phases, or extend this card with your first real slice.
+        </p>
+
+        {/* Phase summary */}
+        <div className="mt-5 grid grid-cols-3 gap-3">
+          {[
+            { label: "Ideation", href: "/ideation", color: "bg-amber-50 text-amber-700 border-amber-100" },
+            { label: "Design", href: "/design", color: "bg-violet-50 text-violet-700 border-violet-100" },
+            { label: "Implementation", href: "/implementation", color: "bg-emerald-50 text-emerald-700 border-emerald-100" },
+          ].map(({ label, href, color }) => (
+            <Link
+              key={label}
+              href={href}
+              className={`flex items-center justify-between rounded-lg border px-3 py-2.5 text-xs font-medium transition-opacity hover:opacity-80 ${color}`}
+            >
+              {label}
+              <ArrowRight className="h-3 w-3" />
+            </Link>
+          ))}
+        </div>
+      </CardContent>
+
+      <CardFooter className="border-t border-slate-100 pt-4">
+        <p className="text-xs text-slate-400">
+          Spec:{" "}
+          <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-[11px]">
+            spec/examples/dashboard-product.yaml
+          </code>
+          {" · "}
+          Events: <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-[11px]">dashboard.shell_viewed</code>
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/products/dashboard/components/shell-events.tsx
+++ b/products/dashboard/components/shell-events.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+/**
+ * ShellEvents — client component, renders nothing.
+ *
+ * Fires dashboard.shell_viewed on every page mount per the spec event catalog.
+ * Include once per page.tsx, passing the current route string.
+ */
+
+import { useEffect } from "react";
+import { emitEvent } from "@/lib/events";
+
+export function ShellEvents({ route }: { route: string }) {
+  useEffect(() => {
+    emitEvent("dashboard.shell_viewed", {
+      route,
+      occurred_at: new Date().toISOString(),
+    });
+  }, [route]);
+
+  return null;
+}

--- a/products/dashboard/components/sidebar.tsx
+++ b/products/dashboard/components/sidebar.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Lightbulb, PenLine, Code2, LayoutDashboard } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { emitEvent } from "@/lib/events";
+
+const phases = [
+  {
+    id: "ideation",
+    label: "Ideation",
+    href: "/ideation",
+    icon: Lightbulb,
+    accent: "text-amber-500",
+    activeBg: "bg-amber-50",
+  },
+  {
+    id: "design",
+    label: "Design",
+    href: "/design",
+    icon: PenLine,
+    accent: "text-violet-500",
+    activeBg: "bg-violet-50",
+  },
+  {
+    id: "implementation",
+    label: "Implementation",
+    href: "/implementation",
+    icon: Code2,
+    accent: "text-emerald-500",
+    activeBg: "bg-emerald-50",
+  },
+] as const;
+
+export function Sidebar() {
+  const pathname = usePathname();
+
+  function handlePhaseClick(phaseId: string) {
+    emitEvent("dashboard.phase_navigated", {
+      phase: phaseId as "ideation" | "design" | "implementation",
+      occurred_at: new Date().toISOString(),
+    });
+  }
+
+  return (
+    <aside className="flex w-60 flex-col border-r border-slate-200 bg-[#f8fafc]">
+      {/* Brand */}
+      <div className="flex h-14 items-center gap-2.5 border-b border-slate-200 px-4">
+        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-slate-900 text-white">
+          <LayoutDashboard className="h-4 w-4" />
+        </div>
+        <span className="text-sm font-semibold tracking-tight text-slate-900">
+          AI-Native
+        </span>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex flex-col gap-1 p-3">
+        <p className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-widest text-slate-400">
+          Phases
+        </p>
+
+        {phases.map(({ id, label, href, icon: Icon, accent, activeBg }) => {
+          const isActive = pathname === href;
+          return (
+            <Link
+              key={id}
+              href={href}
+              onClick={() => handlePhaseClick(id)}
+              className={cn(
+                "group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-all",
+                isActive
+                  ? cn("bg-slate-900 text-white shadow-sm", activeBg)
+                  : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+              )}
+            >
+              <Icon
+                className={cn(
+                  "h-4 w-4 shrink-0 transition-colors",
+                  isActive ? "text-white" : cn(accent, "group-hover:opacity-100")
+                )}
+              />
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Footer */}
+      <div className="mt-auto border-t border-slate-200 p-4">
+        <p className="text-[11px] text-slate-400">
+          v0.1 · Planning phase
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -1,0 +1,28 @@
+import { CircleDot } from "lucide-react";
+
+export function TopBar() {
+  return (
+    <header className="flex h-14 items-center justify-between border-b border-slate-200 bg-white px-6">
+      {/* Left — breadcrumb / page title slot */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-slate-900">Dashboard</span>
+      </div>
+
+      {/* Right — context area */}
+      <div className="flex items-center gap-3">
+        {/* Status indicator */}
+        <div className="flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-1">
+          <CircleDot className="h-3 w-3 text-emerald-500" />
+          <span className="text-xs font-medium text-emerald-700">
+            Planning
+          </span>
+        </div>
+
+        {/* Avatar placeholder */}
+        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-900 text-xs font-semibold text-white">
+          A
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/products/dashboard/components/ui/card.tsx
+++ b/products/dashboard/components/ui/card.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-slate-200 bg-white shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("flex flex-col space-y-1.5 p-6", className)}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement>) {
+  return (
+    <h3
+      className={cn(
+        "font-semibold leading-none tracking-tight text-slate-900",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement>) {
+  return (
+    <p className={cn("text-sm text-slate-500", className)} {...props} />
+  );
+}
+
+function CardContent({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("p-6 pt-0", className)} {...props} />;
+}
+
+function CardFooter({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("flex items-center p-6 pt-0", className)}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/products/dashboard/lib/events.ts
+++ b/products/dashboard/lib/events.ts
@@ -1,0 +1,45 @@
+/**
+ * Client-side event emission helper.
+ *
+ * Sends structured events to /api/events per the spec event catalog in
+ * spec/examples/dashboard-product.yaml. V1 behavior: POST to route handler,
+ * which logs to stdout. PostHog integration is a V2 concern.
+ *
+ * Event names must match the catalog exactly:
+ *   - dashboard.shell_viewed
+ *   - dashboard.phase_navigated
+ */
+
+type ShellViewedPayload = {
+  occurred_at: string;
+  route: string;
+  correlation_id?: string;
+};
+
+type PhaseNavigatedPayload = {
+  occurred_at: string;
+  phase: "ideation" | "design" | "implementation";
+  correlation_id?: string;
+};
+
+type EventPayload = ShellViewedPayload | PhaseNavigatedPayload;
+
+type EventName = "dashboard.shell_viewed" | "dashboard.phase_navigated";
+
+/**
+ * Emit a structured event to /api/events.
+ * Fire-and-forget: errors are logged to console, never thrown.
+ */
+export function emitEvent(name: EventName, payload: EventPayload): void {
+  // Only runs in browser — no-op during SSR
+  if (typeof window === "undefined") return;
+
+  fetch("/api/events", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, payload }),
+  }).catch((err) => {
+    // Non-blocking: telemetry must never break the UI
+    console.warn("[events] emit failed:", name, err);
+  });
+}

--- a/products/dashboard/lib/utils.ts
+++ b/products/dashboard/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/products/dashboard/next-env.d.ts
+++ b/products/dashboard/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/products/dashboard/next.config.ts
+++ b/products/dashboard/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  // product_id: dashboard — ai-native-framework boilerplate
+};
+
+export default nextConfig;

--- a/products/dashboard/package-lock.json
+++ b/products/dashboard/package-lock.json
@@ -1,0 +1,1807 @@
+{
+  "name": "dashboard",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dashboard",
+      "version": "0.1.0",
+      "dependencies": {
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.487.0",
+        "next": "15.3.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "tailwind-merge": "^2.6.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4",
+        "@types/node": "^22",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "tailwindcss": "^4",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.0.tgz",
+      "integrity": "sha512-6mDmHX24nWlHOlbwUiAOmMyY7KELimmi+ed8qWcJYjqXeC+G6JzPZ3QosOAfjNwgMIzwhXBiRiCgdh8axTTdTA==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.0.tgz",
+      "integrity": "sha512-PDQcByT0ZfF2q7QR9d+PNj3wlNN4K6Q8JoHMwFyk252gWo4gKt7BF8Y2+KBgDjTFBETXZ/TkBEUY7NIIY7A/Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.0.tgz",
+      "integrity": "sha512-m+eO21yg80En8HJ5c49AOQpFDq+nP51nu88ZOMCorvw3g//8g1JSUsEiPSiFpJo1KCTQ+jm9H0hwXK49H/RmXg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.0.tgz",
+      "integrity": "sha512-H0Kk04ZNzb6Aq/G6e0un4B3HekPnyy6D+eUBYPJv9Abx8KDYgNMWzKt4Qhj57HXV3sTTjsfc1Trc1SxuhQB+Tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.0.tgz",
+      "integrity": "sha512-k8GVkdMrh/+J9uIv/GpnHakzgDQhrprJ/FbGQvwWmstaeFG06nnAoZCJV+wO/bb603iKV1BXt4gHG+s2buJqZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.0.tgz",
+      "integrity": "sha512-ZMQ9yzDEts/vkpFLRAqfYO1wSpIJGlQNK9gZ09PgyjBJUmg8F/bb8fw2EXKgEaHbCc4gmqMpDfh+T07qUphp9A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.0.tgz",
+      "integrity": "sha512-RFwq5VKYTw9TMr4T3e5HRP6T4RiAzfDJ6XsxH8j/ZeYq2aLsBqCkFzwMI0FmnSsLaUbOb46Uov0VvN3UciHX5A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.0.tgz",
+      "integrity": "sha512-a7kUbqa/k09xPjfCl0RSVAvEjAkYBYxUzSVAzk2ptXiNEL+4bDBo9wNC43G/osLA/EOGzG4CuNRFnQyIHfkRgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.0.tgz",
+      "integrity": "sha512-vHUQS4YVGJPmpjn7r5lEZuMhK5UQBNBRSB+iGDvJjaNk649pTIcRluDWNb9siunyLLiu/LDPHfvxBtNamyuLTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
+      "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.487.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.487.0.tgz",
+      "integrity": "sha512-aKqhOQ+YmFnwq8dWgGjOuLc8V1R9/c/yOd+zDY4+ohsR2Jo05lSGc3WsstYPIzcTpeosN7LoCkLReUUITvaIvw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.0.tgz",
+      "integrity": "sha512-k0MgP6BsK8cZ73wRjMazl2y2UcXj49ZXLDEgx6BikWuby/CN+nh81qFFI16edgd7xYpe/jj2OZEIwCoqnzz0bQ==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.3.0",
+        "@swc/counter": "0.1.3",
+        "@swc/helpers": "0.5.15",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.3.0",
+        "@next/swc-darwin-x64": "15.3.0",
+        "@next/swc-linux-arm64-gnu": "15.3.0",
+        "@next/swc-linux-arm64-musl": "15.3.0",
+        "@next/swc-linux-x64-gnu": "15.3.0",
+        "@next/swc-linux-x64-musl": "15.3.0",
+        "@next/swc-win32-arm64-msvc": "15.3.0",
+        "@next/swc-win32-x64-msvc": "15.3.0",
+        "sharp": "^0.34.1"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
+      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/products/dashboard/package.json
+++ b/products/dashboard/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.487.0",
+    "next": "15.3.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^2.6.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "tailwindcss": "^4",
+    "typescript": "^5"
+  }
+}

--- a/products/dashboard/postcss.config.mjs
+++ b/products/dashboard/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/products/dashboard/tsconfig.json
+++ b/products/dashboard/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/spec/examples/dashboard-product.yaml
+++ b/spec/examples/dashboard-product.yaml
@@ -1,0 +1,275 @@
+spec_version: "1.0.0"
+kind: product
+product_id: "dashboard"
+
+metadata:
+  title: "AI-Native Dashboard"
+  status: draft
+  owner: "acesxx@gmail.com"
+  created_at: "2026-04-12T00:00:00Z"
+  updated_at: "2026-04-12T00:00:00Z"
+  tags:
+    - "dashboard"
+    - "framework"
+    - "internal"
+
+ideation:
+  problem: |
+    Teams building with the AI-native framework have no visual control surface to monitor product
+    phases, navigate between concerns, and understand system state at a glance. Agent sessions
+    produce durable artifacts but there is no lightweight UI that surfaces them in one place.
+  user: "Solo founders and small product teams using the AI-native framework to build products."
+  goal: |
+    Ship a governed dashboard shell — left navigation, top bar, and a Hello World card — that
+    serves as the boilerplate UI host for all future product slices across the Ideation, Design,
+    and Implementation phases.
+  constraints:
+    - "Must use the framework-mandated frontend stack: Next.js + Tailwind + shadcn/ui."
+    - "Dashboard lives inside the existing ai-native-framework repository under products/dashboard/."
+    - "No external auth dependency for V1; shell only — no real data sources required."
+    - "All externally observable state changes must emit structured events per spec/policy."
+    - "Provider-agnostic: no vendor-specific assumptions in core business logic."
+  success_metrics:
+    - name: "shell_renders"
+      definition: "Dashboard shell loads with left menu, top bar, and Hello World card in under 2 seconds on localhost."
+      target: "100% of local dev runs"
+    - name: "phase_nav_reachable"
+      definition: "All three phase navigation items (Ideation, Design, Implementation) are rendered and clickable."
+      target: "100% of renders"
+  risks:
+    - description: "Scope creep into real data wiring before the shell is stable."
+      mitigation: "V1 is shell-only with static Hello World card; data wiring is a separate slice."
+    - description: "Tailwind and shadcn/ui version mismatches with future slices."
+      mitigation: "Pin versions in package.json and document in decision log."
+
+design:
+  objective: |
+    Build a governed Next.js + Tailwind + shadcn/ui dashboard shell with three navigation phases
+    (Ideation, Design, Implementation), a persistent left sidebar, a top bar, and a Hello World
+    card on the default route. The shell must be observable, spec-backed, and harness-ready.
+  requirements:
+    - id: "FR-001"
+      priority: must
+      statement: "The shell MUST render a persistent left sidebar with navigation items for Ideation, Design, and Implementation."
+    - id: "FR-002"
+      priority: must
+      statement: "The shell MUST render a top bar with the product name and a placeholder user/context area."
+    - id: "FR-003"
+      priority: must
+      statement: "The default route (/) MUST render a Hello World card using shadcn/ui Card component."
+    - id: "FR-004"
+      priority: must
+      statement: "The dashboard MUST emit a dashboard.shell_viewed event on every page load."
+    - id: "FR-005"
+      priority: must
+      statement: "The product spec MUST be schema-valid and pass npm run validate before any slice ships."
+    - id: "FR-006"
+      priority: should
+      statement: "Navigation active state SHOULD be visually indicated in the left sidebar."
+    - id: "FR-007"
+      priority: should
+      statement: "The shell SHOULD be responsive down to 1024px viewport width."
+  system_design: |
+    Stack: Next.js 15 (App Router) + Tailwind CSS 4 + shadcn/ui.
+    Layout: root layout.tsx wraps every page with a two-column shell:
+      - Left: <Sidebar /> — fixed width, phase navigation, brand mark.
+      - Right: <TopBar /> + <main> slot for page content.
+    Routing:
+      - /             → Hello World card (phase: none / home)
+      - /ideation     → Ideation phase placeholder
+      - /design       → Design phase placeholder
+      - /implementation → Implementation phase placeholder
+    Event emission: thin client-side event hook calls an /api/events route handler that
+    validates the payload and logs to stdout (V1); PostHog integration is a V2 concern.
+    No database required for V1. All data is static or in-memory.
+    Directory layout under products/dashboard/:
+      app/
+        layout.tsx          — shell with Sidebar + TopBar
+        page.tsx            — Hello World card
+        ideation/page.tsx   — Ideation placeholder
+        design/page.tsx     — Design placeholder
+        implementation/page.tsx — Implementation placeholder
+        api/events/route.ts — Event ingestion endpoint (V1: log only)
+      components/
+        sidebar.tsx         — Left navigation
+        top-bar.tsx         — Top bar
+        hello-world-card.tsx — Hello World card
+      lib/
+        events.ts           — Client-side emit helper
+      public/
+      package.json
+      tailwind.config.ts
+      next.config.ts
+      components.json       — shadcn/ui config
+  tooling_decisions:
+    - decision: "Next.js 15 with App Router"
+      reason: "Framework-mandated default stack (docs/AI_NATIVE_FRAMEWORK.md §6). App Router gives co-located server components and route handlers."
+      alternatives_considered:
+        - "Vite + React (rejected — framework spec calls Next.js)"
+        - "Remix (rejected — not in framework default stack)"
+    - decision: "Tailwind CSS 4"
+      reason: "Framework-mandated default stack. Utility-first CSS minimises context-switching between design and code."
+      alternatives_considered:
+        - "CSS Modules (rejected — framework default is Tailwind)"
+    - decision: "shadcn/ui"
+      reason: "Framework-mandated default stack. Provides accessible, copy-owned components; no black-box library lock-in."
+      alternatives_considered:
+        - "Radix UI primitives directly (too low-level for V1 speed)"
+        - "MUI (rejected — vendor-branded, not in framework stack)"
+    - decision: "Event emission via /api/events route handler"
+      reason: "Keeps event contract in the same repo as the spec; decouples client from PostHog until V2."
+      alternatives_considered:
+        - "Direct PostHog client in browser (deferred to V2)"
+  assumptions:
+    - text: "Node.js 20+ is available in the development and CI environment."
+      id: "A-001"
+    - text: "The dashboard runs at localhost:3000 in development; no custom port needed for V1."
+      id: "A-002"
+    - text: "No authentication is required for V1; the shell is local-only."
+      id: "A-003"
+  facts:
+    - text: "Framework default stack is Next.js + Tailwind + shadcn/ui per docs/AI_NATIVE_FRAMEWORK.md §6."
+      id: "F-001"
+    - text: "Repository validation runs npm run validate via GitHub Actions on every push."
+      id: "F-002"
+
+data_model:
+  entities:
+    - name: "NavigationPhase"
+      description: "A named phase in the product lifecycle surfaced as a sidebar navigation item."
+      fields:
+        - name: "id"
+          type: "string"
+          pk: true
+        - name: "label"
+          type: "string"
+        - name: "href"
+          type: "string"
+        - name: "icon"
+          type: "string"
+      relationships: []
+
+events:
+  naming_convention: "domain.action_in_past_tense"
+  catalog:
+    - name: "dashboard.shell_viewed"
+      description: "User loaded the dashboard shell (any page)."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: none
+        ordering: at_least_once
+      emitted_by:
+        - "app.layout"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - occurred_at
+          - route
+        properties:
+          occurred_at:
+            type: string
+            format: date-time
+          route:
+            type: string
+          correlation_id:
+            type: string
+            format: uuid
+    - name: "dashboard.phase_navigated"
+      description: "User clicked a phase navigation item in the left sidebar."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: none
+        ordering: at_least_once
+      emitted_by:
+        - "components.sidebar"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - occurred_at
+          - phase
+        properties:
+          occurred_at:
+            type: string
+            format: date-time
+          phase:
+            type: string
+            enum:
+              - ideation
+              - design
+              - implementation
+          correlation_id:
+            type: string
+            format: uuid
+
+observability:
+  logs:
+    strategy: "Structured JSON logs from the /api/events route handler; include correlation_id on every entry."
+    pii_policy: "No PII in V1 dashboard events; all payloads are pii: none."
+  errors:
+    tool: "Sentry (V2)"
+    policy: "V1 logs unhandled exceptions to stdout; Sentry integration deferred to V2 when the shell goes beyond localhost."
+  metrics:
+    tool: "PostHog (V2)"
+    core_metrics:
+      - key: "dashboard.shell_viewed"
+        description: "Total dashboard loads; baseline engagement signal."
+        type: event
+      - key: "dashboard.phase_navigated"
+        description: "Phase navigation clicks; indicates which phase receives attention."
+        type: event
+
+context_recovery:
+  canonical_summary: |
+    The Dashboard product is the UI shell for the ai-native-framework repository. It provides
+    a left sidebar with Ideation / Design / Implementation phase navigation, a top bar, and a
+    Hello World card on the default route. Stack: Next.js 15 + Tailwind 4 + shadcn/ui.
+    Lives under products/dashboard/. V1 is shell-only; no auth, no database, no external services.
+    Events are emitted via /api/events and logged to stdout. PostHog and Sentry are V2 concerns.
+    All slices extending this product must include slice_id and parent_product_id: "dashboard".
+  key_decisions:
+    - "Stack is Next.js + Tailwind + shadcn/ui per framework §6 — not a preference, a spec."
+    - "V1 is shell-only; data wiring, auth, and telemetry integrations are separate slices."
+    - "Dashboard lives inside the existing framework repo under products/dashboard/, not a new repo."
+    - "Event emission uses a local /api/events route in V1; PostHog deferred to V2."
+  domain_terms:
+    - term: "shell"
+      definition: "The persistent layout wrapper (Sidebar + TopBar + content slot) that hosts all dashboard pages."
+    - term: "phase"
+      definition: "One of the three product lifecycle stages — Ideation, Design, Implementation — surfaced as a sidebar nav item."
+    - term: "harness"
+      definition: "A Skill + Playbook pair that defines how a specific agent role (Feature Developer, QA Tester, DevOps Engineer) operates within this product."
+    - term: "Hello World card"
+      definition: "The shadcn/ui Card component rendered on the default route as the first observable UI artifact."
+
+decision_log:
+  entries:
+    - id: "DEC-001"
+      date: "2026-04-12"
+      decision: "Dashboard lives inside the existing ai-native-framework repo, not a new repo."
+      reason: "Keeps the framework and its first product in one governed place during the planning phase; avoids premature repo proliferation."
+      alternatives:
+        - "New standalone repo (deferred — add when the dashboard warrants its own governance boundary)"
+    - id: "DEC-002"
+      date: "2026-04-12"
+      decision: "V1 is shell-only with static Hello World card; no real data wiring."
+      reason: "Fastest path to a deployed, observable, spec-backed artifact. Proves the harness pattern before adding complexity."
+      alternatives:
+        - "Wire real data in V1 (rejected — scope creep risk before shell is validated)"
+    - id: "DEC-003"
+      date: "2026-04-12"
+      decision: "Three harnesses defined in Planning: Feature Developer, QA Tester, DevOps Engineer."
+      reason: "These three roles cover the full implementation cycle and recur on every future slice. Encoding them now makes the process library reusable immediately."
+      alternatives:
+        - "One generic Developer harness (rejected — too coarse; QA and DevOps have distinct trigger conditions and authority limits)"
+    - id: "DEC-004"
+      date: "2026-04-12"
+      decision: "Use Next.js + Tailwind + shadcn/ui as specified by framework §6."
+      reason: "Spec-mandated. Deviation would require a decision-log entry with alternatives and a waiver; no waiver warranted."
+      alternatives:
+        - "React + Vite + Tailwind (rejected — not the framework default; would require waiver)"


### PR DESCRIPTION
## Purpose

This PR adds the **initial boilerplate for the dashboard example product**: a runnable Next.js app under `products/dashboard/`, together with a validated product spec so the framework has a concrete, in-repo reference implementation.

## What changed

- **`products/dashboard/`** — Next.js app scaffold: app shell (sidebar, top bar), phase routes (ideation, design, implementation), starter UI components, and a minimal `/api/events` route plus client wiring for shell events.
- **`spec/examples/dashboard-product.yaml`** — Example product definition; passes `npm run validate`.
- **`.gitignore`** — Ignores Next.js build/output dirs for the dashboard app (`.next/`, `out/`, `.vercel`).
- **Root docs** — Small updates in `README.md`, `REPO_SCAFFOLD.md`, and `SECURITY.md` where they should mention or align with the new product layout.

## Context

The branch name predates the main work. **#42** (`Clarify framework doc structure and terminology`) is already on `main`; this branch was merged with `main` and then extended with the dashboard product scaffold. Treat the PR as **product boilerplate + spec**, not as a doc-only follow-up to #42.

---

Made with [Cursor](https://cursor.com)