### PR TITLE
fix(dashboard): bypass ingest and monitoring auth middleware

### DIFF
--- a/products/dashboard/__tests__/middleware/auth.test.ts
+++ b/products/dashboard/__tests__/middleware/auth.test.ts
@@ -3,7 +3,7 @@
  * Tests for middleware.ts — auth and correlation-ID behavior
  *
  * Covers:
- * - Public paths (/login, /auth/callback) bypass auth entirely
+ * - Public paths (/login, /auth/callback, /ingest, /monitoring) bypass auth entirely
  * - Unauthenticated requests → redirect to /login
  * - Authenticated requests → pass through with correlation ID
  * - Session refresh: middleware forwards new cookies when Supabase refreshes a token
@@ -57,6 +57,18 @@ describe("middleware — public paths bypass auth", () => {
 
   it("passes /auth/callback through without calling getUser", async () => {
     const res = await middleware(makeReq("/auth/callback"));
+    expect(mockGetCurrentUserForRequest).not.toHaveBeenCalled();
+    expect(res.status).not.toBe(307);
+  });
+
+  it("passes /ingest static proxy requests through without calling getUser", async () => {
+    const res = await middleware(makeReq("/ingest/array/test/config.js"));
+    expect(mockGetCurrentUserForRequest).not.toHaveBeenCalled();
+    expect(res.status).not.toBe(307);
+  });
+
+  it("passes /monitoring tunnel requests through without calling getUser", async () => {
+    const res = await middleware(makeReq("/monitoring"));
     expect(mockGetCurrentUserForRequest).not.toHaveBeenCalled();
     expect(res.status).not.toBe(307);
   });

--- a/products/dashboard/__tests__/middleware/auth.test.ts
+++ b/products/dashboard/__tests__/middleware/auth.test.ts
@@ -73,6 +73,32 @@ describe("middleware — public paths bypass auth", () => {
     expect(res.status).not.toBe(307);
   });
 
+  it("does not treat /ingestion as a public ingest route", async () => {
+    mockGetCurrentUserForRequest.mockResolvedValue({
+      user: null,
+      response: new Response() as never,
+    });
+
+    const res = await middleware(makeReq("/ingestion"));
+
+    expect(mockGetCurrentUserForRequest).toHaveBeenCalled();
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/login");
+  });
+
+  it("does not treat /monitoring-tools as a public monitoring route", async () => {
+    mockGetCurrentUserForRequest.mockResolvedValue({
+      user: null,
+      response: new Response() as never,
+    });
+
+    const res = await middleware(makeReq("/monitoring-tools"));
+
+    expect(mockGetCurrentUserForRequest).toHaveBeenCalled();
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/login");
+  });
+
   it("passes /login with auth_callback_failed query through without calling getUser", async () => {
     const res = await middleware(makeReq("/login?error=auth_callback_failed"));
     expect(mockGetCurrentUserForRequest).not.toHaveBeenCalled();

--- a/products/dashboard/middleware.ts
+++ b/products/dashboard/middleware.ts
@@ -3,7 +3,8 @@ import type { NextRequest } from "next/server";
 import { CORRELATION_HEADER } from "@/lib/sentry";
 import { getCurrentUserForRequest } from "@/lib/auth/service.server";
 
-const PUBLIC_PATH_PREFIXES = ["/login", "/auth/callback", "/ingest", "/monitoring"];
+const EXACT_PUBLIC_PATHS = new Set(["/login", "/auth/callback"]);
+const PUBLIC_PATH_PREFIXES = ["/ingest", "/monitoring"];
 
 export async function middleware(req: NextRequest) {
   // Inject / propagate correlation ID
@@ -12,9 +13,15 @@ export async function middleware(req: NextRequest) {
     requestHeaders.get(CORRELATION_HEADER) ?? crypto.randomUUID();
   requestHeaders.set(CORRELATION_HEADER, correlationId);
 
-  // Skip auth check for public paths
+  // Skip auth checks for exact public routes and observability endpoints.
   const { pathname } = req.nextUrl;
-  if (PUBLIC_PATH_PREFIXES.some((p) => pathname.startsWith(p))) {
+  const isPublicPath =
+    EXACT_PUBLIC_PATHS.has(pathname) ||
+    PUBLIC_PATH_PREFIXES.some(
+      (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+    );
+
+  if (isPublicPath) {
     const response = NextResponse.next({ request: { headers: requestHeaders } });
     response.headers.set(CORRELATION_HEADER, correlationId);
     return response;
@@ -36,5 +43,7 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|ingest|monitoring).*)"],
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|ingest(?:/|$)|monitoring(?:/|$)).*)",
+  ],
 };

--- a/products/dashboard/middleware.ts
+++ b/products/dashboard/middleware.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from "next/server";
 import { CORRELATION_HEADER } from "@/lib/sentry";
 import { getCurrentUserForRequest } from "@/lib/auth/service.server";
 
-const PUBLIC_PATHS = ["/login", "/auth/callback"];
+const PUBLIC_PATH_PREFIXES = ["/login", "/auth/callback", "/ingest", "/monitoring"];
 
 export async function middleware(req: NextRequest) {
   // Inject / propagate correlation ID
@@ -14,7 +14,7 @@ export async function middleware(req: NextRequest) {
 
   // Skip auth check for public paths
   const { pathname } = req.nextUrl;
-  if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+  if (PUBLIC_PATH_PREFIXES.some((p) => pathname.startsWith(p))) {
     const response = NextResponse.next({ request: { headers: requestHeaders } });
     response.headers.set(CORRELATION_HEADER, correlationId);
     return response;
@@ -36,5 +36,5 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|ingest|monitoring).*)"],
 };


### PR DESCRIPTION
## Summary
- bypass auth middleware for `/ingest` PostHog proxy requests and `/monitoring` Sentry tunnel requests
- exclude those observability routes from the middleware matcher so asset and tunnel traffic never gets redirected to `/login`
- add middleware regression tests covering both public observability paths

## Why
Sentry issue 113019094 shows `SyntaxError: Unexpected token '<'` on `/login` from `app:///ingest/.../config.js`. The middleware was redirecting `/ingest/*` to `/login`, so the browser received HTML instead of JavaScript.

## Verification
- `npm test -- --run __tests__/middleware/auth.test.ts` in `products/dashboard`
- `npm run validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for public paths that bypass authentication, adding cases for `/ingest/*` and `/monitoring`, and negative cases ensuring similar paths are not treated as public.

* **Chores**
  * Updated authentication middleware to treat `/ingest/*` and `/monitoring` as public endpoints (excluded from auth), while preserving request tracking behavior for bypassed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->