### PR TITLE
Revert PostHog profile change and set CodeRabbit profile to chill

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
 reviews:
-  profile: "assertive"
+  profile: "chill"
   high_level_summary: true
   review_status: true
   collapse_walkthrough: false

--- a/docs/ANALYTICS_STANDARD.md
+++ b/docs/ANALYTICS_STANDARD.md
@@ -84,7 +84,7 @@ If a property would allow you to identify a specific person without their UUID, 
 - Optional `traits`: only `plan` and `created_at` (ISO date string). Nothing else.
 - Call `resetIdentity()` on sign-out so the next anonymous session is not linked to the previous user.
 - **Never call `posthog.identify()` directly** in feature code. Use `identifyUser()`.
-- `person_profiles: 'always'` is set at init time — PostHog may create profiles before `identifyUser()` is called, so anonymous sessions can still accumulate profile history before sign-in.
+- `person_profiles: 'identified_only'` is set at init time — PostHog will not create a profile for anonymous users. Identity only exists after `identifyUser()` is called.
 
 ---
 

--- a/products/dashboard/instrumentation-client.ts
+++ b/products/dashboard/instrumentation-client.ts
@@ -60,7 +60,7 @@ if (posthogToken) {
     ui_host: "https://eu.posthog.com",
     capture_pageview: "history_change",
     capture_pageleave: true,
-    person_profiles: "always",
+    person_profiles: "identified_only",
     session_recording: {
       maskAllInputs: true,
       maskTextSelector: "[data-ph-mask]",


### PR DESCRIPTION
## Summary
- revert the merged dashboard PostHog person_profiles change back to identified_only
- restore the matching analytics documentation
- change .coderabbit.yaml from reviews.profile: "assertive" to "chill"
- base the branch on the latest origin/main

## Verification
- npm run validate

## Confirmation
- .coderabbit.yaml on main had profile: "assertive"
- CodeRabbit docs list chill as a valid, less aggressive review profile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to use a more relaxed review profile ("assertive" → "chill"); other review settings remain unchanged. No public or exported code entities were modified. This change adjusts review tone and has low operational impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->