### PR TITLE
fix: correct CodeRabbit ignore pattern for release-please PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -21,6 +21,6 @@ reviews:
     enabled: true
     drafts: false
     ignore_title_patterns:
-      - "^chore\\(main\\): release"
+      - "^chore: release"
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,7 +20,7 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-    ignore_title_patterns:
-      - "^chore: release"
+    ignore_title_keywords:
+      - "chore: release"
 chat:
   auto_reply: true

--- a/ai/MEMORY.md
+++ b/ai/MEMORY.md
@@ -65,7 +65,7 @@ This file stores durable repository memory for agents. It is not a transcript an
 - 2026-04-13: Standardized dashboard release telemetry on a single app-release value derived from root `version.txt` for production builds and commit SHA fallback elsewhere; Sentry release sync on GitHub `release.published` is optional and activates only when Sentry secrets/vars are configured.
 - 2026-04-13: Established single-release-source principle for Sentry configurations: one `const release = getServerSentryRelease()` call drives both `Sentry.init({ release })` and `initialScope.tags.app_release` so the two values can never diverge when `SENTRY_RELEASE` is overridden externally. Never call `getAppRelease()` and a Sentry-specific resolver separately and assign them to different fields.
 - 2026-04-13: Standardized file-path resolution for repo-root artifacts consumed by nested packages: use `__dirname`-relative candidate paths (primary: `path.resolve(__dirname, "../../version.txt")`; fallback: `path.resolve(__dirname, "version.txt")`) rather than `process.cwd()`-relative paths so lookups are stable across build entrypoints regardless of invocation directory.
-- 2026-04-13: Configured CodeRabbit to skip automated review of release-please PRs via `ignore_title_patterns: ["^chore\\(main\\): release"]` in `.coderabbit.yaml` to eliminate review overhead on machine-generated release commits.
+- 2026-04-13: Configured CodeRabbit to skip automated review of release-please PRs via `ignore_title_patterns: ["^chore: release"]` in `.coderabbit.yaml` to eliminate review overhead on machine-generated release commits. Pattern matches the configured `pull-request-title-pattern` in `release-please-config.json` (`"chore: release ${version}"`).
 
 ## Update Rules
 


### PR DESCRIPTION
## Summary

The pattern `^chore\(main\): release` set in PR #58 never matches because `release-please-config.json` sets `pull-request-title-pattern` to `"chore: release ${version}"` — there is no branch name in parentheses.

Corrected to `^chore: release` to match the actual title format (e.g. `chore: release 0.2.0`).

Also updates the dated decision in `ai/MEMORY.md` to record the correct pattern with context on why it's shaped this way.

## Separate action needed — `RELEASE_PLEASE_TOKEN`

The release-please workflow is also currently skipping entirely because `RELEASE_PLEASE_TOKEN` is not set as a repository secret. You'll need to:
1. Create a PAT (or GitHub App token) with `contents: write` and `pull-requests: write` scopes
2. Add it as a repository secret named `RELEASE_PLEASE_TOKEN`

Until that's done, no release PRs or tags will be created on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated review configuration to correctly recognize and exclude release PRs using the literal title keyword "chore: release", preventing them from being flagged by draft review automation.
  * Updated documentation and guidance to reflect the configured release PR title pattern so contributors and tools use the same convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->