### PR TITLE
feat(dashboard): theme tokens + dark-first globals (AEL-45)

### DIFF
--- a/products/dashboard/__tests__/lib/theme.test.ts
+++ b/products/dashboard/__tests__/lib/theme.test.ts
@@ -68,6 +68,22 @@ describe("useTheme", () => {
     const { result } = renderHook(() => useTheme());
     expect(result.current.theme).toBe(DEFAULT_THEME);
   });
+
+  it("shares state across consumers — one consumer's update reaches every other", () => {
+    // Two independent renderHook calls model two components mounting
+    // useTheme() side-by-side. With per-instance state they would drift
+    // after the first toggle; the shared store keeps them coherent.
+    const a = renderHook(() => useTheme());
+    const b = renderHook(() => useTheme());
+
+    act(() => a.result.current.setTheme("light"));
+    expect(a.result.current.theme).toBe("light");
+    expect(b.result.current.theme).toBe("light");
+
+    act(() => b.result.current.toggleTheme());
+    expect(a.result.current.theme).toBe("dark");
+    expect(b.result.current.theme).toBe("dark");
+  });
 });
 
 describe("THEME_INIT_SCRIPT", () => {

--- a/products/dashboard/__tests__/lib/theme.test.ts
+++ b/products/dashboard/__tests__/lib/theme.test.ts
@@ -15,8 +15,8 @@ import {
   DEFAULT_THEME,
   THEME_INIT_SCRIPT,
   THEME_STORAGE_KEY,
-  useTheme,
-} from "@/lib/theme";
+} from "@/lib/theme-tokens";
+import { useTheme } from "@/lib/theme";
 
 function resetDom() {
   document.documentElement.removeAttribute("data-theme");

--- a/products/dashboard/__tests__/lib/theme.test.ts
+++ b/products/dashboard/__tests__/lib/theme.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for lib/theme.ts.
+ *
+ * Spec anchor: AEL-45 — PR 2 (Theme tokens + dark-first globals).
+ *
+ * The hook is the canonical client-side surface for reading and writing the
+ * dashboard theme. These tests pin the contract so later slices (toggle UI,
+ * Settings page, server-rendered themed components) can rely on it.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import {
+  DEFAULT_THEME,
+  THEME_INIT_SCRIPT,
+  THEME_STORAGE_KEY,
+  useTheme,
+} from "@/lib/theme";
+
+function resetDom() {
+  document.documentElement.removeAttribute("data-theme");
+  window.localStorage.clear();
+}
+
+describe("useTheme", () => {
+  beforeEach(() => {
+    resetDom();
+  });
+
+  it("defaults to dark when no DOM attribute is present", () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe(DEFAULT_THEME);
+  });
+
+  it("syncs with the data-theme attribute applied before mount", () => {
+    document.documentElement.setAttribute("data-theme", "light");
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("light");
+  });
+
+  it("setTheme writes data-theme and persists to localStorage", () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setTheme("light"));
+
+    expect(result.current.theme).toBe("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+  });
+
+  it("toggleTheme flips dark <-> light and persists", () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.toggleTheme());
+    expect(result.current.theme).toBe("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+
+    act(() => result.current.toggleTheme());
+    expect(result.current.theme).toBe("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+  });
+
+  it("ignores unrecognised stored values and falls back to default", () => {
+    document.documentElement.setAttribute("data-theme", "neon");
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe(DEFAULT_THEME);
+  });
+});
+
+describe("THEME_INIT_SCRIPT", () => {
+  beforeEach(() => {
+    resetDom();
+  });
+
+  it("applies the persisted theme before paint", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "light");
+
+    new Function(THEME_INIT_SCRIPT)();
+
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("falls back to the default when no preference is stored", () => {
+    new Function(THEME_INIT_SCRIPT)();
+    expect(document.documentElement.getAttribute("data-theme")).toBe(DEFAULT_THEME);
+  });
+
+  it("falls back to the default for unrecognised stored values", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "neon");
+    new Function(THEME_INIT_SCRIPT)();
+    expect(document.documentElement.getAttribute("data-theme")).toBe(DEFAULT_THEME);
+  });
+});

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -1,25 +1,150 @@
 @import "tailwindcss";
 
+/*
+ * Theme tokens.
+ *
+ * Source of truth: the Process Canvas prototype
+ * (`/tmp/design-canvas/ai-native-dashboard/project/Process Canvas.html`,
+ * `[data-theme="dark"]` and `[data-theme="light"]` blocks). Keep these
+ * variable values in sync with that file when the prototype evolves.
+ *
+ * The `[data-theme="..."]` blocks define the runtime token values; the
+ * `@theme inline` block below aliases each token onto a Tailwind v4 utility
+ * (e.g. `bg-bg`, `text-t1`, `border-border`) so feature code can stay in
+ * Tailwind's utility model while still flipping themes at runtime.
+ */
+
+[data-theme="dark"] {
+  --bg: #070d1a;
+  --bg-2: #0c1525;
+  --bg-3: #101c30;
+  --bg-4: #16253d;
+  --bg-5: #1d2f4a;
+
+  --border: rgba(255, 255, 255, 0.07);
+  --border-2: rgba(255, 255, 255, 0.04);
+  --border-hi: rgba(255, 255, 255, 0.12);
+
+  --t1: #e2e8f0;
+  --t2: #64748b;
+  --t3: #334155;
+
+  --primary: #6366f1;
+  --primary-bg: rgba(99, 102, 241, 0.1);
+  --accent: #818cf8;
+
+  --shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
+  --matrix-head: rgba(7, 13, 26, 0.97);
+  --overlay: rgba(0, 0, 0, 0.55);
+
+  --pill-complete-bg: rgba(16, 185, 129, 0.12);
+  --pill-complete-t: #34d399;
+  --pill-complete-d: #10b981;
+
+  --pill-active-bg: rgba(99, 102, 241, 0.12);
+  --pill-active-t: #818cf8;
+  --pill-active-d: #6366f1;
+
+  --pill-pending-bg: rgba(245, 158, 11, 0.12);
+  --pill-pending-t: #fbbf24;
+  --pill-pending-d: #f59e0b;
+
+  --pill-blocked-bg: rgba(239, 68, 68, 0.12);
+  --pill-blocked-t: #f87171;
+  --pill-blocked-d: #ef4444;
+
+  --pill-ns-bg: rgba(255, 255, 255, 0.03);
+  --pill-ns-t: #334155;
+  --pill-ns-d: #1e293b;
+}
+
+[data-theme="light"] {
+  --bg: #ffffff;
+  --bg-2: #f8fafc;
+  --bg-3: #f1f5f9;
+  --bg-4: #e2e8f0;
+  --bg-5: #cbd5e1;
+
+  --border: #e2e8f0;
+  --border-2: rgba(0, 0, 0, 0.04);
+  --border-hi: #cbd5e1;
+
+  --t1: #0f172a;
+  --t2: #475569;
+  --t3: #94a3b8;
+
+  --primary: #6366f1;
+  --primary-bg: rgba(99, 102, 241, 0.07);
+  --accent: #6366f1;
+
+  --shadow: 0 8px 40px rgba(0, 0, 0, 0.1);
+  --matrix-head: rgba(248, 250, 252, 0.97);
+  --overlay: rgba(0, 0, 0, 0.25);
+
+  --pill-complete-bg: #ecfdf5;
+  --pill-complete-t: #059669;
+  --pill-complete-d: #10b981;
+
+  --pill-active-bg: #eef2ff;
+  --pill-active-t: #4f46e5;
+  --pill-active-d: #6366f1;
+
+  --pill-pending-bg: #fffbeb;
+  --pill-pending-t: #d97706;
+  --pill-pending-d: #f59e0b;
+
+  --pill-blocked-bg: #fef2f2;
+  --pill-blocked-t: #dc2626;
+  --pill-blocked-d: #ef4444;
+
+  --pill-ns-bg: #f8fafc;
+  --pill-ns-t: #94a3b8;
+  --pill-ns-d: #e2e8f0;
+}
+
 /* stylelint-disable-next-line scss/at-rule-no-unknown -- Tailwind v4 @theme */
-@theme {
-  --color-background: #ffffff;
-  --color-foreground: #0f172a;
-  --color-muted: #f1f5f9;
-  --color-muted-foreground: #64748b;
-  --color-border: #e2e8f0;
-  --color-sidebar: #f8fafc;
-  --color-sidebar-foreground: #0f172a;
-  --color-sidebar-border: #e2e8f0;
-  --color-sidebar-active: #0f172a;
-  --color-sidebar-active-foreground: #ffffff;
-  --color-primary: #0f172a;
-  --color-primary-foreground: #ffffff;
-  --color-card: #ffffff;
-  --color-card-foreground: #0f172a;
-  --color-accent: #f1f5f9;
-  --color-accent-foreground: #0f172a;
-  --color-ring: #94a3b8;
-  --radius: 0.5rem;
+@theme inline {
+  /* Surfaces */
+  --color-bg: var(--bg);
+  --color-bg-2: var(--bg-2);
+  --color-bg-3: var(--bg-3);
+  --color-bg-4: var(--bg-4);
+  --color-bg-5: var(--bg-5);
+
+  /* Borders */
+  --color-border: var(--border);
+  --color-border-2: var(--border-2);
+  --color-border-hi: var(--border-hi);
+
+  /* Text */
+  --color-t1: var(--t1);
+  --color-t2: var(--t2);
+  --color-t3: var(--t3);
+
+  /* Brand */
+  --color-primary: var(--primary);
+  --color-primary-bg: var(--primary-bg);
+  --color-accent: var(--accent);
+
+  /* Pill states */
+  --color-pill-complete-bg: var(--pill-complete-bg);
+  --color-pill-complete-t: var(--pill-complete-t);
+  --color-pill-complete-d: var(--pill-complete-d);
+  --color-pill-active-bg: var(--pill-active-bg);
+  --color-pill-active-t: var(--pill-active-t);
+  --color-pill-active-d: var(--pill-active-d);
+  --color-pill-pending-bg: var(--pill-pending-bg);
+  --color-pill-pending-t: var(--pill-pending-t);
+  --color-pill-pending-d: var(--pill-pending-d);
+  --color-pill-blocked-bg: var(--pill-blocked-bg);
+  --color-pill-blocked-t: var(--pill-blocked-t);
+  --color-pill-blocked-d: var(--pill-blocked-d);
+  --color-pill-ns-bg: var(--pill-ns-bg);
+  --color-pill-ns-t: var(--pill-ns-t);
+  --color-pill-ns-d: var(--pill-ns-d);
+
+  /* Effects */
+  --shadow-canvas: var(--shadow);
 }
 
 *,
@@ -36,9 +161,13 @@ body {
 }
 
 body {
-  background-color: var(--color-background);
-  color: var(--color-foreground);
+  background-color: var(--bg);
+  color: var(--t1);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
+  /* Smooth theme transitions when the user toggles dark/light. */
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
 }

--- a/products/dashboard/app/layout.tsx
+++ b/products/dashboard/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { getAppRelease, getReleaseChannel } from "@/lib/release";
+import { DEFAULT_THEME, THEME_INIT_SCRIPT } from "@/lib/theme";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/next";
 
@@ -17,9 +18,20 @@ export default function RootLayout({
   const appRelease = getAppRelease();
 
   return (
-    <html lang="en">
+    <html lang="en" data-theme={DEFAULT_THEME}>
+      <head>
+        {/*
+         * Pre-paint theme rehydration. Runs before React hydrates so a
+         * persisted preference replaces the default `data-theme="dark"`
+         * without a visible flash. The script body lives in `lib/theme.ts`
+         * so DOM and storage semantics stay in one place.
+         */}
+        <script
+          dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }}
+        />
+      </head>
       <body
-        className="h-screen flex overflow-hidden"
+        className="h-screen flex overflow-hidden bg-bg text-t1"
         data-release={appRelease}
         data-release-channel={getReleaseChannel()}
       >

--- a/products/dashboard/app/layout.tsx
+++ b/products/dashboard/app/layout.tsx
@@ -23,8 +23,10 @@ export default function RootLayout({
         {/*
          * Pre-paint theme rehydration. Runs before React hydrates so a
          * persisted preference replaces the default `data-theme="dark"`
-         * without a visible flash. The script body lives in `lib/theme.ts`
-         * so DOM and storage semantics stay in one place.
+         * without a visible flash. The script body lives in
+         * `lib/theme-tokens.ts` (server-safe) and the matching client
+         * runtime lives in `lib/theme.ts`, so DOM and storage semantics
+         * stay in one place.
          */}
         <script
           dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }}

--- a/products/dashboard/app/layout.tsx
+++ b/products/dashboard/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { getAppRelease, getReleaseChannel } from "@/lib/release";
-import { DEFAULT_THEME, THEME_INIT_SCRIPT } from "@/lib/theme";
+import { DEFAULT_THEME, THEME_INIT_SCRIPT } from "@/lib/theme-tokens";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/next";
 

--- a/products/dashboard/e2e/theme.spec.ts
+++ b/products/dashboard/e2e/theme.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * Theme rendering checks — login page must render cleanly in both themes.
+ *
+ * Spec anchor: AEL-45 — PR 2 (Theme tokens + dark-first globals).
+ *
+ * The login page intentionally uses a hard-coded dark hero card that does
+ * not flip with `data-theme`. These tests pin the contract that:
+ *   1. The default render is dark (matches `<html data-theme="dark">`).
+ *   2. Toggling `data-theme="light"` does not break the page or hide the
+ *      sign-in form (no visual regression on the only authenticated entry
+ *      surface that exists today).
+ */
+
+import { test, expect } from "@playwright/test";
+
+test.describe("theme — login page renders in both themes", () => {
+  test("default render uses data-theme=\"dark\"", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(page.getByRole("form", { name: /sign in/i })).toBeVisible();
+  });
+
+  test("toggling data-theme=\"light\" leaves the form healthy", async ({ page }) => {
+    await page.goto("/login");
+    await page.evaluate(() =>
+      document.documentElement.setAttribute("data-theme", "light"),
+    );
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await expect(page.getByRole("form", { name: /sign in/i })).toBeVisible();
+  });
+});

--- a/products/dashboard/e2e/theme.spec.ts
+++ b/products/dashboard/e2e/theme.spec.ts
@@ -6,12 +6,14 @@
  * The login page intentionally uses a hard-coded dark hero card that does
  * not flip with `data-theme`. These tests pin the contract that:
  *   1. The default render is dark (matches `<html data-theme="dark">`).
- *   2. Toggling `data-theme="light"` does not break the page or hide the
- *      sign-in form (no visual regression on the only authenticated entry
- *      surface that exists today).
+ *   2. A persisted `theme=light` preference boots the page in light mode
+ *      via the inline pre-paint script — exercising the real entry path
+ *      for a returning user, not just a post-load DOM mutation.
  */
 
 import { test, expect } from "@playwright/test";
+
+const THEME_STORAGE_KEY = "theme";
 
 test.describe("theme — login page renders in both themes", () => {
   test("default render uses data-theme=\"dark\"", async ({ page }) => {
@@ -20,11 +22,18 @@ test.describe("theme — login page renders in both themes", () => {
     await expect(page.getByRole("form", { name: /sign in/i })).toBeVisible();
   });
 
-  test("toggling data-theme=\"light\" leaves the form healthy", async ({ page }) => {
-    await page.goto("/login");
-    await page.evaluate(() =>
-      document.documentElement.setAttribute("data-theme", "light"),
+  test("persisted theme=\"light\" boots the page in light mode", async ({ page }) => {
+    // Seed the persisted preference before any document loads, so the
+    // inline pre-paint script in app/layout.tsx is the thing that flips
+    // data-theme — that is the contract a returning user actually hits.
+    await page.addInitScript(
+      ([key, value]) => {
+        window.localStorage.setItem(key, value);
+      },
+      [THEME_STORAGE_KEY, "light"] as const,
     );
+
+    await page.goto("/login");
     await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
     await expect(page.getByRole("form", { name: /sign in/i })).toBeVisible();
   });

--- a/products/dashboard/lib/theme-tokens.ts
+++ b/products/dashboard/lib/theme-tokens.ts
@@ -1,0 +1,33 @@
+/**
+ * Theme tokens — server-safe surface.
+ *
+ * These constants are imported by both the Server Component root layout
+ * (`app/layout.tsx`) and the client-only `useTheme()` hook in `lib/theme.ts`.
+ * Keeping them in a module with no `"use client"` directive avoids forcing
+ * the layout across a client boundary just to read a couple of strings.
+ *
+ * Do not add browser- or React-only code here. Anything that touches
+ * `document`, `window`, `localStorage`, or React hooks belongs in
+ * `lib/theme.ts`.
+ */
+
+export type Theme = "dark" | "light";
+
+export const DEFAULT_THEME: Theme = "dark";
+
+/** localStorage key used to persist the user's theme preference. */
+export const THEME_STORAGE_KEY = "theme";
+
+/**
+ * Inline script body used by `RootLayout` to rehydrate the persisted theme
+ * before paint. Pure string — safe to embed in a Server Component.
+ */
+export const THEME_INIT_SCRIPT = `(() => {
+  try {
+    const stored = window.localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});
+    const theme = stored === "light" || stored === "dark" ? stored : ${JSON.stringify(DEFAULT_THEME)};
+    document.documentElement.setAttribute("data-theme", theme);
+  } catch {
+    document.documentElement.setAttribute("data-theme", ${JSON.stringify(DEFAULT_THEME)});
+  }
+})();`;

--- a/products/dashboard/lib/theme.ts
+++ b/products/dashboard/lib/theme.ts
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Theme runtime helpers.
+ *
+ * The dashboard ships dark-first: server renders `<html data-theme="dark">`
+ * and an inline pre-paint script in `app/layout.tsx` rehydrates the user's
+ * persisted preference before first paint to avoid a theme flash. This
+ * module is the canonical client-side surface for reading and writing that
+ * preference.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+export type Theme = "dark" | "light";
+
+export const DEFAULT_THEME: Theme = "dark";
+
+/** localStorage key used to persist the user's theme preference. */
+export const THEME_STORAGE_KEY = "theme";
+
+/** Inline script body used by `RootLayout` to rehydrate the persisted theme before paint. */
+export const THEME_INIT_SCRIPT = `(() => {
+  try {
+    const stored = window.localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});
+    const theme = stored === "light" || stored === "dark" ? stored : ${JSON.stringify(DEFAULT_THEME)};
+    document.documentElement.setAttribute("data-theme", theme);
+  } catch {
+    document.documentElement.setAttribute("data-theme", ${JSON.stringify(DEFAULT_THEME)});
+  }
+})();`;
+
+function isTheme(value: unknown): value is Theme {
+  return value === "dark" || value === "light";
+}
+
+function readDomTheme(): Theme {
+  if (typeof document === "undefined") return DEFAULT_THEME;
+  const attr = document.documentElement.getAttribute("data-theme");
+  return isTheme(attr) ? attr : DEFAULT_THEME;
+}
+
+function applyTheme(theme: Theme): void {
+  if (typeof document !== "undefined") {
+    document.documentElement.setAttribute("data-theme", theme);
+  }
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      // Persisting is best-effort. A sandboxed/full storage quota or a
+      // privacy-mode browser still gets a working theme — the in-memory
+      // state and DOM attribute are authoritative for the session.
+    }
+  }
+}
+
+/**
+ * Read and write the active theme.
+ *
+ * The hook starts with `DEFAULT_THEME` to keep server and first client
+ * render aligned with the static `<html data-theme="dark">` markup, then
+ * syncs with whatever the pre-paint script applied on the client.
+ */
+export function useTheme(): {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+} {
+  const [theme, setThemeState] = useState<Theme>(DEFAULT_THEME);
+
+  useEffect(() => {
+    setThemeState(readDomTheme());
+  }, []);
+
+  const setTheme = useCallback((next: Theme) => {
+    applyTheme(next);
+    setThemeState(next);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((current) => {
+      const next: Theme = current === "dark" ? "light" : "dark";
+      applyTheme(next);
+      return next;
+    });
+  }, []);
+
+  return { theme, setTheme, toggleTheme };
+}

--- a/products/dashboard/lib/theme.ts
+++ b/products/dashboard/lib/theme.ts
@@ -1,41 +1,28 @@
 "use client";
 
 /**
- * Theme runtime helpers.
+ * Theme runtime — client-only surface.
  *
- * The dashboard ships dark-first: server renders `<html data-theme="dark">`
- * and an inline pre-paint script in `app/layout.tsx` rehydrates the user's
- * persisted preference before first paint to avoid a theme flash. This
- * module is the canonical client-side surface for reading and writing that
- * preference.
+ * The dashboard ships dark-first: the server renders
+ * `<html data-theme="dark">` and an inline pre-paint script in
+ * `app/layout.tsx` rehydrates the user's persisted preference before first
+ * paint to avoid a theme flash. This module owns the client-side hook.
+ *
+ * Server Components that only need the constants or the inline init
+ * script must import from `lib/theme-tokens.ts` instead, so they do not
+ * cross the client boundary that `"use client"` defines here.
  *
  * State is centralised in a module-level subscriber set so every
  * `useTheme()` consumer (current or future) sees the same value. Without
  * that, two components calling the hook would each keep an independent
- * `useState` snapshot, drift after the first toggle, and silently flip the
- * wrong way on the next call. `useSyncExternalStore` keeps the React
- * renders coherent across all subscribers.
+ * snapshot, drift after the first toggle, and silently flip the wrong way
+ * on the next call. `useSyncExternalStore` keeps the React renders
+ * coherent across all subscribers.
  */
 
 import { useCallback, useSyncExternalStore } from "react";
 
-export type Theme = "dark" | "light";
-
-export const DEFAULT_THEME: Theme = "dark";
-
-/** localStorage key used to persist the user's theme preference. */
-export const THEME_STORAGE_KEY = "theme";
-
-/** Inline script body used by `RootLayout` to rehydrate the persisted theme before paint. */
-export const THEME_INIT_SCRIPT = `(() => {
-  try {
-    const stored = window.localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});
-    const theme = stored === "light" || stored === "dark" ? stored : ${JSON.stringify(DEFAULT_THEME)};
-    document.documentElement.setAttribute("data-theme", theme);
-  } catch {
-    document.documentElement.setAttribute("data-theme", ${JSON.stringify(DEFAULT_THEME)});
-  }
-})();`;
+import { DEFAULT_THEME, THEME_STORAGE_KEY, type Theme } from "./theme-tokens";
 
 function isTheme(value: unknown): value is Theme {
   return value === "dark" || value === "light";

--- a/products/dashboard/lib/theme.ts
+++ b/products/dashboard/lib/theme.ts
@@ -8,9 +8,16 @@
  * persisted preference before first paint to avoid a theme flash. This
  * module is the canonical client-side surface for reading and writing that
  * preference.
+ *
+ * State is centralised in a module-level subscriber set so every
+ * `useTheme()` consumer (current or future) sees the same value. Without
+ * that, two components calling the hook would each keep an independent
+ * `useState` snapshot, drift after the first toggle, and silently flip the
+ * wrong way on the next call. `useSyncExternalStore` keeps the React
+ * renders coherent across all subscribers.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 export type Theme = "dark" | "light";
 
@@ -40,6 +47,23 @@ function readDomTheme(): Theme {
   return isTheme(attr) ? attr : DEFAULT_THEME;
 }
 
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function emitThemeChange(): void {
+  listeners.forEach((listener) => listener());
+}
+
+function getServerSnapshot(): Theme {
+  return DEFAULT_THEME;
+}
+
 function applyTheme(theme: Theme): void {
   if (typeof document !== "undefined") {
     document.documentElement.setAttribute("data-theme", theme);
@@ -48,42 +72,33 @@ function applyTheme(theme: Theme): void {
     try {
       window.localStorage.setItem(THEME_STORAGE_KEY, theme);
     } catch {
-      // Persisting is best-effort. A sandboxed/full storage quota or a
-      // privacy-mode browser still gets a working theme — the in-memory
+      // Persisting is best-effort. A sandboxed browser, full storage
+      // quota, or privacy mode still gets a working theme — the in-memory
       // state and DOM attribute are authoritative for the session.
     }
   }
+  emitThemeChange();
 }
 
 /**
  * Read and write the active theme.
  *
- * The hook starts with `DEFAULT_THEME` to keep server and first client
- * render aligned with the static `<html data-theme="dark">` markup, then
- * syncs with whatever the pre-paint script applied on the client.
+ * All subscribers share one module-level store, so an update from any
+ * consumer is reflected in every other consumer's next render.
  */
 export function useTheme(): {
   theme: Theme;
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
 } {
-  const [theme, setThemeState] = useState<Theme>(DEFAULT_THEME);
-
-  useEffect(() => {
-    setThemeState(readDomTheme());
-  }, []);
+  const theme = useSyncExternalStore(subscribe, readDomTheme, getServerSnapshot);
 
   const setTheme = useCallback((next: Theme) => {
     applyTheme(next);
-    setThemeState(next);
   }, []);
 
   const toggleTheme = useCallback(() => {
-    setThemeState((current) => {
-      const next: Theme = current === "dark" ? "light" : "dark";
-      applyTheme(next);
-      return next;
-    });
+    applyTheme(readDomTheme() === "dark" ? "light" : "dark");
   }, []);
 
   return { theme, setTheme, toggleTheme };


### PR DESCRIPTION
## Summary

Foundational slice (PR 2 of the Platform Dashboard MVP plan, [AEL-45](https://linear.app/aelizondo/issue/AEL-45/pr-2-theme-tokens-dark-first-globals)). Ports the Process Canvas prototype's design tokens into the dashboard so later slices have a stable token surface.

- `app/globals.css`: replaces the placeholder Tailwind v4 `@theme` block with the prototype's `[data-theme="dark"]` and `[data-theme="light"]` variable blocks (verbatim values from `Process Canvas.html`), plus a `@theme inline` alias layer so feature code can stay in the utility model (`bg-bg`, `text-t1`, `border-border`, `bg-pill-complete`, `shadow-canvas`, etc.).
- `app/layout.tsx`: `<html data-theme="dark">` + an inline pre-paint script that rehydrates any stored preference before first paint, so toggling the theme later won't flash. Body adopts `bg-bg` / `text-t1`.
- `lib/theme.ts`: typed `useTheme()` hook (`'dark' | 'light'`), `setTheme`, `toggleTheme`, plus `THEME_INIT_SCRIPT` and `DEFAULT_THEME` exports so the layout and the hook share one source of truth.
- Tests: 8 unit tests covering hook init, set/toggle/persist, unrecognised values, and the pre-paint script behaviour; 2 Playwright checks confirm the login page stays healthy in both themes.

No behaviour changes. The login page uses hard-coded hero colors and renders unchanged.

## Spec / scope link

- Linear: [AEL-45 — PR 2: Theme tokens + dark-first globals](https://linear.app/aelizondo/issue/AEL-45/pr-2-theme-tokens-dark-first-globals)
- Project: [Platform Dashboard MVP](https://linear.app/aelizondo/project/platform-dashboard-mvp-70a12d18de1c) (slice 2 of 14)
- Source design: `Process Canvas.html` lines 13–36 (data-theme blocks)

## Closing checklist (issue body)

- [x] `npm run validate` green (root)
- [x] `next build` + types green (no separate `lint` / `typecheck` script in this product)
- [x] Visual regression check: dark and light render for login page (Playwright `e2e/theme.spec.ts`)
- [x] PR opened ready-for-review against `staging`
- [ ] CodeRabbit threads resolved
- [ ] Merged

## Risk profile

Foundational. Visual-only. No runtime behaviour, network paths, or auth surface changed; observability scope unchanged.

## Test plan

- [x] `npm run validate` (root)
- [x] `cd products/dashboard && npm run test` → 16 files / 120 tests pass (8 new theme tests)
- [x] `cd products/dashboard && npm run build` → compiles, types check, all routes generated
- [ ] CI: `test` + `e2e` + smoke must stay green on Vercel preview
- [ ] Manual sanity: open Vercel preview, run `document.documentElement.setAttribute('data-theme','light')` in console — surfaces should swap with no broken styles

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard supports dark and light modes with runtime theme tokens, smoother transitions, themed background/text, and early theme initialization so the UI boots in the chosen mode.
* **Tests**
  * Added unit and end-to-end tests verifying theme initialization, toggling, persistence, and consistent behavior across consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->