### PR TITLE
feat(observability): wire structured logger into all request paths

### DIFF
--- a/products/dashboard/app/api/events/route.ts
+++ b/products/dashboard/app/api/events/route.ts
@@ -76,10 +76,10 @@ function sanitizePayload(
 export async function POST(req: NextRequest) {
   let correlationId: string | null = req.headers.get(CORRELATION_HEADER);
 
-  // Scoped logger — correlation_id bound from the inbound request header.
-  // All log lines for this request are queryable in Sentry Logs by correlation_id.
+  // Scoped logger — normalize the header before binding so malformed IDs
+  // never fragment correlation in Sentry Logs.
   const logger = createLogger({
-    correlation_id: correlationId ?? undefined,
+    correlation_id: normalizeCorrelationId(correlationId) ?? undefined,
     feature: "api.events",
   });
 

--- a/products/dashboard/app/api/events/route.ts
+++ b/products/dashboard/app/api/events/route.ts
@@ -8,7 +8,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { captureError, startSpan, setMonitoringTag } from "@/lib/monitoring";
+import { captureError, createLogger, startSpan, setMonitoringTag } from "@/lib/monitoring";
 import {
   CORRELATION_HEADER,
   PRODUCT_ID,
@@ -76,6 +76,13 @@ function sanitizePayload(
 export async function POST(req: NextRequest) {
   let correlationId: string | null = req.headers.get(CORRELATION_HEADER);
 
+  // Scoped logger — correlation_id bound from the inbound request header.
+  // All log lines for this request are queryable in Sentry Logs by correlation_id.
+  const logger = createLogger({
+    correlation_id: correlationId ?? undefined,
+    feature: "api.events",
+  });
+
   try {
     return await startSpan(
       {
@@ -92,10 +99,12 @@ export async function POST(req: NextRequest) {
         try {
           parsed = await req.json();
         } catch {
+          logger.warn("event.rejected", { reason: "invalid_json" });
           return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
         }
 
         if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+          logger.warn("event.rejected", { reason: "invalid_envelope" });
           return NextResponse.json(
             { error: "invalid event envelope" },
             { status: 400 }
@@ -109,10 +118,12 @@ export async function POST(req: NextRequest) {
           typeof body.payload !== "object" ||
           Array.isArray(body.payload)
         ) {
+          logger.warn("event.rejected", { reason: "invalid_payload" });
           return NextResponse.json({ error: "invalid payload" }, { status: 400 });
         }
 
         if (!body.event_name || typeof body.event_name !== "string") {
+          logger.warn("event.rejected", { reason: "missing_event_name" });
           return NextResponse.json(
             { error: "missing event_name" },
             { status: 400 }
@@ -120,6 +131,10 @@ export async function POST(req: NextRequest) {
         }
 
         if (!ALLOWED_EVENTS.has(body.event_name)) {
+          logger.warn("event.rejected", {
+            reason: "unknown_event",
+            event_name: body.event_name,
+          });
           return NextResponse.json(
             { error: `unknown event: ${body.event_name}` },
             { status: 422 }
@@ -128,6 +143,7 @@ export async function POST(req: NextRequest) {
 
         const occurredAt = clampString(body.occurred_at, 64);
         if (!occurredAt) {
+          logger.warn("event.rejected", { reason: "missing_occurred_at" });
           return NextResponse.json(
             { error: "occurred_at is required on envelope" },
             { status: 400 }
@@ -136,24 +152,19 @@ export async function POST(req: NextRequest) {
 
         const sanitizedPayload = sanitizePayload(body.event_name, body.payload);
         if (!sanitizedPayload) {
+          logger.warn("event.rejected", {
+            reason: "invalid_catalog_payload",
+            event_name: body.event_name,
+          });
           return NextResponse.json({ error: "invalid payload" }, { status: 400 });
         }
 
-        const entry = {
-          level: "info",
-          event_name: body.event_name,
-          occurred_at: occurredAt,
-          payload: sanitizedPayload,
-          emitted_by: clampString(body.emitted_by, 32) ?? "client",
-          schema_version: clampString(body.schema_version, 16) ?? "1.0.0",
-          correlation_id:
-            normalizeCorrelationId(body.correlation_id) ?? correlationId,
-          received_at: new Date().toISOString(),
-          product_id: PRODUCT_ID,
-          slice_id: SHELL_SLICE_ID,
-        };
+        const emittedBy = clampString(body.emitted_by, 32) ?? "client";
+        const schemaVersion = clampString(body.schema_version, 16) ?? "1.0.0";
+        const resolvedCorrelationId =
+          normalizeCorrelationId(body.correlation_id) ?? correlationId;
 
-        correlationId = entry.correlation_id;
+        correlationId = resolvedCorrelationId;
         setMonitoringTag("product_id", PRODUCT_ID);
         setMonitoringTag("slice_id", SHELL_SLICE_ID);
         setMonitoringTag("feature", body.event_name);
@@ -161,7 +172,13 @@ export async function POST(req: NextRequest) {
           setMonitoringTag("correlation_id", correlationId);
         }
 
-        console.log(JSON.stringify(entry));
+        logger.info("event.received", {
+          event_name: body.event_name,
+          occurred_at: occurredAt,
+          emitted_by: emittedBy,
+          schema_version: schemaVersion,
+          correlation_id: resolvedCorrelationId ?? undefined,
+        });
 
         return NextResponse.json(
           { ok: true, correlation_id: correlationId },
@@ -170,6 +187,9 @@ export async function POST(req: NextRequest) {
       }
     );
   } catch (error) {
+    logger.error("event.handler_error", {
+      correlation_id: correlationId ?? undefined,
+    });
     captureError(error, {
       feature: "events_api",
       extra: { ...(correlationId ? { correlation_id: correlationId } : {}) },

--- a/products/dashboard/app/api/events/route.ts
+++ b/products/dashboard/app/api/events/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { captureError, createLogger, startSpan, setMonitoringTag } from "@/lib/monitoring";
+import { normalizeCorrelationId } from "@/lib/correlation";
 import {
   CORRELATION_HEADER,
   PRODUCT_ID,
@@ -35,16 +36,6 @@ function clampString(value: unknown, max = 64): string | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
   return trimmed.slice(0, max);
-}
-
-/** Accept only well-formed UUID v1–v5; reject everything else. */
-function normalizeCorrelationId(value: unknown): string | null {
-  if (typeof value !== "string") return null;
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-    value
-  )
-    ? value
-    : null;
 }
 
 /** Validate and sanitize catalog payload only (`occurred_at` lives on the envelope per policy). */
@@ -74,12 +65,14 @@ function sanitizePayload(
 }
 
 export async function POST(req: NextRequest) {
-  let correlationId: string | null = req.headers.get(CORRELATION_HEADER);
+  // Normalize the header once so every downstream use (logger, tags, response)
+  // shares a single validated value and the raw input never re-enters.
+  let correlationId: string | null = normalizeCorrelationId(
+    req.headers.get(CORRELATION_HEADER)
+  );
 
-  // Scoped logger — normalize the header before binding so malformed IDs
-  // never fragment correlation in Sentry Logs.
   const logger = createLogger({
-    correlation_id: normalizeCorrelationId(correlationId) ?? undefined,
+    correlation_id: correlationId ?? undefined,
     feature: "api.events",
   });
 

--- a/products/dashboard/app/api/sentry-test/route.ts
+++ b/products/dashboard/app/api/sentry-test/route.ts
@@ -1,4 +1,5 @@
 import { captureError, createLogger, startSpan, flush } from "@/lib/monitoring";
+import { normalizeCorrelationId } from "@/lib/correlation";
 import { NextResponse } from "next/server";
 import {
   CORRELATION_HEADER,
@@ -6,17 +7,10 @@ import {
   SHELL_SLICE_ID,
 } from "@/lib/sentry";
 
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
 export async function GET(req: Request) {
-  const rawCorrelationId = req.headers.get(CORRELATION_HEADER);
   // Normalize before binding to the logger so malformed header values
   // never fragment correlation in Sentry Logs.
-  const correlationId =
-    rawCorrelationId && UUID_RE.test(rawCorrelationId)
-      ? rawCorrelationId
-      : null;
+  const correlationId = normalizeCorrelationId(req.headers.get(CORRELATION_HEADER));
 
   const logger = createLogger({
     correlation_id: correlationId ?? undefined,

--- a/products/dashboard/app/api/sentry-test/route.ts
+++ b/products/dashboard/app/api/sentry-test/route.ts
@@ -1,4 +1,4 @@
-import { captureError, startSpan, flush } from "@/lib/monitoring";
+import { captureError, createLogger, startSpan, flush } from "@/lib/monitoring";
 import { NextResponse } from "next/server";
 import {
   CORRELATION_HEADER,
@@ -8,6 +8,11 @@ import {
 
 export async function GET(req: Request) {
   const correlationId = req.headers.get(CORRELATION_HEADER);
+
+  const logger = createLogger({
+    correlation_id: correlationId ?? undefined,
+    feature: "api.sentry-test",
+  });
 
   return await startSpan(
     {
@@ -19,6 +24,8 @@ export async function GET(req: Request) {
       },
     },
     async () => {
+      logger.info("sentry.test.triggered", { route: "/api/sentry-test" });
+
       const error = new Error("Sentry server test");
       captureError(error, {
         feature: "sentry_test",
@@ -27,6 +34,8 @@ export async function GET(req: Request) {
           ...(correlationId ? { correlation_id: correlationId } : {}),
         },
       });
+
+      logger.error("sentry.test.error_captured", { route: "/api/sentry-test" });
 
       await flush(2000);
 

--- a/products/dashboard/app/api/sentry-test/route.ts
+++ b/products/dashboard/app/api/sentry-test/route.ts
@@ -6,8 +6,17 @@ import {
   SHELL_SLICE_ID,
 } from "@/lib/sentry";
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export async function GET(req: Request) {
-  const correlationId = req.headers.get(CORRELATION_HEADER);
+  const rawCorrelationId = req.headers.get(CORRELATION_HEADER);
+  // Normalize before binding to the logger so malformed header values
+  // never fragment correlation in Sentry Logs.
+  const correlationId =
+    rawCorrelationId && UUID_RE.test(rawCorrelationId)
+      ? rawCorrelationId
+      : null;
 
   const logger = createLogger({
     correlation_id: correlationId ?? undefined,

--- a/products/dashboard/lib/correlation.ts
+++ b/products/dashboard/lib/correlation.ts
@@ -44,6 +44,19 @@ function safeSessionSet(key: string, value: string): void {
 const CORRELATION_ID_MAX_LEN = 128;
 const CORRELATION_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
 
+const UUID_V1_V5_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Accept only well-formed UUID v1–v5; return null for everything else.
+ * Use this on inbound server headers before binding to logger context or
+ * Sentry tags so malformed values never fragment correlation in Sentry Logs.
+ */
+export function normalizeCorrelationId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return UUID_V1_V5_RE.test(value) ? value : null;
+}
+
 /** Reject malformed persisted IDs so headers and Sentry tags stay safe and bounded. */
 function sanitizeCorrelationId(value: string | null): string | null {
   if (value == null) return null;

--- a/products/dashboard/lib/events.ts
+++ b/products/dashboard/lib/events.ts
@@ -1,4 +1,4 @@
-import { captureError, startSpan } from "@/lib/monitoring";
+import { captureError, createLogger, startSpan } from "@/lib/monitoring";
 import {
   applyBrowserObservabilityContext,
   getBrowserCorrelationHeaders,
@@ -52,6 +52,9 @@ export function emitEvent<T extends EventName>(name: T, payload: EventMap[T]): v
   const correlationId = getBrowserCorrelationId();
   applyBrowserObservabilityContext(name);
 
+  // Client-side logger — correlation_id from the browser session, feature from the event name.
+  const logger = createLogger({ correlation_id: correlationId, feature: name });
+
   void startSpan(
     {
       name: `event.emit ${name}`,
@@ -84,14 +87,14 @@ export function emitEvent<T extends EventName>(name: T, payload: EventMap[T]): v
         if (!res.ok) {
           throw new Error(`HTTP ${res.status}`);
         }
+
+        logger.info("event.emitted", { event_name: name });
       } catch (err) {
+        logger.warn("event.emit_failed", { event_name: name });
         captureError(err, {
           feature: name,
           extra: { correlation_id: correlationId },
         });
-
-        // Non-blocking: telemetry must never break the UI
-        console.warn("[events] emit failed:", name, err);
       }
     }
   );


### PR DESCRIPTION
## Summary

Follows PR #50 (createLogger service). Binds the logger into every existing server and client path so the boilerplate ships with Sentry Logs wired end-to-end — not just available, but actually used.

- **`app/api/events/route.ts`** — `createLogger` scoped to `x-correlation-id` from the inbound header; `logger.info("event.received")` replaces the old `console.log(JSON.stringify(...))` (which went to stdout only); `logger.warn` on every validation rejection path so rejections are queryable in Sentry Logs by `reason` + `correlation_id`
- **`app/api/sentry-test/route.ts`** — `createLogger` with `correlation_id`; logs `sentry.test.triggered` / `sentry.test.error_captured` lifecycle around `captureError`
- **`lib/events.ts`** — `createLogger` bound to `getBrowserCorrelationId()`; `logger.info("event.emitted")` on success, `logger.warn("event.emit_failed")` on error (replaces bare `console.warn`)

Every log line in Sentry Logs is queryable by `correlation_id`, `feature`, `product_id`, `slice_id`.

## Test plan

- [ ] `npx tsc --noEmit` — passes (confirmed locally)
- [ ] Load dashboard → navigate between phases → verify `event.emitted` / `event.received` log lines appear in Sentry Logs with matching `correlation_id`
- [ ] Hit `/api/events` with a malformed body → verify `event.rejected` warning appears in Sentry Logs with `reason` attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved structured logging and error tracking across dashboard APIs and client-side event emission to boost observability and reliability.
  * Correlation IDs are now normalized and included in logs to improve traceability of requests and errors.
  * Validation failures and handler errors now produce specific, structured warning/error logs with reasons.
  * A diagnostics route now emits correlated info/error logs when invoked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->