### PR TITLE
feat(framework): analytics standard, feature request template, and implementation playbook

### DIFF
--- a/ai/PLAYBOOKS.md
+++ b/ai/PLAYBOOKS.md
@@ -63,6 +63,16 @@ That sequence is **practical**, not a ranking of importance: mature repos often 
 - **Load:** [`playbooks/framework-review.md`](playbooks/framework-review.md)
 - **Constraints:** audit the framework, not ordinary feature code; follow the authority ladder and do not weaken higher-order artifacts to satisfy lower-order drift.
 
+### Feature implementation (dashboard)
+
+- **When to use:** implementing any new feature in `products/dashboard/` from a completed feature request.
+- **Inputs:** completed `templates/feature-request.md`; current `spec/examples/dashboard-product.yaml`; current `lib/analytics/events.ts`.
+- **Outputs:** updated spec YAML, updated `AnalyticsEvent` type registry, feature component(s), dual-pipeline analytics wiring (PostHog + internal audit), passing `npm run validate`.
+- **Load:** [`playbooks/feature-implementation.md`](playbooks/feature-implementation.md)
+- **Constraints:** spec update and type registry entry are required before any component code; `npm run validate` must pass before the PR ships; no direct `posthog-js` imports outside `lib/analytics/`.
+
+---
+
 ## Adding A New Playbook
 
 Add a new playbook document under `ai/playbooks/` when all of these are true:

--- a/ai/PLAYBOOKS.md
+++ b/ai/PLAYBOOKS.md
@@ -69,7 +69,7 @@ That sequence is **practical**, not a ranking of importance: mature repos often 
 - **Inputs:** completed `templates/feature-request.md`; current `spec/examples/dashboard-product.yaml`; current `products/dashboard/lib/analytics/events.ts`.
 - **Outputs:** updated spec YAML, updated `AnalyticsEvent` type registry, feature component(s), dual-pipeline analytics wiring (PostHog + internal audit), passing `npm run validate`.
 - **Load:** [`playbooks/feature-implementation.md`](playbooks/feature-implementation.md)
-- **Constraints:** spec update and type registry entry are required before any component code; `npm run validate` must pass before the PR ships; no direct `posthog-js` imports outside `lib/analytics/`.
+- **Constraints:** spec update and type registry entry are required before any component code; `npm run validate` must pass before the PR ships; `posthog-js` may only be imported in the approved files listed in `docs/ANALYTICS_STANDARD.md` §3 — feature code must use `useAnalytics()` from `lib/analytics/events`.
 
 ---
 

--- a/ai/PLAYBOOKS.md
+++ b/ai/PLAYBOOKS.md
@@ -66,7 +66,7 @@ That sequence is **practical**, not a ranking of importance: mature repos often 
 ### Feature implementation (dashboard)
 
 - **When to use:** implementing any new feature in `products/dashboard/` from a completed feature request.
-- **Inputs:** completed `templates/feature-request.md`; current `spec/examples/dashboard-product.yaml`; current `lib/analytics/events.ts`.
+- **Inputs:** completed `templates/feature-request.md`; current `spec/examples/dashboard-product.yaml`; current `products/dashboard/lib/analytics/events.ts`.
 - **Outputs:** updated spec YAML, updated `AnalyticsEvent` type registry, feature component(s), dual-pipeline analytics wiring (PostHog + internal audit), passing `npm run validate`.
 - **Load:** [`playbooks/feature-implementation.md`](playbooks/feature-implementation.md)
 - **Constraints:** spec update and type registry entry are required before any component code; `npm run validate` must pass before the PR ships; no direct `posthog-js` imports outside `lib/analytics/`.

--- a/ai/SKILLS.md
+++ b/ai/SKILLS.md
@@ -47,7 +47,7 @@ Discovery should stay broad and cheap. Execution should stay narrow and deep.
 - **When to use:** implementing a new feature in `products/dashboard/` from a completed `templates/feature-request.md`
 - **Inputs:** completed feature request, current spec YAML, current `AnalyticsEvent` type registry
 - **Outputs:** updated spec, updated type registry, wired component(s), passing validation, PR
-- **Load:** `ai/playbooks/feature-implementation.md`
+- **Load:** `playbooks/feature-implementation.md`
 - **Constraints:** spec-first; events required before code; `npm run validate` before PR
 
 ### Framework Keeper

--- a/ai/SKILLS.md
+++ b/ai/SKILLS.md
@@ -42,6 +42,14 @@ Discovery should stay broad and cheap. Execution should stay narrow and deep.
 - **Outputs:** implementation, verification evidence, review closure, published PR state
 - **Load:** `skills/developer.md`
 
+### Feature implementation (dashboard product)
+
+- **When to use:** implementing a new feature in `products/dashboard/` from a completed `templates/feature-request.md`
+- **Inputs:** completed feature request, current spec YAML, current `AnalyticsEvent` type registry
+- **Outputs:** updated spec, updated type registry, wired component(s), passing validation, PR
+- **Load:** `ai/playbooks/feature-implementation.md`
+- **Constraints:** spec-first; events required before code; `npm run validate` before PR
+
 ### Framework Keeper
 
 - **When to use:** auditing the framework itself for contradiction, duplication, unnecessary complexity, or underspecified decision paths

--- a/ai/playbooks/feature-implementation.md
+++ b/ai/playbooks/feature-implementation.md
@@ -1,0 +1,239 @@
+# Feature Implementation Playbook
+
+**Version:** 1.0  
+**Product:** `products/dashboard`  
+**Authority:** Subordinate to `spec/schema/`, `spec/policy/`, and `docs/ANALYTICS_STANDARD.md`. Extends `ai/skills/developer.md` for dashboard product work.
+
+---
+
+## Objective
+
+Implement a dashboard feature from a completed feature request (`templates/feature-request.md`) with observability, type safety, and spec compliance as default parts of the deliverable — not follow-up items.
+
+---
+
+## Inputs
+
+- Completed `templates/feature-request.md` for the feature
+- Current state of `spec/examples/dashboard-product.yaml`
+- Current state of `products/dashboard/lib/analytics/events.ts`
+- Current state of the relevant components under `products/dashboard/`
+
+## Outputs
+
+- Updated `spec/examples/dashboard-product.yaml` (events + metrics)
+- Updated `products/dashboard/lib/analytics/events.ts` (new event type entries)
+- Feature component(s) under `products/dashboard/`
+- PostHog capture calls in every user-action path
+- `npm run validate` passing
+- PR ready for review per `ai/playbooks/pull-request-execution-loop.md`
+
+---
+
+## Workflow
+
+### Step 1 — Read before touching anything
+
+1. Read the feature request in full.
+2. Read `spec/examples/dashboard-product.yaml` — understand existing events and which slice this feature belongs to.
+3. Read `products/dashboard/lib/analytics/events.ts` — understand existing event types so you do not duplicate or conflict.
+4. Read the component(s) the feature will touch or extend. The reference implementation for the full dual-pipeline pattern is `components/shell-events.tsx` and `components/sidebar.tsx`.
+
+Do not edit any file until these four reads are complete.
+
+### Step 2 — Spec first: update the event catalog
+
+Before writing any component code, add the new event(s) to `spec/examples/dashboard-product.yaml` under `events.catalog`.
+
+Each catalog entry requires:
+
+```yaml
+- name: "domain.action_past_tense"        # must match spec/policy/event-taxonomy.yaml
+  description: "..."
+  version: "1.0.0"
+  schema_version: "1.0.0"
+  classification:
+    pii: none                              # none | low | high — be honest
+    idempotency: none                      # none | recommended | required
+    ordering: at_least_once
+  emitted_by:
+    - "components.your-component"         # matches the component file/folder name
+  payload:
+    type: object
+    additionalProperties: false
+    required:
+      - key_property
+    properties:
+      key_property:
+        type: string
+```
+
+Also add or update `observability.metrics.core_metrics` if the feature introduces a trackable signal worth monitoring long-term.
+
+Run `npm run validate` after this step. **Do not continue if validation fails.**
+
+### Step 3 — Type registry: add to AnalyticsEvent
+
+Add the new event(s) to the `AnalyticsEvent` union in `products/dashboard/lib/analytics/events.ts`:
+
+```ts
+// ── [Feature domain] ──────────────────────────────────────────────────────
+| { event: 'domain.action_past_tense'; properties: { key_property: string } }
+```
+
+Rules:
+- Event name must exactly match the catalog entry added in Step 2.
+- Properties must never include email, name, or any user-entered string.
+- Group new entries under a named comment block (see existing grouping in the file).
+
+### Step 4 — Implement the component
+
+Write the UI component(s). Keep this step strictly UI — no analytics capture calls yet.
+
+Component conventions in this codebase:
+- Client components: `"use client"` at top, file in `components/`
+- Server components: no directive, file in `components/` or colocated in `app/`
+- Route handlers: `app/api/<resource>/route.ts`
+- Styles: Tailwind utility classes; use `cn()` from `@/lib/utils` for conditional classes
+- UI primitives: `components/ui/` (shadcn/ui) — do not re-implement what's already there
+
+### Step 5 — Wire the dual pipeline
+
+Every user-facing action that was declared in the feature request's events table must call **both** pipelines:
+
+```ts
+// 1. Internal audit pipeline — correlation_id tagged, logged to stdout via /api/events
+emitEvent("domain.action_past_tense", { key_property: value });
+
+// 2. PostHog — typed, goes to EU region via /ingest proxy
+capture("domain.action_past_tense", { key_property: value });
+```
+
+The `capture` function comes from `useAnalytics()` imported from `@/lib/analytics/events`:
+
+```ts
+import { useAnalytics } from "@/lib/analytics/events";
+
+// inside your component:
+const { capture } = useAnalytics();
+```
+
+The `emitEvent` function comes from `@/lib/events` (unchanged).
+
+**Do not call `posthog.capture()` directly. Do not import `posthog-js` in feature files.**
+
+For page-level views (equivalent to `ShellEvents`), fire on `useEffect` with the route or feature name as dependency:
+
+```ts
+useEffect(() => {
+  emitEvent("feature.viewed", { feature_name: "your-feature" });
+  capture("feature.viewed", { feature_name: "your-feature" });
+}, [capture]);
+```
+
+For action events (equivalent to `Sidebar.handlePhaseClick`), fire inline on the handler:
+
+```ts
+function handleAction() {
+  // ... business logic ...
+  emitEvent("domain.action_past_tense", { key_property: value });
+  capture("domain.action_past_tense", { key_property: value });
+}
+```
+
+### Step 6 — Error monitoring coverage
+
+**Never import `@sentry/nextjs` in feature code.** All error monitoring goes through `lib/monitoring`.
+
+Every route handler must be wrapped in `startSpan`:
+
+```ts
+import { captureError, startSpan, setMonitoringTag } from "@/lib/monitoring"
+
+return await startSpan({ name: "POST /api/my-route", op: "http.server", attributes: { "app.product_id": PRODUCT_ID } }, async () => {
+  // handler body
+})
+```
+
+Every catch block that could silently fail in production must call `captureError`:
+
+```ts
+} catch (err) {
+  captureError(err, { feature: "my-feature", extra: { correlation_id: correlationId } })
+}
+```
+
+Client components that render user data or make external calls should be wrapped in `MonitoringBoundary`:
+
+```tsx
+import { MonitoringBoundary } from "@/lib/monitoring/boundary"
+
+<MonitoringBoundary feature="my-feature" fallback={<ErrorState />}>
+  <MyComponent />
+</MonitoringBoundary>
+```
+
+Reference: `app/api/events/route.ts` is the canonical route handler example. `app/api/sentry-test/route.ts` shows `captureError` + `flush` for deliberate test captures.
+
+### Step 7 — Validate and verify
+
+```bash
+cd /path/to/repo && npm run validate
+```
+
+Must pass. If it fails, fix the YAML before continuing.
+
+Also verify manually:
+- No `import posthog` outside `lib/analytics/`
+- No `import { PostHog }` outside `lib/analytics/`
+- Every event fired in the component matches an entry in `AnalyticsEvent`
+- The spec YAML entry was added to `spec/examples/dashboard-product.yaml`, not only to `golden-product.yaml`
+
+### Step 8 — PR
+
+Follow `ai/playbooks/pull-request-execution-loop.md`.
+
+PR description must include:
+- Which feature request this implements (link or name)
+- The new event(s) added to the type registry
+- Confirmation that `npm run validate` passes
+
+---
+
+## Decision Rules
+
+- If the feature request's events table is blank, stop and ask. Events are required, not optional.
+- If a property the feature naturally produces would require PII (email, name, user input), use `user_id` (UUID) instead and note the substitution in the PR.
+- If the feature needs a new API route, it needs its own internal event and Sentry span — do not skip either.
+- If a new event concept would apply to multiple future features, prefer a generic form (`feature.viewed`, `feature.action_taken`) with a discriminating property over a narrow, one-off name.
+- If a feature has no user-facing action that warrants a PostHog event, document why in the spec under `observability` and leave a comment in the component. This is a legitimate decision, not a skip.
+- Never import `@sentry/nextjs` or `posthog-js` directly in feature code. Both have abstraction layers — use them.
+
+---
+
+## Reference Implementation
+
+The complete dual-pipeline pattern as shipped in the dashboard shell:
+
+| Concern | File | What it shows |
+|---------|------|---------------|
+| Event type registry | `lib/analytics/events.ts` | How to add a new event to `AnalyticsEvent` |
+| Page view tracking | `components/shell-events.tsx` | `useEffect` + dual pipeline for page-level events |
+| Action tracking | `components/sidebar.tsx` | Inline handler + dual pipeline for user actions |
+| Route handler instrumentation | `app/api/events/route.ts` | `startSpan` + `captureError` + `setMonitoringTag` |
+| Deliberate error capture | `app/api/sentry-test/route.ts` | `captureError` + `flush` pattern |
+| Server-side analytics capture | `lib/analytics/server.ts` | `captureServerEvent` for route handlers and server components |
+| Error abstraction layer | `lib/monitoring/index.ts` | All exports available to feature code |
+| React error boundary | `lib/monitoring/boundary.tsx` | `MonitoringBoundary` usage |
+
+---
+
+## Canonical References
+
+- `AGENTS.md`
+- `ai/skills/developer.md`
+- `ai/playbooks/pull-request-execution-loop.md`
+- `docs/ANALYTICS_STANDARD.md` (§§ 1–8 for PostHog; § 9 for error monitoring)
+- `spec/policy/event-taxonomy.yaml`
+- `spec/examples/dashboard-product.yaml`
+- `templates/feature-request.md`

--- a/docs/ANALYTICS_STANDARD.md
+++ b/docs/ANALYTICS_STANDARD.md
@@ -1,0 +1,291 @@
+# Analytics Standard
+
+**Scope:** `products/dashboard` and all future products in this repository.  
+**Authority:** Normative for any code that emits events or evaluates feature flags. See `spec/policy/event-taxonomy.yaml` for the canonical naming policy.
+
+---
+
+## 1. The rule: spec first, then type, then code
+
+Before capturing a new event, follow this sequence without exception:
+
+1. **Add to spec** — add the event entry to the relevant spec YAML under `spec/examples/` in the `events.catalog` block. Include the full classification block (pii, idempotency, ordering) and payload schema.
+2. **Add to the type registry** — add the event to the `AnalyticsEvent` union in `lib/analytics/events.ts`. TypeScript will enforce name/property pairing at compile time everywhere the event is used.
+3. **Add the capture call** — only after steps 1 and 2, add `capture()` or `captureServerEvent()` in the feature code.
+
+This enforces the framework's event-catalog discipline at the process level. Shipping an event that is not in the spec is a spec violation.
+
+---
+
+## 2. Event naming
+
+Pattern: `domain.action_past_tense` — from `spec/policy/event-taxonomy.yaml`.
+
+| ✓ Valid | ✗ Invalid |
+|---------|-----------|
+| `user.signed_up` | `click` |
+| `feature.viewed` | `button_pressed` |
+| `spec.exported` | `page_load` |
+| `dashboard.phase_navigated` | `UserSignedUp` |
+
+- Domain is lowercase, singular noun representing the subject area.
+- Action is a past-tense verb (or verb phrase), snake_case.
+- No more than two segments. `auth.user.signed_up` is wrong; `user.signed_up` is right.
+
+---
+
+## 3. Which helper to use where
+
+| Context | Import | Call |
+|---------|--------|------|
+| Client component | `import { useAnalytics } from '@/lib/analytics/events'` | `const { capture } = useAnalytics()` |
+| Server component | `import { captureServerEvent } from '@/lib/analytics/server'` | `await captureServerEvent(userId, event, props)` |
+| Route handler | `import { captureServerEvent } from '@/lib/analytics/server'` | `await captureServerEvent(userId, event, props)` |
+
+**Never import `posthog-js` or `posthog-node` directly in feature files.**  
+The only files that may import them are:
+- `instrumentation-client.ts` (init only)
+- `lib/analytics/posthog-server.ts` (server singleton)
+- `lib/analytics/events.ts` (hook implementation)
+- `lib/analytics/identity.ts` (identify/reset)
+- `lib/analytics/flags.ts` (server-side flag evaluation)
+
+---
+
+## 4. PII rules (non-negotiable)
+
+**Allowed in event properties:**
+- `user_id` (UUID only — the Supabase auth UUID)
+- Plan name (`free` | `pro`)
+- Feature name (a string constant you defined, not user input)
+- Action name (a string constant)
+- Counts, booleans
+- ISO date strings (e.g. `created_at: "2026-04-12"` — no timestamp with time component that could be correlated to a specific user action)
+
+**Never allowed in event properties:**
+- Email address
+- Full name or display name
+- IP address
+- Any string typed or entered by the user
+- Session token, cookie value, or any credential fragment
+
+If a property would allow you to identify a specific person without their UUID, it does not belong in an event payload.
+
+---
+
+## 5. Identity rules
+
+| Action | Function | File |
+|--------|----------|------|
+| User signs in | `identifyUser(userId, traits?)` | `lib/analytics/identity.ts` |
+| User signs out | `resetIdentity()` | `lib/analytics/identity.ts` |
+
+- Call `identifyUser()` exactly once per sign-in, passing the Supabase auth UUID as `userId`.
+- Optional `traits`: only `plan` and `created_at` (ISO date string). Nothing else.
+- Call `resetIdentity()` on sign-out so the next anonymous session is not linked to the previous user.
+- **Never call `posthog.identify()` directly** in feature code. Use `identifyUser()`.
+- `person_profiles: 'identified_only'` is set at init time — PostHog will not create a profile for anonymous users. Identity only exists after `identifyUser()` is called.
+
+---
+
+## 6. Feature flags
+
+### Adding a flag
+
+1. Document flag intent and rollout plan in the product spec `decision_log`.
+2. Add the flag key to the `FeatureFlag` union in `lib/analytics/flags.ts`.
+3. Create the flag in the PostHog dashboard (EU region) with matching key.
+
+### Evaluating flags
+
+**Server-side** (Server Components, Route Handlers):
+
+```ts
+import { getFlag } from '@/lib/analytics/flags'
+
+const isEnabled = await getFlag('your-flag-key', userId)
+```
+
+**Client-side:** use `usePostHog()` from `posthog-js/react` inside a dedicated `useFlag` hook — never inline in feature components. Example:
+
+```ts
+// lib/analytics/useFlag.ts
+'use client'
+import { usePostHog } from 'posthog-js/react'
+import type { FeatureFlag } from './flags'
+
+export function useFlag(flag: FeatureFlag): boolean {
+  const posthog = usePostHog()
+  return posthog?.isFeatureEnabled(flag) ?? false
+}
+```
+
+---
+
+## 7. What not to instrument
+
+Do not capture events for:
+
+- Internal state changes with no user intent (e.g. a React re-render, a cache miss)
+- Every keystroke or character of input
+- Events that fire more than once per deliberate user action
+- Any event where capturing it would require PII in a property
+- Errors — use Sentry for that
+
+The goal is behavioral signal, not a log stream.
+
+---
+
+## 8. Worked example: `spec.exported`
+
+This example shows the complete path for a hypothetical event where a user exports a spec document.
+
+### Step 1 — spec YAML entry (`spec/examples/dashboard-product.yaml`, `events.catalog`)
+
+```yaml
+- name: "spec.exported"
+  description: "User exported a spec document to a file."
+  version: "1.0.0"
+  schema_version: "1.0.0"
+  classification:
+    pii: none
+    idempotency: none
+    ordering: at_least_once
+  emitted_by:
+    - "components.spec-editor"
+  payload:
+    type: object
+    additionalProperties: false
+    required:
+      - format
+    properties:
+      format:
+        type: string
+        enum:
+          - yaml
+          - json
+          - pdf
+```
+
+### Step 2 — `AnalyticsEvent` union entry (`lib/analytics/events.ts`)
+
+```ts
+| { event: 'spec.exported'; properties: { format: 'yaml' | 'json' | 'pdf' } }
+```
+
+### Step 3 — capture call in the export button component
+
+```tsx
+'use client'
+import { useAnalytics } from '@/lib/analytics/events'
+
+export function ExportButton({ format }: { format: 'yaml' | 'json' | 'pdf' }) {
+  const { capture } = useAnalytics()
+
+  return (
+    <button
+      onClick={() => {
+        // ... export logic ...
+        capture('spec.exported', { format })
+      }}
+    >
+      Export
+    </button>
+  )
+}
+```
+
+TypeScript enforces that `format` must be one of `'yaml' | 'json' | 'pdf'`. Any other value is a compile error. Any event name not in `AnalyticsEvent` is also a compile error.
+
+### Step 4 — In the PostHog dashboard (EU region)
+
+Navigate to **Insights → Events** and filter by `spec.exported`. The event will appear with property `format` populated. You can create a funnel or trend chart, or use it as a feature flag condition.
+
+---
+
+---
+
+## 9. Error monitoring standard
+
+### The rule: never import `@sentry/nextjs` in feature code
+
+| Need | Import from | Call |
+|------|-------------|------|
+| Catch an error | `@/lib/monitoring` | `captureError(err, { feature: '...' })` |
+| Log a warning or degraded state | `@/lib/monitoring` | `captureMessage('...', 'warning', { feature: '...' })` |
+| Contain a client component | `@/lib/monitoring/boundary` | `<MonitoringBoundary feature="...">` |
+| Performance span | `@/lib/monitoring` | `startSpan(...)` |
+
+**Never** write `import * as Sentry from '@sentry/nextjs'` in feature code. The only files that may import `@sentry/nextjs` directly are:
+
+- `sentry.server.config.ts`, `sentry.edge.config.ts` — Sentry SDK init
+- `instrumentation-client.ts` — Sentry client init + Next.js router hooks (uses `Sentry.init()`, `replayIntegration()`)
+- `next.config.ts` — build-time `withSentryConfig` wrapper
+- `lib/monitoring/index.ts` and `lib/monitoring/boundary.tsx` — the abstraction layer itself
+
+### When to use each
+
+**`captureError(error, context)`** — caught exceptions, API failures, data integrity violations. Returns the Sentry event ID for cross-linking.
+
+```ts
+import { captureError } from "@/lib/monitoring"
+
+try {
+  await riskyOperation()
+} catch (err) {
+  captureError(err, { feature: "spec-editor", action: "save" })
+}
+```
+
+**`captureMessage(message, level, context)`** — unexpected-but-handled states, fallback paths taken. Use `'warning'` by default. Use `'info'` sparingly (PostHog is the right tool for business events).
+
+```ts
+import { captureMessage } from "@/lib/monitoring"
+
+if (response.status === 206) {
+  captureMessage("Partial spec returned from API", "warning", { feature: "spec-loader" })
+}
+```
+
+**`MonitoringBoundary`** — any client component that renders user data or makes external calls. The `feature` prop is required; it forces the call site to name the bounded region, making Sentry issue grouping useful.
+
+```tsx
+import { MonitoringBoundary } from "@/lib/monitoring/boundary"
+
+<MonitoringBoundary feature="spec-editor" fallback={<ErrorState />}>
+  <SpecEditor />
+</MonitoringBoundary>
+```
+
+### Always include `feature` context
+
+Every `captureError()` and `captureMessage()` call must include `feature`. This is the single most important field for triage: it tells you which part of the product broke without reading the stack trace.
+
+### Identity sync
+
+`identifyUser()` in `lib/analytics/identity.ts` calls both PostHog and `setMonitoringUser()` in a single call. `resetIdentity()` calls both PostHog reset and `clearMonitoringUser()`. You never need to call either Sentry or PostHog identity functions directly.
+
+### Cross-linking with PostHog (for later)
+
+`captureError()` returns the Sentry event ID as a string. When a logging layer is added, pass this as `sentry_event_id` to create a full trace: PostHog event → Sentry error → log entry.
+
+### PII rules (same as PostHog)
+
+- `userId` accepts Supabase UUID only
+- `extra` must not contain email, name, or user-entered content
+- `feature` and `action` must be string constants defined in code, not user input
+
+---
+
+## File map
+
+| File | Purpose |
+|------|---------|
+| `instrumentation-client.ts` | PostHog init + Sentry init. Runs once on client load. SDK infrastructure — exempt from lib/monitoring constraint. |
+| `lib/analytics/events.ts` | `AnalyticsEvent` type registry + `useAnalytics()` hook. |
+| `lib/analytics/server.ts` | `captureServerEvent()` for server components and route handlers. |
+| `lib/analytics/posthog-server.ts` | PostHog Node SDK singleton. Not imported outside `lib/analytics/`. |
+| `lib/analytics/identity.ts` | `identifyUser()` and `resetIdentity()`. Syncs PostHog + Sentry identity. Called from auth flows only. |
+| `lib/analytics/flags.ts` | `getFlag()` server-side flag evaluation + `FeatureFlag` type. |
+| `lib/monitoring/index.ts` | Single import surface for all Sentry operations in feature code. |
+| `lib/monitoring/boundary.tsx` | `MonitoringBoundary` — React error boundary with required feature tag. |

--- a/docs/ANALYTICS_STANDARD.md
+++ b/docs/ANALYTICS_STANDARD.md
@@ -60,7 +60,7 @@ The only files that may import them are:
 - Feature name (a string constant you defined, not user input)
 - Action name (a string constant)
 - Counts, booleans
-- ISO date strings (e.g. `created_at: "2026-04-12"` — no timestamp with time component that could be correlated to a specific user action)
+- ISO date strings (e.g. `created_at: "2026-04-12"`) and schema-defined RFC3339 timestamps for sanctioned fields (e.g. `occurred_at` in event payloads) — arbitrary user-supplied datetime values and free-form timestamps remain forbidden
 
 **Never allowed in event properties:**
 - Email address

--- a/docs/ANALYTICS_STANDARD.md
+++ b/docs/ANALYTICS_STANDARD.md
@@ -203,8 +203,6 @@ Navigate to **Insights → Events** and filter by `spec.exported`. The event wil
 
 ---
 
----
-
 ## 9. Error monitoring standard
 
 ### The rule: never import `@sentry/nextjs` in feature code

--- a/spec/examples/golden-product.yaml
+++ b/spec/examples/golden-product.yaml
@@ -121,35 +121,6 @@ events:
           occurred_at:
             type: string
             format: date-time
-    - name: "auth.user_signed_up"
-      description: "A new user completed signup."
-      version: "1.0.0"
-      schema_version: "1.0.0"
-      classification:
-        pii: high
-        idempotency: required
-        ordering: at_least_once
-      emitted_by:
-        - "api.auth"
-      payload:
-        type: object
-        additionalProperties: false
-        required:
-          - user_id
-          - occurred_at
-        properties:
-          user_id:
-            type: string
-            format: uuid
-          occurred_at:
-            type: string
-            format: date-time
-          plan:
-            type: string
-            enum:
-              - free
-              - pro
-
 observability:
   logs:
     strategy: "Structured JSON logs; include correlation_id and trace ids when available."

--- a/spec/examples/golden-product.yaml
+++ b/spec/examples/golden-product.yaml
@@ -70,6 +70,57 @@ data_model:
 events:
   naming_convention: "domain.action_in_past_tense"
   catalog:
+    - name: "user.signed_up"
+      description: "A new user completed the sign-up flow."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: high
+        idempotency: required
+        ordering: at_least_once
+      emitted_by:
+        - "api.auth"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - user_id
+          - occurred_at
+        properties:
+          user_id:
+            type: string
+            format: uuid
+          occurred_at:
+            type: string
+            format: date-time
+          plan:
+            type: string
+            enum:
+              - free
+              - pro
+    - name: "user.signed_in"
+      description: "An existing user successfully authenticated."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: high
+        idempotency: none
+        ordering: at_least_once
+      emitted_by:
+        - "api.auth"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - user_id
+          - occurred_at
+        properties:
+          user_id:
+            type: string
+            format: uuid
+          occurred_at:
+            type: string
+            format: date-time
     - name: "auth.user_signed_up"
       description: "A new user completed signup."
       version: "1.0.0"
@@ -112,6 +163,12 @@ observability:
       - key: "activation_completed"
         description: "User completed primary activation funnel step."
         type: event
+      - key: "user.signed_in"
+        description: "Successful sign-in events; measures returning user engagement rate."
+        type: event
+      - key: "user.signed_up"
+        description: "New user registrations; primary acquisition funnel entry point."
+        type: event
 
 context_recovery:
   canonical_summary: |
@@ -135,3 +192,11 @@ decision_log:
       alternatives:
         - "Framework-first (rejected)"
         - "Product-only with backfill (escape hatch)"
+    - id: "DEC-002"
+      date: "2026-04-12"
+      decision: "Adopt PostHog for product analytics with typed abstraction layer."
+      reason: "Enables growth experimentation and feedback synthesis. Typed event registry in lib/analytics/events.ts enforces spec-first discipline at compile time; no feature code imports posthog-js directly."
+      alternatives:
+        - "Mixpanel"
+        - "Amplitude"
+        - "raw posthog-js without abstraction"

--- a/templates/feature-request.md
+++ b/templates/feature-request.md
@@ -1,0 +1,95 @@
+# Feature Request: [Feature Name]
+
+<!--
+  This template is the intake form for any new dashboard feature.
+  Fill it out before asking an agent to implement.
+  An agent implementing from this template will follow ai/playbooks/feature-implementation.md.
+
+  The spec-first discipline is non-negotiable:
+    1. Fill out this template (events section required)
+    2. Agent updates spec/examples/ and lib/analytics/events.ts
+    3. Agent implements the component
+    4. npm run validate must pass before the PR ships
+-->
+
+## What it does
+
+<!-- One to two sentences. User-facing description. -->
+
+## User action
+
+<!--
+  The specific thing a user does that makes this feature meaningful.
+  Be concrete. "User clicks X to do Y" is better than "user can interact with Z."
+-->
+
+## Where it lives in the UI
+
+<!--
+  Route and component area.
+  Example: "Button in the top-right of /design page, inside the existing TopBar component."
+  Example: "New card below the Hello World card on the home route (/)."
+-->
+
+## Acceptance criteria
+
+<!--
+  Short, verifiable list. Each item should be checkable by a person or an automated test.
+  Example:
+  - [ ] Button renders on /design
+  - [ ] Clicking it opens a modal
+  - [ ] Modal closes on Escape key
+  - [ ] spec.exported event appears in PostHog after export
+-->
+
+- [ ]
+- [ ]
+
+## Events this feature emits
+
+<!--
+  At least one event. This section is required — it drives the spec update and the type registry.
+  Name the event using the taxonomy: domain.action_past_tense
+  Key property: the single most important thing to know about this action (no PII).
+
+  Example:
+  | Event | Trigger | Key property |
+  | spec.exported | User clicks Export | format: yaml|json|pdf |
+
+  If you are not sure of the event name, describe what happens and the agent will name it per policy.
+-->
+
+| Event | Trigger | Key property |
+|-------|---------|--------------|
+|       |         |              |
+
+## Core metric this feature contributes to
+
+<!--
+  Which PostHog metric (from the spec's observability.metrics) does this feature affect?
+  Or name a new one if this feature introduces a new signal worth tracking long-term.
+  Example: "dashboard.phase_navigated — measures which phases receive attention"
+-->
+
+## Non-goals for this iteration
+
+<!--
+  Explicit scope limit. Prevents scope creep during implementation.
+  Example: "Does not persist the exported file to a backend — download only."
+-->
+
+-
+
+## Data / backend requirements
+
+<!--
+  Does this feature need a new API route, database access, or external service?
+  If none, write "None — client-side only."
+-->
+
+## Risks and open questions
+
+<!--
+  Anything the implementer should know before starting.
+  Leave blank if none.
+-->


### PR DESCRIPTION
## Summary

- Adds `docs/ANALYTICS_STANDARD.md` — the normative developer contract for PostHog and Sentry across all products (§1–8 PostHog, §9 Sentry error monitoring)
- Adds `templates/feature-request.md` — structured intake form with a required events table and core metric field, making observability a default part of every feature request
- Adds `ai/playbooks/feature-implementation.md` — 8-step agent playbook that bakes spec-first, dual-pipeline, and `lib/monitoring` coverage into the definition of done
- Updates `spec/examples/golden-product.yaml` with `user.signed_up`/`user.signed_in` catalog entries, new core metrics, and DEC-002 (PostHog adoption)

## What this enables

Every future feature developed in this repository now has a formal, machine-executable path:
1. Fill out `templates/feature-request.md` (events table required)
2. Agent runs `ai/playbooks/feature-implementation.md` — spec → type → code → validate → PR
3. `docs/ANALYTICS_STANDARD.md` is the authoritative contract; `spec/policy/event-taxonomy.yaml` governs naming

The reference implementation (dual-pipeline pattern in `shell-events.tsx` and `sidebar.tsx`) is delivered in PR #48.

## Validation

`npm run validate` passes (all spec YAML valid).

## Test plan

- [ ] `npm run validate` passes
- [ ] `spec/examples/golden-product.yaml` includes `user.signed_up` and `user.signed_in` with full classification blocks
- [ ] `templates/feature-request.md` has required events table
- [ ] `ai/playbooks/feature-implementation.md` 8 steps reference correct file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an analytics standard, a dashboard feature-implementation playbook and index entry, a dashboard feature skill entry, and a new feature-request template to enforce spec-first workflows, analytics & monitoring conventions, and PR validation.
* **New Features**
  * Renamed the signup event, added a user signed-in event, registered core observability metrics for both, and logged a decision about the analytics approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->