### PR TITLE
feat(dashboard): change Design phase color from purple to blue

### DIFF
--- a/products/dashboard/app/design/page.tsx
+++ b/products/dashboard/app/design/page.tsx
@@ -11,7 +11,7 @@ export default function DesignPage() {
         <Card>
           <CardHeader>
             <div className="flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-violet-100 text-violet-600">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-100 text-blue-600">
                 <PenLine className="h-5 w-5" />
               </div>
               <div>

--- a/products/dashboard/components/hello-world-card.tsx
+++ b/products/dashboard/components/hello-world-card.tsx
@@ -37,7 +37,7 @@ export function HelloWorldCard() {
         <div className="mt-5 grid grid-cols-3 gap-3">
           {[
             { label: "Ideation", href: "/ideation", color: "bg-amber-50 text-amber-700 border-amber-100" },
-            { label: "Design", href: "/design", color: "bg-violet-50 text-violet-700 border-violet-100" },
+            { label: "Design", href: "/design", color: "bg-blue-50 text-blue-700 border-blue-100" },
             { label: "Implementation", href: "/implementation", color: "bg-emerald-50 text-emerald-700 border-emerald-100" },
           ].map(({ label, href, color }) => (
             <Link

--- a/products/dashboard/components/sidebar.tsx
+++ b/products/dashboard/components/sidebar.tsx
@@ -21,8 +21,8 @@ const phases = [
     label: "Design",
     href: "/design",
     icon: PenLine,
-    accent: "text-violet-500",
-    activeBg: "bg-violet-50",
+    accent: "text-blue-500",
+    activeBg: "bg-blue-50",
   },
   {
     id: "implementation",


### PR DESCRIPTION
## Summary
- Replaces violet/purple Tailwind classes with blue equivalents across three files in `products/dashboard/`
- `hello-world-card.tsx`: `bg-violet-50 text-violet-700 border-violet-100` → `bg-blue-50 text-blue-700 border-blue-100`
- `sidebar.tsx`: `text-violet-500 bg-violet-50` → `text-blue-500 bg-blue-50`
- `design/page.tsx`: `bg-violet-100 text-violet-600` → `bg-blue-100 text-blue-600`

## Test plan
- [ ] `npm run validate` passes (confirmed locally)
- [ ] Design phase card on home page shows blue instead of purple
- [ ] Sidebar Design item accent and active background are blue
- [ ] Design page icon is blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated dashboard color palette from violet to blue across the design page, navigation cards, and sidebar components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->