### PR TITLE
Relax dashboard PostHog person profiles

### DIFF
--- a/docs/ANALYTICS_STANDARD.md
+++ b/docs/ANALYTICS_STANDARD.md
@@ -84,7 +84,7 @@ If a property would allow you to identify a specific person without their UUID, 
 - Optional `traits`: only `plan` and `created_at` (ISO date string). Nothing else.
 - Call `resetIdentity()` on sign-out so the next anonymous session is not linked to the previous user.
 - **Never call `posthog.identify()` directly** in feature code. Use `identifyUser()`.
-- `person_profiles: 'identified_only'` is set at init time — PostHog will not create a profile for anonymous users. Identity only exists after `identifyUser()` is called.
+- `person_profiles: 'always'` is set at init time — PostHog may create profiles before `identifyUser()` is called, so anonymous sessions can still accumulate profile history before sign-in.
 
 ---
 

--- a/products/dashboard/instrumentation-client.ts
+++ b/products/dashboard/instrumentation-client.ts
@@ -60,7 +60,7 @@ if (posthogToken) {
     ui_host: "https://eu.posthog.com",
     capture_pageview: "history_change",
     capture_pageleave: true,
-    person_profiles: "identified_only",
+    person_profiles: "always",
     session_recording: {
       maskAllInputs: true,
       maskTextSelector: "[data-ph-mask]",


### PR DESCRIPTION
## Summary
- change the dashboard PostHog browser client to use person_profiles: "always"
- update the analytics standard so the documented profile behavior matches runtime
- base the change on the latest origin/main

## Verification
- npm run validate
- npx tsc --noEmit in products/dashboard

## Notes
- npm run lint in products/dashboard is currently interactive because Next.js prompts to configure ESLint in this app when no ESLint config is present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics tracking configuration to capture profile history for anonymous users prior to sign-in, enabling better visibility into complete user journeys.
  * Updated documentation to reflect the revised analytics tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->