### PR TITLE
feat(observability): structured log pipeline via Sentry Logs

### DIFF
--- a/products/dashboard/lib/monitoring/index.ts
+++ b/products/dashboard/lib/monitoring/index.ts
@@ -120,3 +120,20 @@ export const flush = Sentry.flush;
 // ─── Next.js instrumentation hook re-exports ─────────────────────────────────
 
 export const captureRequestError = Sentry.captureRequestError;
+
+// ─── Structured log pipeline ──────────────────────────────────────────────────
+//
+// Routed through Sentry Logs (enableLogs: true in all runtime configs).
+// All log lines are queryable in Sentry with correlation_id and product tags.
+//
+// createLogger(context) — bind correlation_id + feature to a request scope.
+// log                   — bare singleton for startup / build-time messages.
+
+export {
+  createLogger,
+  log,
+  type Logger,
+  type LogContext,
+  type LogAttributes,
+  type LogAttributeValue,
+} from "./logger";

--- a/products/dashboard/lib/monitoring/logger.ts
+++ b/products/dashboard/lib/monitoring/logger.ts
@@ -71,10 +71,7 @@ function buildAttrs(
   baseCtx: LogContext,
   callAttrs: LogAttributes | undefined,
 ): LogAttributes {
-  const merged: LogAttributes = {
-    product_id: PRODUCT_ID,
-    slice_id: SHELL_SLICE_ID,
-  };
+  const merged: LogAttributes = {};
 
   for (const [k, v] of Object.entries(baseCtx)) {
     if (v !== undefined) merged[k] = v;
@@ -85,6 +82,10 @@ function buildAttrs(
       if (v !== undefined) merged[k] = v;
     }
   }
+
+  // Always stamp routing tags last so callers cannot override them.
+  merged.product_id = PRODUCT_ID;
+  merged.slice_id = SHELL_SLICE_ID;
 
   return merged;
 }
@@ -97,17 +98,20 @@ function buildAttrs(
  * or a stable feature context (route handler, server action, component tree).
  */
 export function createLogger(context: LogContext = {}): Logger {
+  // Snapshot at creation time so external mutations to the passed object
+  // cannot affect log metadata after the logger is constructed.
+  const snapshot: LogContext = { ...context };
   return {
     trace: (msg, attrs) =>
-      Sentry.logger.trace(msg, buildAttrs(context, attrs)),
+      Sentry.logger.trace(msg, buildAttrs(snapshot, attrs)),
     debug: (msg, attrs) =>
-      Sentry.logger.debug(msg, buildAttrs(context, attrs)),
-    info: (msg, attrs) => Sentry.logger.info(msg, buildAttrs(context, attrs)),
-    warn: (msg, attrs) => Sentry.logger.warn(msg, buildAttrs(context, attrs)),
+      Sentry.logger.debug(msg, buildAttrs(snapshot, attrs)),
+    info: (msg, attrs) => Sentry.logger.info(msg, buildAttrs(snapshot, attrs)),
+    warn: (msg, attrs) => Sentry.logger.warn(msg, buildAttrs(snapshot, attrs)),
     error: (msg, attrs) =>
-      Sentry.logger.error(msg, buildAttrs(context, attrs)),
+      Sentry.logger.error(msg, buildAttrs(snapshot, attrs)),
     fatal: (msg, attrs) =>
-      Sentry.logger.fatal(msg, buildAttrs(context, attrs)),
+      Sentry.logger.fatal(msg, buildAttrs(snapshot, attrs)),
   };
 }
 

--- a/products/dashboard/lib/monitoring/logger.ts
+++ b/products/dashboard/lib/monitoring/logger.ts
@@ -1,0 +1,121 @@
+/**
+ * lib/monitoring/logger.ts
+ *
+ * Structured log pipeline via Sentry Logs (enableLogs: true).
+ * All log lines are queryable in Sentry with correlation_id and product tags.
+ *
+ * Usage (server route handler / server component):
+ *   import { createLogger } from "@/lib/monitoring";
+ *   import { CORRELATION_HEADER } from "@/lib/sentry";
+ *   import { headers } from "next/headers";
+ *
+ *   const h = await headers();
+ *   const logger = createLogger({
+ *     correlation_id: h.get(CORRELATION_HEADER) ?? undefined,
+ *     feature: "api.events",
+ *   });
+ *   logger.info("Request received", { path: req.url });
+ *
+ * Usage (client component):
+ *   import { createLogger } from "@/lib/monitoring";
+ *   import { getBrowserCorrelationId } from "@/lib/correlation";
+ *
+ *   const logger = createLogger({
+ *     correlation_id: getBrowserCorrelationId(),
+ *     feature: "dashboard.ideation",
+ *   });
+ *   logger.info("Panel opened");
+ *
+ * Quick logging without context binding (no correlation_id):
+ *   import { log } from "@/lib/monitoring";
+ *   log.warn("Missing env var", { key: "SENTRY_DSN" });
+ */
+
+import * as Sentry from "@sentry/nextjs";
+import { PRODUCT_ID, SHELL_SLICE_ID } from "@/lib/sentry";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Scalar attribute values accepted by Sentry Logs. */
+export type LogAttributeValue = string | number | boolean;
+
+/** Structured attributes attached to a single log line. */
+export type LogAttributes = Record<string, LogAttributeValue | undefined>;
+
+/**
+ * Bound context that is stamped on every log line produced by this logger.
+ * product_id and slice_id are always added automatically.
+ */
+export interface LogContext {
+  /** Propagated x-correlation-id header value. */
+  correlation_id?: string;
+  /** Feature/module identifier, e.g. "api.events" or "dashboard.shell". */
+  feature?: string;
+  /** Any additional attributes to bind to every line. */
+  [key: string]: LogAttributeValue | undefined;
+}
+
+/** Structured logger interface. Mirrors Sentry log levels. */
+export interface Logger {
+  trace(message: string, attrs?: LogAttributes): void;
+  debug(message: string, attrs?: LogAttributes): void;
+  info(message: string, attrs?: LogAttributes): void;
+  warn(message: string, attrs?: LogAttributes): void;
+  error(message: string, attrs?: LogAttributes): void;
+  fatal(message: string, attrs?: LogAttributes): void;
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────────
+
+function buildAttrs(
+  baseCtx: LogContext,
+  callAttrs: LogAttributes | undefined,
+): LogAttributes {
+  const merged: LogAttributes = {
+    product_id: PRODUCT_ID,
+    slice_id: SHELL_SLICE_ID,
+  };
+
+  for (const [k, v] of Object.entries(baseCtx)) {
+    if (v !== undefined) merged[k] = v;
+  }
+
+  if (callAttrs) {
+    for (const [k, v] of Object.entries(callAttrs)) {
+      if (v !== undefined) merged[k] = v;
+    }
+  }
+
+  return merged;
+}
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a logger with bound context stamped on every line.
+ * Prefer this over the bare `log` singleton when you have a correlation_id
+ * or a stable feature context (route handler, server action, component tree).
+ */
+export function createLogger(context: LogContext = {}): Logger {
+  return {
+    trace: (msg, attrs) =>
+      Sentry.logger.trace(msg, buildAttrs(context, attrs)),
+    debug: (msg, attrs) =>
+      Sentry.logger.debug(msg, buildAttrs(context, attrs)),
+    info: (msg, attrs) => Sentry.logger.info(msg, buildAttrs(context, attrs)),
+    warn: (msg, attrs) => Sentry.logger.warn(msg, buildAttrs(context, attrs)),
+    error: (msg, attrs) =>
+      Sentry.logger.error(msg, buildAttrs(context, attrs)),
+    fatal: (msg, attrs) =>
+      Sentry.logger.fatal(msg, buildAttrs(context, attrs)),
+  };
+}
+
+// ─── Default singleton ────────────────────────────────────────────────────────
+
+/**
+ * Bare logger without a bound correlation_id.
+ * Use for startup logs, build-time messages, or when correlation context is
+ * unavailable. Prefer createLogger() in request-scoped code.
+ */
+export const log: Logger = createLogger();


### PR DESCRIPTION
## Summary

- Adds `createLogger(context)` factory in `lib/monitoring/logger.ts` — binds `correlation_id`, `feature`, `product_id`, and `slice_id` to every log line routed through Sentry Logs
- Adds bare `log` singleton for startup / build-time messages that have no request scope
- Re-exports both from `lib/monitoring/index.ts` so feature code never imports `@sentry/nextjs` directly (same contract as `captureError`/`captureWarning`)
- No new dependencies — `enableLogs: true` was already set in all three runtime configs (server, edge, client); this is the service layer that was missing

## Usage

```ts
// Server route handler / server component
import { createLogger } from "@/lib/monitoring";
import { CORRELATION_HEADER } from "@/lib/sentry";
import { headers } from "next/headers";

const h = await headers();
const logger = createLogger({
  correlation_id: h.get(CORRELATION_HEADER) ?? undefined,
  feature: "api.events",
});
logger.info("Request received", { path: req.url });
logger.error("Upstream timeout", { service: "posthog", duration_ms: 5000 });

// Client component
import { createLogger } from "@/lib/monitoring";
import { getBrowserCorrelationId } from "@/lib/correlation";

const logger = createLogger({
  correlation_id: getBrowserCorrelationId(),
  feature: "dashboard.ideation",
});
logger.info("Panel opened");

// Quick / startup logging
import { log } from "@/lib/monitoring";
log.warn("Missing env var", { key: "SENTRY_DSN" });
```

## Test plan

- [ ] `npx tsc --noEmit` passes (confirmed locally)
- [ ] Verify log lines appear in Sentry Logs dashboard with `correlation_id`, `product_id`, `slice_id` attributes after deploying with a valid `SENTRY_DSN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a structured logging API with multiple levels (trace, debug, info, warn, error, fatal).
  * Introduced contextual logging with correlation_id and feature attribution, plus per-call attributes.
  * Provides a default global logger and ensures logs include product and slice identifiers for consistent tracing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->