### PR TITLE
ci(dashboard): upload Vitest LCOV to Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ name: test
 # (or this workflow). release-please version/changelog PRs skip this job; Mergify
 # merges those via the `release-please` queue without a `test` check.
 # This is a BLOCKING merge gate per docs/QUALITY_STANDARD.md §6.1.
+# Coverage uploads to Codecov when CODECOV_TOKEN is set (see codecov.yml);
+# Codecov status is informational by default and does not add a merge gate.
 #
 # Job name "test" is the check name that Mergify requires.
 
@@ -12,10 +14,12 @@ on:
     branches: [main]
     paths:
       - "products/dashboard/**"
+      - "codecov.yml"
   pull_request:
     paths:
       - "products/dashboard/**"
       - ".github/workflows/test.yml"
+      - "codecov.yml"
   workflow_dispatch:
 
 concurrency:
@@ -46,6 +50,15 @@ jobs:
 
       - name: Run Vitest (unit + component + integration) with coverage
         run: npm run test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: products/dashboard/coverage/lcov.info
+          flags: dashboard
+          name: dashboard-vitest
+          fail_ci_if_error: false
 
       - name: Upload coverage report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules/
 products/dashboard/.next/
 products/dashboard/out/
 products/dashboard/.vercel
+products/dashboard/coverage/
 
 # Build output
 dist/

--- a/ai/playbooks/repository-foundation.md
+++ b/ai/playbooks/repository-foundation.md
@@ -47,6 +47,8 @@ At the end of this playbook, the repository should have:
 
 For this repository, the required validation command is `npm run validate` and the required check context is `validate`.
 
+When the golden dashboard (`products/dashboard`) is present, Vitest coverage may upload to **Codecov** from the `test` workflow. Store the repository upload token as the GitHub Actions secret `CODECOV_TOKEN`, and keep Codecov’s GitHub check **informational** unless branch protection intentionally requires it (this repository defaults to informational status in `codecov.yml`). For Dependabot pull requests, duplicate the secret under **Dependabot secrets** if uploads should run on those PRs.
+
 ## 3. Add repository governance files
 
 Create the following files before broader collaboration begins:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+# Codecov configuration for products/dashboard Vitest (LCOV).
+# Upload token: GitHub Actions secret CODECOV_TOKEN (repository settings).
+# https://docs.codecov.com/docs/codecov-yaml
+#
+# Vitest writes SF: paths relative to products/dashboard; prefix so they match git.
+fixes:
+  - "::products/dashboard/"
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/docs/QUALITY_STANDARD.md
+++ b/docs/QUALITY_STANDARD.md
@@ -65,6 +65,7 @@ These are the blessed defaults for the golden product (`products/dashboard`). Do
 | Error monitoring | **Sentry** | See `docs/ANALYTICS_STANDARD.md §9`; already required; Sentry is the source of truth for production error rates |
 | Product analytics | **PostHog** | See `docs/ANALYTICS_STANDARD.md`; funnel and retention data drives the production verification loop |
 | Preview environments | **Vercel preview deployments** | Per-PR preview URLs enable smoke verification before merge and release |
+| Coverage aggregation | **Codecov** (optional) | LCOV from Vitest uploads on PR/main for trends and patch comments; configured as a non-blocking signal via `codecov.yml` unless the team tightens thresholds in Codecov |
 
 **AI evals** do not have a single default tool. Use a structured eval runner (custom scripts, LangSmith, or equivalent) that:
 
@@ -176,6 +177,7 @@ In this repository, these conceptual gates map to the required CI checks as foll
 
 ### 6.2 Non-blocking checks (run on PR, failures tracked but do not block)
 
+- Codecov coverage upload and PR comments (LCOV from `products/dashboard` Vitest; project/patch status is **informational** in `codecov.yml` unless changed in Codecov settings)
 - Full integration suite (runs async or in a parallel non-required job)
 - Full E2E suite
 - Non-critical accessibility scan

--- a/products/dashboard/vitest.config.ts
+++ b/products/dashboard/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     exclude: ["node_modules", ".next", "e2e/**", "**/*.spec.ts", "**/*.spec.tsx"],
     coverage: {
       provider: "v8",
-      reporter: ["text", "json", "html"],
+      reporter: ["text", "json", "html", "lcov"],
       exclude: ["node_modules", ".next", "e2e", "tests/msw", "*.config.*"],
     },
   },


### PR DESCRIPTION
## Summary
Wire Codecov for `products/dashboard` Vitest coverage: LCOV output, GitHub Actions upload (`codecov/codecov-action@v5`), and root `codecov.yml` with informational project/patch status plus path fixes for monorepo layout.

## Additional changes
- Ignore `products/dashboard/coverage/` in git (generated artifacts).
- Document Codecov in `docs/QUALITY_STANDARD.md` and `ai/playbooks/repository-foundation.md` (`CODECOV_TOKEN`, Dependabot secret note).

## Verification
- `npm run validate`
- `npm run test:coverage` in `products/dashboard`

**Note:** Requires repository secret `CODECOV_TOKEN` (already configured per operator).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quality standards to include Codecov as an optional tool for code coverage tracking and PR reporting.
  * Added repository foundation guidance for configuring Codecov with dashboard tests.

* **Chores**
  * Configured automated code coverage reporting through Codecov for dashboard test uploads.
  * Enhanced test infrastructure to generate coverage reports in standard format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->