### PR TITLE
fix(codecov): remove duplicate products/dashboard path prefix

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,9 @@
 # Upload token: GitHub Actions secret CODECOV_TOKEN (repository settings).
 # https://docs.codecov.com/docs/codecov-yaml
 #
-# Vitest writes SF: paths relative to products/dashboard; prefix so they match git.
-fixes:
-  - "::products/dashboard/"
+# Do not add `fixes` to prefix `products/dashboard/` here: CI LCOV uses absolute paths
+# under the repo checkout, and Codecov already normalizes them to the git tree. A
+# `::products/dashboard/` fix duplicates the segment in the Codecov UI.
 
 coverage:
   status:


### PR DESCRIPTION
## Problem
Codecov showed `products / dashboard / products / dashboard / …` in the file tree.

## Cause
LCOV from GitHub Actions uses absolute paths under the repo checkout. Codecov normalizes those to the git tree (`products/dashboard/...`) on its own. The `fixes: - "::products/dashboard/"` entry prepended the segment again.

## Change
Remove the `fixes` block and document why it must stay absent.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Codecov configuration to remove the path normalization rule, allowing Codecov to use its default handling of coverage report file paths from CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->