### PR TITLE
feat(dashboard): workflow persistence layer + repository (AEL-47)

### DIFF
--- a/interfaces/interfaces.yaml
+++ b/interfaces/interfaces.yaml
@@ -58,6 +58,94 @@ interfaces:
       properties:
         type: object
 
+  workflow_repository:
+    description: >
+      Provider-agnostic persistence interface for workflow templates,
+      instances, tasks, events, and the framework items library
+      (Skills + Playbooks). Business logic MUST target this interface
+      so the storage backend stays swappable per §5.1 Layer 1. The
+      Supabase implementation lives at
+      `products/dashboard/lib/workflows/repository.ts`; the SQL schema
+      it maps to lives at
+      `products/dashboard/supabase/migrations/20260419120000_workflow_persistence.sql`.
+    operations:
+      get_templates:
+        description: "List all workflow templates ordered by label."
+        outputs:
+          templates:
+            type: array
+      get_instance:
+        description: "Fetch a single workflow instance by id, including its tasks and recent events."
+        inputs:
+          id:
+            type: string
+            format: uuid
+        outputs:
+          instance:
+            type: object
+      list_instances:
+        description: "List instances, optionally filtered by template id."
+        inputs:
+          template_id:
+            type: string
+            required: false
+        outputs:
+          instances:
+            type: array
+      create_instance:
+        description: >
+          Create a new workflow instance from a template. Materializes
+          one workflow_tasks row per entry in the template's
+          task_templates JSON, copying default roles from the template.
+        inputs:
+          template_id:
+            type: string
+          label:
+            type: string
+        outputs:
+          instance:
+            type: object
+      update_task:
+        description: "Patch a workflow task's mutable fields (status, substatus, agent assignment, etc.)."
+        inputs:
+          task_id:
+            type: string
+            format: uuid
+          patch:
+            type: object
+        outputs:
+          task:
+            type: object
+      add_event:
+        description: "Append a workflow_event row scoped to a task (and its parent instance)."
+        inputs:
+          task_id:
+            type: string
+            format: uuid
+          event:
+            type: object
+        outputs:
+          event:
+            type: object
+      get_framework_items:
+        description: "List Skills and Playbooks, optionally filtered by type."
+        inputs:
+          type:
+            type: string
+            enum: [skill, playbook]
+            required: false
+        outputs:
+          items:
+            type: array
+      upsert_framework_item:
+        description: "Create or update a framework item (Skill or Playbook)."
+        inputs:
+          item:
+            type: object
+        outputs:
+          item:
+            type: object
+
 policies:
   human_in_the_loop:
     required_for:
@@ -102,3 +190,23 @@ adapters:
     notes: >
       Introduce only with decision-log rationale per §8.2.
       Do not use V3 patterns without documented justification.
+
+  supabase_workflow_repository:
+    description: >
+      Supabase (Postgres + RLS) implementation of `workflow_repository`.
+      Wraps the @supabase/supabase-js client and reads/writes the
+      `workflow_templates`, `workflow_instances`, `workflow_tasks`,
+      `workflow_events`, and `framework_items` tables. Auth flows are
+      delegated to the existing server-side adapter at
+      `products/dashboard/lib/auth/supabase-server-adapter.ts`.
+    status: recommended_default
+    maturity_levels: [1, 2]
+    open_source: true
+    repository: "https://github.com/supabase/supabase-js"
+    implements:
+      - workflow_repository
+    notes: >
+      DEC-002 (single-user V1): RLS policies allow any authenticated
+      session to read/write all rows. A future migration introducing
+      `company_id` will tighten policies to per-company scope without
+      changing the interface.

--- a/products/dashboard/__tests__/lib/workflows/repository.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/repository.test.ts
@@ -1,0 +1,424 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { createWorkflowRepository } from "@/lib/workflows/repository";
+
+// Lightweight in-memory fake of the subset of @supabase/supabase-js the
+// repository touches. Keeps the tests hermetic — no Docker, no network.
+//
+// The fake supports the chainable query-builder shape returned by
+// `client.from(table)`: select / eq / order / limit / maybeSingle / single,
+// plus mutating insert/update/upsert that flow through the same shape.
+
+interface RowMap {
+  [table: string]: Record<string, unknown>[];
+}
+
+interface FilterState {
+  table: string;
+  rows: Record<string, unknown>[];
+  filters: Array<(row: Record<string, unknown>) => boolean>;
+  orderBy: Array<{ column: string; ascending: boolean }>;
+  limitN?: number;
+  pendingInsert?: Record<string, unknown>[];
+  pendingUpdate?: Record<string, unknown>;
+  pendingUpsert?: Record<string, unknown>[];
+  selecting: boolean;
+}
+
+function makeQueryBuilder(state: FilterState, store: RowMap) {
+  const builder: any = {
+    select(_columns?: string) {
+      state.selecting = true;
+      return builder;
+    },
+    eq(column: string, value: unknown) {
+      state.filters.push((row) => row[column] === value);
+      return builder;
+    },
+    order(column: string, options?: { ascending?: boolean }) {
+      state.orderBy.push({ column, ascending: options?.ascending ?? true });
+      return builder;
+    },
+    limit(n: number) {
+      state.limitN = n;
+      return builder;
+    },
+    insert(rows: Record<string, unknown> | Record<string, unknown>[]) {
+      state.pendingInsert = Array.isArray(rows) ? rows : [rows];
+      return builder;
+    },
+    update(patch: Record<string, unknown>) {
+      state.pendingUpdate = patch;
+      return builder;
+    },
+    upsert(rows: Record<string, unknown> | Record<string, unknown>[]) {
+      state.pendingUpsert = Array.isArray(rows) ? rows : [rows];
+      return builder;
+    },
+    async maybeSingle() {
+      const result = applyOperation(state, store);
+      const row = result[0] ?? null;
+      return { data: row, error: null };
+    },
+    async single() {
+      const result = applyOperation(state, store);
+      if (result.length === 0) {
+        return { data: null, error: { message: "no rows" } };
+      }
+      return { data: result[0], error: null };
+    },
+    then(resolve: (value: { data: unknown; error: null }) => unknown) {
+      const result = applyOperation(state, store);
+      return Promise.resolve(resolve({ data: result, error: null }));
+    },
+  };
+  return builder;
+}
+
+let nextIdCounter = 0;
+function nextId(prefix: string): string {
+  nextIdCounter += 1;
+  return `${prefix}-${nextIdCounter}`;
+}
+
+function applyOperation(
+  state: FilterState,
+  store: RowMap,
+): Record<string, unknown>[] {
+  const tableRows = (store[state.table] ??= []);
+
+  if (state.pendingInsert) {
+    const inserted = state.pendingInsert.map((row) => ({
+      id: row.id ?? nextId(state.table),
+      created_at: row.created_at ?? "2026-04-19T12:00:00Z",
+      updated_at: row.updated_at ?? "2026-04-19T12:00:00Z",
+      ...row,
+    }));
+    tableRows.push(...inserted);
+    return inserted;
+  }
+
+  if (state.pendingUpsert) {
+    const result: Record<string, unknown>[] = [];
+    for (const row of state.pendingUpsert) {
+      const existingIndex = tableRows.findIndex((r) => r.id === row.id);
+      const merged = {
+        created_at: tableRows[existingIndex]?.created_at ?? "2026-04-19T12:00:00Z",
+        updated_at: "2026-04-19T12:00:01Z",
+        ...row,
+      };
+      if (existingIndex >= 0) {
+        tableRows[existingIndex] = { ...tableRows[existingIndex], ...merged };
+        result.push(tableRows[existingIndex]);
+      } else {
+        tableRows.push(merged);
+        result.push(merged);
+      }
+    }
+    return result;
+  }
+
+  if (state.pendingUpdate) {
+    const updated: Record<string, unknown>[] = [];
+    for (const row of tableRows) {
+      if (state.filters.every((f) => f(row))) {
+        Object.assign(row, state.pendingUpdate, {
+          updated_at: "2026-04-19T12:00:02Z",
+        });
+        updated.push(row);
+      }
+    }
+    return updated;
+  }
+
+  // Read path
+  let rows = tableRows.filter((row) => state.filters.every((f) => f(row)));
+
+  for (const ord of state.orderBy) {
+    rows = [...rows].sort((a, b) => {
+      const av = a[ord.column];
+      const bv = b[ord.column];
+      if (av === bv) return 0;
+      if (av === null || av === undefined) return 1;
+      if (bv === null || bv === undefined) return -1;
+      return (av < bv ? -1 : 1) * (ord.ascending ? 1 : -1);
+    });
+  }
+
+  if (typeof state.limitN === "number") {
+    rows = rows.slice(0, state.limitN);
+  }
+
+  return rows;
+}
+
+function makeFakeClient(store: RowMap): SupabaseClient {
+  return {
+    from(table: string) {
+      const state: FilterState = {
+        table,
+        rows: [],
+        filters: [],
+        orderBy: [],
+        selecting: false,
+      };
+      return makeQueryBuilder(state, store);
+    },
+  } as unknown as SupabaseClient;
+}
+
+describe("workflow repository", () => {
+  let store: RowMap;
+
+  beforeEach(() => {
+    nextIdCounter = 0;
+    store = {
+      workflow_templates: [
+        {
+          id: "client-delivery",
+          label: "Client Project Delivery",
+          color: "#6366f1",
+          multi_instance: true,
+          stages: [
+            { id: "pre-sales", label: "Pre-Sales" },
+            { id: "validation", label: "Validation" },
+          ],
+          roles: [
+            { id: "sales", label: "Sales", owner: "Hans / Dave" },
+            { id: "product", label: "Product", owner: "Andres" },
+          ],
+          task_templates: [
+            {
+              role: "sales",
+              stage: "pre-sales",
+              title: "Project Description",
+              desc: "Define objective",
+              agent: "Sales Ops",
+              skill: "sales-ops",
+              playbook: "presales-qualification",
+              triggers: [{ type: "manual", label: "Manual start" }],
+              gates: [{ type: "playbook_done", label: "Done" }],
+            },
+            {
+              role: "product",
+              stage: "validation",
+              title: "PDR Review",
+              desc: "Evaluate, accept or reject",
+              agent: "PM",
+              skill: "pm",
+              playbook: "pdr-review",
+              checkpoint: true,
+              triggers: [
+                { type: "after_task", taskRef: "Project Description", label: "After PD" },
+              ],
+              gates: [{ type: "checkpoint", label: "Approve" }],
+            },
+          ],
+          created_at: "2026-04-19T12:00:00Z",
+          updated_at: "2026-04-19T12:00:00Z",
+        },
+        {
+          id: "product-dev",
+          label: "Product Development",
+          color: "#10b981",
+          multi_instance: false,
+          stages: [],
+          roles: [],
+          task_templates: [],
+          created_at: "2026-04-19T12:00:00Z",
+          updated_at: "2026-04-19T12:00:00Z",
+        },
+      ],
+      workflow_instances: [],
+      workflow_tasks: [],
+      workflow_events: [],
+      framework_items: [
+        {
+          id: "sk-pm",
+          type: "skill",
+          name: "PM",
+          description: "Product management",
+          icon: "📋",
+          content: "# PM Skill",
+          created_at: "2026-04-19T12:00:00Z",
+          updated_at: "2026-04-19T12:00:00Z",
+        },
+        {
+          id: "pb-presales",
+          type: "playbook",
+          name: "presales-qualification",
+          description: "Qualify clients",
+          icon: "📄",
+          content: "# Presales",
+          created_at: "2026-04-19T12:00:00Z",
+          updated_at: "2026-04-19T12:00:00Z",
+        },
+      ],
+    };
+  });
+
+  describe("getTemplates", () => {
+    it("returns all templates mapped to camelCase shape, ordered by label", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+
+      const templates = await repo.getTemplates();
+
+      expect(templates).toHaveLength(2);
+      expect(templates[0]).toMatchObject({
+        id: "client-delivery",
+        label: "Client Project Delivery",
+        multiInstance: true,
+        color: "#6366f1",
+      });
+      expect(templates[0].roles).toEqual([
+        { id: "sales", label: "Sales", owner: "Hans / Dave" },
+        { id: "product", label: "Product", owner: "Andres" },
+      ]);
+      expect(templates[0].taskTemplates).toHaveLength(2);
+      expect(templates[1].id).toBe("product-dev");
+    });
+  });
+
+  describe("createInstance", () => {
+    it("creates instance + materializes tasks from the template's taskTemplates", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+
+      const instance = await repo.createInstance("client-delivery", "Acme Corp");
+
+      expect(instance.templateId).toBe("client-delivery");
+      expect(instance.label).toBe("Acme Corp");
+      expect(instance.status).toBe("active");
+      expect(instance.roles).toEqual([
+        { id: "sales", label: "Sales", owner: "Hans / Dave" },
+        { id: "product", label: "Product", owner: "Andres" },
+      ]);
+      expect(instance.tasks).toHaveLength(2);
+      expect(instance.events).toEqual([]);
+
+      const [first, second] = instance.tasks;
+      expect(first).toMatchObject({
+        instanceId: instance.id,
+        roleId: "sales",
+        stageId: "pre-sales",
+        title: "Project Description",
+        description: "Define objective",
+        status: "not_started",
+        substatus: "",
+        checkpoint: false,
+        agent: "Sales Ops",
+        skill: "sales-ops",
+        playbook: "presales-qualification",
+      });
+      expect(first.triggers).toEqual([{ type: "manual", label: "Manual start" }]);
+      expect(second.checkpoint).toBe(true);
+      expect(second.title).toBe("PDR Review");
+
+      // Tasks were persisted to the store
+      expect(store.workflow_tasks).toHaveLength(2);
+    });
+
+    it("creates an instance with no tasks when the template is empty", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+
+      const instance = await repo.createInstance("product-dev", "Dashboard MVP");
+
+      expect(instance.templateId).toBe("product-dev");
+      expect(instance.tasks).toEqual([]);
+      expect(store.workflow_tasks).toHaveLength(0);
+    });
+
+    it("rejects unknown template ids", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+
+      await expect(repo.createInstance("nope", "X")).rejects.toThrow(
+        /unknown template_id/i,
+      );
+    });
+  });
+
+  describe("updateTask", () => {
+    it("patches mutable fields and returns the updated row", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+      const instance = await repo.createInstance("client-delivery", "Acme Corp");
+      const targetTaskId = instance.tasks[0].id;
+
+      const updated = await repo.updateTask(targetTaskId, {
+        status: "active",
+        substatus: "Agent began work",
+        agent: "New Agent",
+      });
+
+      expect(updated.id).toBe(targetTaskId);
+      expect(updated.status).toBe("active");
+      expect(updated.substatus).toBe("Agent began work");
+      expect(updated.agent).toBe("New Agent");
+
+      // Untouched fields preserved
+      expect(updated.title).toBe("Project Description");
+      expect(updated.roleId).toBe("sales");
+    });
+
+    it("throws when called with an empty patch (programmer error)", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+
+      await expect(repo.updateTask("any-id", {})).rejects.toThrow(/empty patch/i);
+    });
+  });
+
+  describe("addEvent + getInstance", () => {
+    it("appends an event and surfaces it via getInstance", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+      const instance = await repo.createInstance("client-delivery", "Acme Corp");
+      const taskId = instance.tasks[0].id;
+
+      const event = await repo.addEvent(taskId, {
+        name: "task.started",
+        description: "Sales Ops Agent began qualification",
+        payload: { agent: "Sales Ops" },
+      });
+
+      expect(event.taskId).toBe(taskId);
+      expect(event.instanceId).toBe(instance.id);
+      expect(event.payload).toEqual({ agent: "Sales Ops" });
+
+      const detail = await repo.getInstance(instance.id);
+      expect(detail).not.toBeNull();
+      expect(detail!.events).toHaveLength(1);
+      expect(detail!.events[0].name).toBe("task.started");
+    });
+  });
+
+  describe("framework items", () => {
+    it("listFrameworkItems filters by type", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+
+      const skills = await repo.getFrameworkItems("skill");
+      const playbooks = await repo.getFrameworkItems("playbook");
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].id).toBe("sk-pm");
+      expect(playbooks).toHaveLength(1);
+      expect(playbooks[0].id).toBe("pb-presales");
+    });
+
+    it("upsertFrameworkItem replaces existing rows", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+
+      const updated = await repo.upsertFrameworkItem({
+        id: "sk-pm",
+        type: "skill",
+        name: "PM",
+        description: "Updated description",
+        icon: "📋",
+        content: "# Updated PM Skill",
+      });
+
+      expect(updated.description).toBe("Updated description");
+      expect(updated.content).toBe("# Updated PM Skill");
+      expect(store.framework_items).toHaveLength(2);
+    });
+  });
+});

--- a/products/dashboard/lib/workflows/repository.server.ts
+++ b/products/dashboard/lib/workflows/repository.server.ts
@@ -1,0 +1,37 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+import { getSupabaseRuntimeConfig } from "@/lib/auth/config";
+import { createWorkflowRepository } from "./repository";
+import type { WorkflowRepository } from "./types";
+
+// Server-side factory. Uses the same cookie-aware Supabase client as the auth
+// adapter so RLS policies see the signed-in user automatically (DEC-002).
+//
+// Note: this MUST only be imported from server components, route handlers, or
+// server actions. The browser-side equivalent will live alongside the existing
+// supabase-browser-adapter when the dashboard wires up client interactions.
+export async function getServerWorkflowRepository(): Promise<WorkflowRepository> {
+  const cookieStore = await cookies();
+  const { url, anonKey } = getSupabaseRuntimeConfig();
+
+  const client = createServerClient(url, anonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options),
+          );
+        } catch {
+          // Server Components cannot always write cookies; auth middleware
+          // refreshes the session on the next request.
+        }
+      },
+    },
+  });
+
+  return createWorkflowRepository(client);
+}

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -1,0 +1,431 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type {
+  FrameworkItem,
+  FrameworkItemType,
+  WorkflowEvent,
+  WorkflowEventInput,
+  WorkflowInstance,
+  WorkflowInstanceDetail,
+  WorkflowRepository,
+  WorkflowRole,
+  WorkflowTask,
+  WorkflowTaskPatch,
+  WorkflowTaskTemplate,
+  WorkflowTemplate,
+} from "./types";
+
+// Row shapes returned by Supabase. Kept private — callers consume the camelCase
+// domain types defined in `./types`. Mapping happens once here so the rest of
+// the app never touches snake_case.
+interface WorkflowTemplateRow {
+  id: string;
+  label: string;
+  color: string;
+  multi_instance: boolean;
+  stages: unknown;
+  roles: unknown;
+  task_templates: unknown;
+  created_at: string;
+  updated_at: string;
+}
+
+interface WorkflowInstanceRow {
+  id: string;
+  template_id: string;
+  label: string;
+  status: WorkflowInstance["status"];
+  roles: unknown;
+  created_at: string;
+  updated_at: string;
+}
+
+interface WorkflowTaskRow {
+  id: string;
+  instance_id: string;
+  role_id: string;
+  stage_id: string;
+  title: string;
+  description: string;
+  status: WorkflowTask["status"];
+  substatus: string;
+  checkpoint: boolean;
+  triggers: unknown;
+  gates: unknown;
+  agent: string | null;
+  skill: string | null;
+  playbook: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface WorkflowEventRow {
+  id: string;
+  instance_id: string;
+  task_id: string | null;
+  name: string;
+  description: string;
+  payload: unknown;
+  created_at: string;
+}
+
+interface FrameworkItemRow {
+  id: string;
+  type: FrameworkItemType;
+  name: string;
+  description: string;
+  icon: string | null;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function toJsonArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function toJsonObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function mapTemplate(row: WorkflowTemplateRow): WorkflowTemplate {
+  return {
+    id: row.id,
+    label: row.label,
+    color: row.color,
+    multiInstance: row.multi_instance,
+    stages: toJsonArray(row.stages),
+    roles: toJsonArray(row.roles),
+    taskTemplates: toJsonArray(row.task_templates),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapInstance(row: WorkflowInstanceRow): WorkflowInstance {
+  return {
+    id: row.id,
+    templateId: row.template_id,
+    label: row.label,
+    status: row.status,
+    roles: toJsonArray(row.roles),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapTask(row: WorkflowTaskRow): WorkflowTask {
+  return {
+    id: row.id,
+    instanceId: row.instance_id,
+    roleId: row.role_id,
+    stageId: row.stage_id,
+    title: row.title,
+    description: row.description,
+    status: row.status,
+    substatus: row.substatus,
+    checkpoint: row.checkpoint,
+    triggers: toJsonArray(row.triggers),
+    gates: toJsonArray(row.gates),
+    agent: row.agent,
+    skill: row.skill,
+    playbook: row.playbook,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapEvent(row: WorkflowEventRow): WorkflowEvent {
+  return {
+    id: row.id,
+    instanceId: row.instance_id,
+    taskId: row.task_id,
+    name: row.name,
+    description: row.description,
+    payload: toJsonObject(row.payload),
+    createdAt: row.created_at,
+  };
+}
+
+function mapFrameworkItem(row: FrameworkItemRow): FrameworkItem {
+  return {
+    id: row.id,
+    type: row.type,
+    name: row.name,
+    description: row.description,
+    icon: row.icon,
+    content: row.content,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function patchToRow(patch: WorkflowTaskPatch): Record<string, unknown> {
+  const row: Record<string, unknown> = {};
+  if (patch.roleId !== undefined) row.role_id = patch.roleId;
+  if (patch.stageId !== undefined) row.stage_id = patch.stageId;
+  if (patch.title !== undefined) row.title = patch.title;
+  if (patch.description !== undefined) row.description = patch.description;
+  if (patch.status !== undefined) row.status = patch.status;
+  if (patch.substatus !== undefined) row.substatus = patch.substatus;
+  if (patch.checkpoint !== undefined) row.checkpoint = patch.checkpoint;
+  if (patch.triggers !== undefined) row.triggers = patch.triggers;
+  if (patch.gates !== undefined) row.gates = patch.gates;
+  if (patch.agent !== undefined) row.agent = patch.agent;
+  if (patch.skill !== undefined) row.skill = patch.skill;
+  if (patch.playbook !== undefined) row.playbook = patch.playbook;
+  return row;
+}
+
+export class WorkflowRepositoryError extends Error {
+  readonly cause?: unknown;
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "WorkflowRepositoryError";
+    this.cause = cause;
+  }
+}
+
+function unwrap<T>(label: string, data: T | null, error: unknown): T {
+  if (error) {
+    throw new WorkflowRepositoryError(`${label} failed`, error);
+  }
+  if (data === null || data === undefined) {
+    throw new WorkflowRepositoryError(`${label} returned no row`);
+  }
+  return data;
+}
+
+export function createWorkflowRepository(
+  client: SupabaseClient,
+): WorkflowRepository {
+  return {
+    async getTemplates(): Promise<WorkflowTemplate[]> {
+      const { data, error } = await client
+        .from("workflow_templates")
+        .select("*")
+        .order("label", { ascending: true });
+
+      if (error) {
+        throw new WorkflowRepositoryError("getTemplates failed", error);
+      }
+      return (data ?? []).map((row) => mapTemplate(row as WorkflowTemplateRow));
+    },
+
+    async getInstance(id: string): Promise<WorkflowInstanceDetail | null> {
+      const { data: instanceRow, error: instanceErr } = await client
+        .from("workflow_instances")
+        .select("*")
+        .eq("id", id)
+        .maybeSingle();
+
+      if (instanceErr) {
+        throw new WorkflowRepositoryError("getInstance failed", instanceErr);
+      }
+      if (!instanceRow) {
+        return null;
+      }
+
+      const [{ data: taskRows, error: tasksErr }, { data: eventRows, error: eventsErr }] =
+        await Promise.all([
+          client
+            .from("workflow_tasks")
+            .select("*")
+            .eq("instance_id", id)
+            .order("created_at", { ascending: true }),
+          client
+            .from("workflow_events")
+            .select("*")
+            .eq("instance_id", id)
+            .order("created_at", { ascending: false })
+            .limit(50),
+        ]);
+
+      if (tasksErr) {
+        throw new WorkflowRepositoryError("getInstance tasks failed", tasksErr);
+      }
+      if (eventsErr) {
+        throw new WorkflowRepositoryError("getInstance events failed", eventsErr);
+      }
+
+      return {
+        ...mapInstance(instanceRow as WorkflowInstanceRow),
+        tasks: (taskRows ?? []).map((row) => mapTask(row as WorkflowTaskRow)),
+        events: (eventRows ?? []).map((row) => mapEvent(row as WorkflowEventRow)),
+      };
+    },
+
+    async listInstances(templateId?: string): Promise<WorkflowInstance[]> {
+      let query = client
+        .from("workflow_instances")
+        .select("*")
+        .order("created_at", { ascending: false });
+
+      if (templateId) {
+        query = query.eq("template_id", templateId);
+      }
+
+      const { data, error } = await query;
+      if (error) {
+        throw new WorkflowRepositoryError("listInstances failed", error);
+      }
+      return (data ?? []).map((row) => mapInstance(row as WorkflowInstanceRow));
+    },
+
+    async createInstance(
+      templateId: string,
+      label: string,
+    ): Promise<WorkflowInstanceDetail> {
+      // Fetch the template so we can copy default roles and materialize tasks.
+      const { data: tplRow, error: tplErr } = await client
+        .from("workflow_templates")
+        .select("*")
+        .eq("id", templateId)
+        .maybeSingle();
+
+      if (tplErr) {
+        throw new WorkflowRepositoryError("createInstance template lookup failed", tplErr);
+      }
+      if (!tplRow) {
+        throw new WorkflowRepositoryError(
+          `createInstance: unknown template_id "${templateId}"`,
+        );
+      }
+      const template = mapTemplate(tplRow as WorkflowTemplateRow);
+
+      const { data: insertedInstance, error: insertErr } = await client
+        .from("workflow_instances")
+        .insert({
+          template_id: template.id,
+          label,
+          status: "active",
+          roles: template.roles as unknown as WorkflowRole[],
+        })
+        .select("*")
+        .single();
+
+      const instance = mapInstance(
+        unwrap("createInstance insert", insertedInstance, insertErr) as WorkflowInstanceRow,
+      );
+
+      // Materialize tasks from template.taskTemplates. Skip when empty so
+      // empty templates still produce a valid instance with no tasks.
+      let tasks: WorkflowTask[] = [];
+      if (template.taskTemplates.length > 0) {
+        const taskRowsToInsert = template.taskTemplates.map(
+          (tpl: WorkflowTaskTemplate) => ({
+            instance_id: instance.id,
+            role_id: tpl.role,
+            stage_id: tpl.stage,
+            title: tpl.title,
+            description: tpl.desc ?? "",
+            status: "not_started" as const,
+            substatus: "",
+            checkpoint: tpl.checkpoint ?? false,
+            triggers: tpl.triggers ?? [],
+            gates: tpl.gates ?? [],
+            agent: tpl.agent ?? null,
+            skill: tpl.skill ?? null,
+            playbook: tpl.playbook ?? null,
+          }),
+        );
+
+        const { data: insertedTasks, error: tasksErr } = await client
+          .from("workflow_tasks")
+          .insert(taskRowsToInsert)
+          .select("*");
+
+        if (tasksErr) {
+          throw new WorkflowRepositoryError(
+            "createInstance tasks insert failed",
+            tasksErr,
+          );
+        }
+        tasks = (insertedTasks ?? []).map((row) => mapTask(row as WorkflowTaskRow));
+      }
+
+      return { ...instance, tasks, events: [] };
+    },
+
+    async updateTask(taskId: string, patch: WorkflowTaskPatch): Promise<WorkflowTask> {
+      const row = patchToRow(patch);
+      if (Object.keys(row).length === 0) {
+        throw new WorkflowRepositoryError("updateTask called with empty patch");
+      }
+
+      const { data, error } = await client
+        .from("workflow_tasks")
+        .update(row)
+        .eq("id", taskId)
+        .select("*")
+        .single();
+
+      return mapTask(unwrap("updateTask", data, error) as WorkflowTaskRow);
+    },
+
+    async addEvent(taskId: string, event: WorkflowEventInput): Promise<WorkflowEvent> {
+      // Look up parent instance so events can be queried by instance directly
+      // even when filtering by task is not desired.
+      const { data: taskRow, error: taskErr } = await client
+        .from("workflow_tasks")
+        .select("instance_id")
+        .eq("id", taskId)
+        .single();
+
+      if (taskErr || !taskRow) {
+        throw new WorkflowRepositoryError("addEvent task lookup failed", taskErr);
+      }
+
+      const { data, error } = await client
+        .from("workflow_events")
+        .insert({
+          instance_id: (taskRow as { instance_id: string }).instance_id,
+          task_id: taskId,
+          name: event.name,
+          description: event.description ?? "",
+          payload: event.payload ?? {},
+        })
+        .select("*")
+        .single();
+
+      return mapEvent(unwrap("addEvent", data, error) as WorkflowEventRow);
+    },
+
+    async getFrameworkItems(type?: FrameworkItemType): Promise<FrameworkItem[]> {
+      let query = client
+        .from("framework_items")
+        .select("*")
+        .order("type", { ascending: true })
+        .order("name", { ascending: true });
+
+      if (type) {
+        query = query.eq("type", type);
+      }
+
+      const { data, error } = await query;
+      if (error) {
+        throw new WorkflowRepositoryError("getFrameworkItems failed", error);
+      }
+      return (data ?? []).map((row) => mapFrameworkItem(row as FrameworkItemRow));
+    },
+
+    async upsertFrameworkItem(item: FrameworkItem): Promise<FrameworkItem> {
+      const { data, error } = await client
+        .from("framework_items")
+        .upsert({
+          id: item.id,
+          type: item.type,
+          name: item.name,
+          description: item.description,
+          icon: item.icon,
+          content: item.content,
+        })
+        .select("*")
+        .single();
+
+      return mapFrameworkItem(unwrap("upsertFrameworkItem", data, error) as FrameworkItemRow);
+    },
+  };
+}

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -1,0 +1,156 @@
+// Shared workflow domain types. These mirror the SQL schema in
+// `products/dashboard/supabase/migrations/20260419120000_workflow_persistence.sql`
+// and the `workflow_repository` interface defined in
+// `interfaces/interfaces.yaml`.
+
+export type WorkflowInstanceStatus =
+  | "not_started"
+  | "active"
+  | "blocked"
+  | "complete";
+
+export type WorkflowTaskStatus =
+  | "not_started"
+  | "active"
+  | "pending_approval"
+  | "blocked"
+  | "complete";
+
+export type FrameworkItemType = "skill" | "playbook";
+
+export interface WorkflowStage {
+  id: string;
+  label: string;
+  sub?: string;
+}
+
+export interface WorkflowRole {
+  id: string;
+  label: string;
+  owner?: string;
+}
+
+export interface WorkflowTrigger {
+  type: string;
+  label?: string;
+  taskRef?: string;
+  taskId?: string;
+  eventName?: string;
+}
+
+export interface WorkflowGate {
+  type: string;
+  label?: string;
+}
+
+export interface WorkflowTaskTemplate {
+  role: string;
+  stage: string;
+  title: string;
+  desc?: string;
+  agent?: string;
+  skill?: string;
+  playbook?: string;
+  checkpoint?: boolean;
+  triggers?: WorkflowTrigger[];
+  gates?: WorkflowGate[];
+}
+
+export interface WorkflowTemplate {
+  id: string;
+  label: string;
+  color: string;
+  multiInstance: boolean;
+  stages: WorkflowStage[];
+  roles: WorkflowRole[];
+  taskTemplates: WorkflowTaskTemplate[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkflowTask {
+  id: string;
+  instanceId: string;
+  roleId: string;
+  stageId: string;
+  title: string;
+  description: string;
+  status: WorkflowTaskStatus;
+  substatus: string;
+  checkpoint: boolean;
+  triggers: WorkflowTrigger[];
+  gates: WorkflowGate[];
+  agent: string | null;
+  skill: string | null;
+  playbook: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkflowEvent {
+  id: string;
+  instanceId: string;
+  taskId: string | null;
+  name: string;
+  description: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface WorkflowInstance {
+  id: string;
+  templateId: string;
+  label: string;
+  status: WorkflowInstanceStatus;
+  roles: WorkflowRole[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkflowInstanceDetail extends WorkflowInstance {
+  tasks: WorkflowTask[];
+  events: WorkflowEvent[];
+}
+
+export interface FrameworkItem {
+  id: string;
+  type: FrameworkItemType;
+  name: string;
+  description: string;
+  icon: string | null;
+  content: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface WorkflowTaskPatch {
+  roleId?: string;
+  stageId?: string;
+  title?: string;
+  description?: string;
+  status?: WorkflowTaskStatus;
+  substatus?: string;
+  checkpoint?: boolean;
+  triggers?: WorkflowTrigger[];
+  gates?: WorkflowGate[];
+  agent?: string | null;
+  skill?: string | null;
+  playbook?: string | null;
+}
+
+export interface WorkflowEventInput {
+  name: string;
+  description?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface WorkflowRepository {
+  getTemplates(): Promise<WorkflowTemplate[]>;
+  getInstance(id: string): Promise<WorkflowInstanceDetail | null>;
+  listInstances(templateId?: string): Promise<WorkflowInstance[]>;
+  createInstance(templateId: string, label: string): Promise<WorkflowInstanceDetail>;
+  updateTask(taskId: string, patch: WorkflowTaskPatch): Promise<WorkflowTask>;
+  addEvent(taskId: string, event: WorkflowEventInput): Promise<WorkflowEvent>;
+  getFrameworkItems(type?: FrameworkItemType): Promise<FrameworkItem[]>;
+  upsertFrameworkItem(item: FrameworkItem): Promise<FrameworkItem>;
+}

--- a/products/dashboard/supabase/migrations/20260419120000_workflow_persistence.sql
+++ b/products/dashboard/supabase/migrations/20260419120000_workflow_persistence.sql
@@ -1,0 +1,209 @@
+-- Workflow persistence tables for the AI-Native Platform Dashboard (PR 4 / AEL-47).
+--
+-- Source of truth for entity shapes: `spec/examples/platform-product.yaml`
+-- (data_model.entities). Field comments below name the spec entity each column
+-- maps to. Repository contracts live in `interfaces/interfaces.yaml` under the
+-- `workflow_repository` adapter; business logic targets those interfaces, not
+-- this schema directly, so the storage backend stays swappable.
+--
+-- V1 scope (DEC-002): one company, one founder, no multi-tenancy. RLS is still
+-- non-negotiable — every table is locked down to authenticated users so the
+-- dashboard can never accidentally serve rows over an unauthenticated session.
+
+create extension if not exists "pgcrypto";
+
+-- ---------------------------------------------------------------------------
+-- workflow_templates: reusable definition of a workflow (WorkflowTemplate).
+-- ---------------------------------------------------------------------------
+create table if not exists public.workflow_templates (
+  id              text primary key,
+  label           text not null,
+  color           text not null,
+  multi_instance  boolean not null default false,
+  stages          jsonb not null default '[]'::jsonb,
+  roles           jsonb not null default '[]'::jsonb,
+  task_templates  jsonb not null default '[]'::jsonb,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+
+comment on table public.workflow_templates is
+  'Reusable workflow definitions (WorkflowTemplate per spec/examples/platform-product.yaml).';
+
+-- ---------------------------------------------------------------------------
+-- workflow_instances: a running instance of a template (WorkflowInstance).
+-- ---------------------------------------------------------------------------
+create table if not exists public.workflow_instances (
+  id          uuid primary key default gen_random_uuid(),
+  template_id text not null references public.workflow_templates(id) on delete restrict,
+  label       text not null,
+  status      text not null default 'active'
+    check (status in ('not_started', 'active', 'blocked', 'complete')),
+  roles       jsonb not null default '[]'::jsonb,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create index if not exists workflow_instances_template_id_idx
+  on public.workflow_instances (template_id);
+
+comment on table public.workflow_instances is
+  'Running instances of workflow templates (WorkflowInstance).';
+
+-- ---------------------------------------------------------------------------
+-- workflow_tasks: atomic unit of work inside an instance (WorkflowTask).
+-- Stage and role identifiers reference the JSONB stages/roles arrays on the
+-- parent template/instance; we store the string id rather than a hard FK so
+-- template edits cannot orphan rows.
+-- ---------------------------------------------------------------------------
+create table if not exists public.workflow_tasks (
+  id          uuid primary key default gen_random_uuid(),
+  instance_id uuid not null references public.workflow_instances(id) on delete cascade,
+  role_id     text not null,
+  stage_id    text not null,
+  title       text not null,
+  description text not null default '',
+  status      text not null default 'not_started'
+    check (status in ('not_started', 'active', 'pending_approval', 'blocked', 'complete')),
+  substatus   text not null default '',
+  checkpoint  boolean not null default false,
+  triggers    jsonb not null default '[]'::jsonb,
+  gates       jsonb not null default '[]'::jsonb,
+  agent       text,
+  skill       text,
+  playbook    text,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create index if not exists workflow_tasks_instance_id_idx
+  on public.workflow_tasks (instance_id);
+create index if not exists workflow_tasks_status_idx
+  on public.workflow_tasks (status);
+
+comment on table public.workflow_tasks is
+  'Per-instance task rows materialized from a template''s task_templates (WorkflowTask).';
+comment on column public.workflow_tasks.description is
+  'Renamed from spec field `desc` to avoid the SQL reserved word.';
+
+-- ---------------------------------------------------------------------------
+-- workflow_events: structured domain events (WorkflowEvent).
+-- ---------------------------------------------------------------------------
+create table if not exists public.workflow_events (
+  id          uuid primary key default gen_random_uuid(),
+  instance_id uuid not null references public.workflow_instances(id) on delete cascade,
+  task_id     uuid references public.workflow_tasks(id) on delete cascade,
+  name        text not null,
+  description text not null default '',
+  payload     jsonb not null default '{}'::jsonb,
+  created_at  timestamptz not null default now()
+);
+
+create index if not exists workflow_events_instance_id_idx
+  on public.workflow_events (instance_id, created_at desc);
+create index if not exists workflow_events_task_id_idx
+  on public.workflow_events (task_id, created_at desc);
+
+comment on table public.workflow_events is
+  'Domain events emitted against an instance/task (WorkflowEvent). Feeds the Event Feed.';
+
+-- ---------------------------------------------------------------------------
+-- framework_items: editable Skills + Playbooks library (FrameworkItem).
+-- ---------------------------------------------------------------------------
+create table if not exists public.framework_items (
+  id          text primary key,
+  type        text not null check (type in ('skill', 'playbook')),
+  name        text not null,
+  description text not null default '',
+  icon        text,
+  content     text not null default '',
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create index if not exists framework_items_type_idx
+  on public.framework_items (type);
+
+comment on table public.framework_items is
+  'Founder-authored Skills and Playbooks rendered by the Framework screens (FrameworkItem).';
+
+-- ---------------------------------------------------------------------------
+-- updated_at maintenance
+-- ---------------------------------------------------------------------------
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists workflow_templates_set_updated_at on public.workflow_templates;
+create trigger workflow_templates_set_updated_at
+  before update on public.workflow_templates
+  for each row execute function public.set_updated_at();
+
+drop trigger if exists workflow_instances_set_updated_at on public.workflow_instances;
+create trigger workflow_instances_set_updated_at
+  before update on public.workflow_instances
+  for each row execute function public.set_updated_at();
+
+drop trigger if exists workflow_tasks_set_updated_at on public.workflow_tasks;
+create trigger workflow_tasks_set_updated_at
+  before update on public.workflow_tasks
+  for each row execute function public.set_updated_at();
+
+drop trigger if exists framework_items_set_updated_at on public.framework_items;
+create trigger framework_items_set_updated_at
+  before update on public.framework_items
+  for each row execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- Row Level Security — single-user V1 per DEC-002.
+-- Every table is restricted to authenticated users. Policies are intentionally
+-- coarse (any signed-in session sees all rows) because V1 has exactly one
+-- founder per installation; multi-tenant scoping arrives with a later PR when
+-- a `company_id` is introduced.
+-- ---------------------------------------------------------------------------
+alter table public.workflow_templates enable row level security;
+alter table public.workflow_instances enable row level security;
+alter table public.workflow_tasks     enable row level security;
+alter table public.workflow_events    enable row level security;
+alter table public.framework_items    enable row level security;
+
+drop policy if exists "workflow_templates: authenticated read"   on public.workflow_templates;
+drop policy if exists "workflow_templates: authenticated write"  on public.workflow_templates;
+create policy "workflow_templates: authenticated read"
+  on public.workflow_templates for select to authenticated using (true);
+create policy "workflow_templates: authenticated write"
+  on public.workflow_templates for all     to authenticated using (true) with check (true);
+
+drop policy if exists "workflow_instances: authenticated read"   on public.workflow_instances;
+drop policy if exists "workflow_instances: authenticated write"  on public.workflow_instances;
+create policy "workflow_instances: authenticated read"
+  on public.workflow_instances for select to authenticated using (true);
+create policy "workflow_instances: authenticated write"
+  on public.workflow_instances for all     to authenticated using (true) with check (true);
+
+drop policy if exists "workflow_tasks: authenticated read"   on public.workflow_tasks;
+drop policy if exists "workflow_tasks: authenticated write"  on public.workflow_tasks;
+create policy "workflow_tasks: authenticated read"
+  on public.workflow_tasks for select to authenticated using (true);
+create policy "workflow_tasks: authenticated write"
+  on public.workflow_tasks for all     to authenticated using (true) with check (true);
+
+drop policy if exists "workflow_events: authenticated read"   on public.workflow_events;
+drop policy if exists "workflow_events: authenticated write"  on public.workflow_events;
+create policy "workflow_events: authenticated read"
+  on public.workflow_events for select to authenticated using (true);
+create policy "workflow_events: authenticated write"
+  on public.workflow_events for all     to authenticated using (true) with check (true);
+
+drop policy if exists "framework_items: authenticated read"   on public.framework_items;
+drop policy if exists "framework_items: authenticated write"  on public.framework_items;
+create policy "framework_items: authenticated read"
+  on public.framework_items for select to authenticated using (true);
+create policy "framework_items: authenticated write"
+  on public.framework_items for all     to authenticated using (true) with check (true);

--- a/products/dashboard/supabase/migrations/20260419120100_workflow_seed.sql
+++ b/products/dashboard/supabase/migrations/20260419120100_workflow_seed.sql
@@ -1,0 +1,199 @@
+-- Seed migration for the four canonical workflow templates and the founder
+-- Skills/Playbooks library used by the dashboard mock data.
+--
+-- Source files (design handoff, kept under /tmp/design-canvas):
+--   * `Process Canvas v2/data.js` -> updated stages/roles/icons for the four
+--     templates and the canonical CompanyX task list used to derive the
+--     Client Project Delivery `task_templates` (per AEL-47 + TransportBand01).
+--   * `pc-components.jsx` -> `FRAMEWORK_ITEMS_DEFAULT` (Skills + Playbooks)
+--     and `taskTemplates` for Product Development / Go-to-Market / Operations.
+--
+-- This migration is idempotent (`on conflict ... do update`) so re-running it
+-- against an existing dev database refreshes the seed in place.
+
+-- ---------------------------------------------------------------------------
+-- Workflow templates
+-- ---------------------------------------------------------------------------
+insert into public.workflow_templates (id, label, color, multi_instance, stages, roles, task_templates)
+values
+  -- Client Project Delivery (TransportBand01-aligned: 8 stages, 7 roles).
+  -- task_templates derived from the CompanyX instance tasks in v2 data.js:
+  -- triggers reference upstream task titles (taskRef) rather than instance ids.
+  (
+    'client-delivery',
+    'Client Project Delivery',
+    '#6366f1',
+    true,
+    '[
+      {"id":"pre-sales","label":"Pre-Sales","sub":"Customer"},
+      {"id":"validation","label":"Validation","sub":"PDR"},
+      {"id":"ready","label":"Ready","sub":"Received PO"},
+      {"id":"planning","label":"Planning","sub":"Project"},
+      {"id":"in-dev","label":"In Development","sub":"Product Launch"},
+      {"id":"deployment","label":"Deployment","sub":"Installation"},
+      {"id":"closure","label":"Closure","sub":"Confirmation"},
+      {"id":"delivered","label":"Delivered","sub":"Done"}
+    ]'::jsonb,
+    '[
+      {"id":"sales","label":"Sales","owner":"Hans / Dave"},
+      {"id":"product","label":"Product","owner":"Andres / Dechaun"},
+      {"id":"finance","label":"Finance","owner":"Joanna"},
+      {"id":"project","label":"Project","owner":"Patrick"},
+      {"id":"dev","label":"Development","owner":"Noah / Dev Team"},
+      {"id":"marketing","label":"Marketing","owner":"Cristina"},
+      {"id":"infra","label":"Support / Infra","owner":"Robert"}
+    ]'::jsonb,
+    '[
+      {"role":"sales","stage":"pre-sales","title":"Project Description","desc":"Define objective, identify PDR need","agent":"Sales Ops","skill":"sales-ops","playbook":"presales-qualification","triggers":[{"type":"manual","label":"Manual start"}],"gates":[{"type":"playbook_done","label":"Agent completes playbook"}]},
+      {"role":"sales","stage":"ready","title":"FO & TO Confirmation","desc":"Functional and technical description confirmation","agent":"Sales Ops","skill":"sales-ops","playbook":"fo-to-confirmation","triggers":[{"type":"after_task","taskRef":"PDR Review","label":"After PDR Review"}],"gates":[{"type":"playbook_done","label":"Agent completes playbook"}]},
+      {"role":"sales","stage":"planning","title":"Update Business Model","desc":"Update pricebook, article numbers, Navision","agent":"Sales Ops","skill":"sales-ops","playbook":"business-model-update","triggers":[{"type":"after_task","taskRef":"Project Scope & Planning","label":"After Project Scope & Planning"}],"gates":[{"type":"checkpoint","label":"Human review required"}]},
+      {"role":"sales","stage":"delivered","title":"Account Management","desc":"Cross/upselling, renewal opportunities","agent":"Sales Ops","skill":"sales-ops","playbook":"account-management","triggers":[{"type":"after_task","taskRef":"Project Delivery Confirmation","label":"After Project Delivery Confirmation"}],"gates":[{"type":"manual","label":"Human initiates"}]},
+      {"role":"product","stage":"validation","title":"PDR Review","desc":"Evaluate, accept or reject, offer to customer","agent":"PM","skill":"pm","playbook":"pdr-review","triggers":[{"type":"after_task","taskRef":"Project Description","label":"After Project Description"}],"gates":[{"type":"checkpoint","label":"Human approval required"}]},
+      {"role":"product","stage":"planning","title":"Roadmap Estimation","desc":"Capacity & prioritization for this project","agent":"PM","skill":"pm","playbook":"roadmap-estimation","triggers":[{"type":"after_task","taskRef":"PDR Review","label":"After PDR Review"}],"gates":[{"type":"playbook_done","label":"Agent completes playbook"}]},
+      {"role":"product","stage":"in-dev","title":"Backlog Refinement","desc":"Feature grooming & sprint support","agent":"PM","skill":"pm","playbook":"backlog-refinement","checkpoint":true,"triggers":[{"type":"after_task","taskRef":"Project Scope & Planning","label":"After Project Scope & Planning"},{"type":"after_task","taskRef":"Register Quote","label":"After Register Quote"}],"gates":[{"type":"checkpoint","label":"Human approval to start sprint"}]},
+      {"role":"product","stage":"delivered","title":"Usage Metrics","desc":"Platform metrics & feature usage reporting","agent":"PM","skill":"pm","playbook":"usage-metrics","triggers":[{"type":"after_task","taskRef":"Project Delivery Confirmation","label":"After Project Delivery Confirmation"}],"gates":[{"type":"playbook_done","label":"Agent completes playbook"}]},
+      {"role":"finance","stage":"ready","title":"Initial Invoicing","desc":"Send initial invoice (usually 50%)","agent":"Finance Ops","skill":"finance-ops","playbook":"initial-invoicing","triggers":[{"type":"after_task","taskRef":"FO & TO Confirmation","label":"After FO & TO Confirmation"}],"gates":[{"type":"playbook_done","label":"Agent sends invoice"}]},
+      {"role":"finance","stage":"ready","title":"Project Confirmation","desc":"PO confirmation, project start authorization","agent":"Finance Ops","skill":"finance-ops","playbook":"project-confirmation","triggers":[{"type":"after_task","taskRef":"Initial Invoicing","label":"After Initial Invoicing"}],"gates":[{"type":"checkpoint","label":"Human confirms PO received"}]},
+      {"role":"finance","stage":"planning","title":"Register Quote","desc":"Quote added to Exact, linked to project","agent":"Finance Ops","skill":"finance-ops","playbook":"register-quote","triggers":[{"type":"after_task","taskRef":"Project Confirmation","label":"After Project Confirmation"}],"gates":[{"type":"playbook_done","label":"Agent completes entry"}]},
+      {"role":"finance","stage":"deployment","title":"SLA Invoicing","desc":"Send invoice upon delivery (when applicable)","agent":"Finance Ops","skill":"finance-ops","playbook":"sla-invoicing","triggers":[{"type":"after_task","taskRef":"Acceptation","label":"After Acceptation"}],"gates":[{"type":"playbook_done","label":"Agent sends invoice"}]},
+      {"role":"finance","stage":"closure","title":"Final Invoicing","desc":"Send final invoice & close financially","agent":"Finance Ops","skill":"finance-ops","playbook":"final-invoicing","triggers":[{"type":"after_task","taskRef":"Project Delivery Confirmation","label":"After Project Delivery Confirmation"}],"gates":[{"type":"checkpoint","label":"Human confirms invoice sent"}]},
+      {"role":"project","stage":"planning","title":"Project Scope & Planning","desc":"Timeline, phases, dependencies, customer alignment","agent":"Project Mgr","skill":"project","playbook":"project-planning","triggers":[{"type":"after_task","taskRef":"Project Confirmation","label":"After Project Confirmation"}],"gates":[{"type":"checkpoint","label":"Human reviews plan"}]},
+      {"role":"project","stage":"deployment","title":"Acceptation","desc":"Testing & feedback loop with customer","agent":"Project Mgr","skill":"project","playbook":"acceptation","triggers":[{"type":"after_task","taskRef":"Software Release","label":"After Software Release"}],"gates":[{"type":"checkpoint","label":"Customer sign-off required"}]},
+      {"role":"project","stage":"deployment","title":"Production Rollout","desc":"End-user onboarding, go-live coordination","agent":"Project Mgr","skill":"project","playbook":"production-rollout","triggers":[{"type":"after_task","taskRef":"Acceptation","label":"After Acceptation"}],"gates":[{"type":"checkpoint","label":"Human approves go-live"}]},
+      {"role":"project","stage":"closure","title":"Project Delivery Confirmation","desc":"Validate completion, no pending items","agent":"Project Mgr","skill":"project","playbook":"delivery-confirmation","triggers":[{"type":"after_task","taskRef":"Production Rollout","label":"After Production Rollout"},{"type":"after_task","taskRef":"Setup & License","label":"After Setup & License"}],"gates":[{"type":"checkpoint","label":"Human final sign-off"}]},
+      {"role":"project","stage":"delivered","title":"Customer Relationship","desc":"Follow up, future planning, maintenance coordination","agent":"Project Mgr","skill":"project","playbook":"customer-relationship","triggers":[{"type":"after_task","taskRef":"Project Delivery Confirmation","label":"After Project Delivery Confirmation"}],"gates":[{"type":"manual","label":"Ongoing — human managed"}]},
+      {"role":"dev","stage":"in-dev","title":"Software Release","desc":"Epics, stories, development, hotfixes, QA","agent":"Builder","skill":"builder","playbook":"dev-execution","triggers":[{"type":"after_task","taskRef":"Backlog Refinement","label":"After Backlog Refinement approval"}],"gates":[{"type":"playbook_done","label":"All stories done + QA pass"}]},
+      {"role":"marketing","stage":"pre-sales","title":"Lead Generation","desc":"Processes, tools and campaigns","agent":"Growth","skill":"growth","playbook":"lead-generation","triggers":[{"type":"manual","label":"Manual start"}],"gates":[{"type":"playbook_done","label":"Lead qualified"}]},
+      {"role":"marketing","stage":"in-dev","title":"Marketing Assets","desc":"Feature newsletter, product content & communication","agent":"Growth","skill":"growth","playbook":"marketing-assets","triggers":[{"type":"after_task","taskRef":"Backlog Refinement","label":"After Backlog Refinement"}],"gates":[{"type":"checkpoint","label":"Human reviews content"}]},
+      {"role":"marketing","stage":"deployment","title":"Communication Confirmation","desc":"Consent for commercial communication","agent":"Growth","skill":"growth","playbook":"comms-confirmation","triggers":[{"type":"after_task","taskRef":"Production Rollout","label":"After Production Rollout"}],"gates":[{"type":"checkpoint","label":"Customer consent confirmed"}]},
+      {"role":"marketing","stage":"delivered","title":"Use Cases","desc":"Customer content, photos, market analysis","agent":"Growth","skill":"growth","playbook":"use-cases","triggers":[{"type":"after_task","taskRef":"Customer Relationship","label":"After Customer Relationship starts"}],"gates":[{"type":"playbook_done","label":"Content published"}]},
+      {"role":"marketing","stage":"delivered","title":"Client Communication","desc":"Newsletter, client satisfaction follow-up","agent":"Growth","skill":"growth","playbook":"client-communication","triggers":[{"type":"after_task","taskRef":"Use Cases","label":"After Use Cases"}],"gates":[{"type":"playbook_done","label":"Communication sent"}]},
+      {"role":"infra","stage":"planning","title":"Installation & Infra Planning","desc":"Setup and IT requirements, prerequisites","agent":"DevOps","skill":"devops","playbook":"infra-planning","triggers":[{"type":"after_task","taskRef":"Project Scope & Planning","label":"After Project Scope & Planning"}],"gates":[{"type":"playbook_done","label":"Infra plan approved"}]},
+      {"role":"infra","stage":"in-dev","title":"Support Content","desc":"Support website, LMS courses preparation","agent":"DevOps","skill":"devops","playbook":"support-content","triggers":[{"type":"after_task","taskRef":"Installation & Infra Planning","label":"After Infra Planning"}],"gates":[{"type":"playbook_done","label":"Content published"}]},
+      {"role":"infra","stage":"deployment","title":"Setup & License","desc":"Infrastructure provisioning, license activation","agent":"DevOps","skill":"devops","playbook":"infra-setup","triggers":[{"type":"after_task","taskRef":"Acceptation","label":"After Acceptation"}],"gates":[{"type":"checkpoint","label":"Human confirms infra live"}]},
+      {"role":"infra","stage":"delivered","title":"Customer Support","desc":"Helpdesk, training, documentation","agent":"DevOps","skill":"devops","playbook":"customer-support","triggers":[{"type":"after_task","taskRef":"Customer Relationship","label":"After Customer Relationship"}],"gates":[{"type":"manual","label":"Ongoing — human managed"}]}
+    ]'::jsonb
+  ),
+  -- Product Development
+  (
+    'product-dev',
+    'Product Development',
+    '#10b981',
+    false,
+    '[
+      {"id":"ideation","label":"Ideation","sub":"Problem definition"},
+      {"id":"design","label":"Design","sub":"Spec & prototype"},
+      {"id":"build","label":"Build","sub":"Vertical slice"},
+      {"id":"review","label":"Review","sub":"Quality gate"},
+      {"id":"ship","label":"Ship","sub":"Deployed"},
+      {"id":"measure","label":"Measure","sub":"Feedback loop"}
+    ]'::jsonb,
+    '[
+      {"id":"product","label":"Product","owner":"Andres"},
+      {"id":"design","label":"Design","owner":"Designer Agent"},
+      {"id":"engineering","label":"Engineering","owner":"Dev Team"},
+      {"id":"qa","label":"Quality","owner":"QA Agent"}
+    ]'::jsonb,
+    '[
+      {"role":"product","stage":"ideation","title":"Problem Statement","desc":"User, goal, constraints, metrics","agent":"PM","skill":"pm","playbook":"problem-framing","triggers":[{"type":"manual","label":"New feature request"}],"gates":[{"type":"playbook_done","label":"Schema-valid spec"}]},
+      {"role":"design","stage":"ideation","title":"Discovery Research","desc":"Interviews, competitive analysis","agent":"Researcher","skill":"researcher","playbook":"discovery-research","triggers":[{"type":"after_task","taskRef":"Problem Statement","label":"Problem scoped"}],"gates":[{"type":"playbook_done","label":"Research report"}]},
+      {"role":"product","stage":"design","title":"Slice Spec","desc":"Event catalog, data model","agent":"PM","skill":"pm","playbook":"slice-spec","triggers":[{"type":"after_task","taskRef":"Discovery Research","label":"Research complete"}],"gates":[{"type":"playbook_done","label":"Validate passes"}]},
+      {"role":"design","stage":"design","title":"UI Prototype","desc":"Hi-fi, 3 variations","agent":"Designer","skill":"designer","playbook":"ui-design","checkpoint":true,"triggers":[{"type":"after_task","taskRef":"Slice Spec","label":"Spec validated"}],"gates":[{"type":"checkpoint","label":"Design review approval"}]},
+      {"role":"engineering","stage":"build","title":"Vertical Slice","desc":"UI + API + persistence + telemetry","agent":"Builder","skill":"builder","playbook":"dev-execution","triggers":[{"type":"after_task","taskRef":"UI Prototype","label":"Design approved"}],"gates":[{"type":"playbook_done","label":"Deployed to staging"}]},
+      {"role":"qa","stage":"review","title":"Quality Gate","desc":"Unit, E2E, accessibility, evals","agent":"QA Engineer","skill":"qa","playbook":"quality-gate","triggers":[{"type":"after_task","taskRef":"Vertical Slice","label":"Slice built"}],"gates":[{"type":"checkpoint","label":"All suites passing"}]}
+    ]'::jsonb
+  ),
+  -- Go-to-Market
+  (
+    'gtm',
+    'Go-to-Market',
+    '#f59e0b',
+    false,
+    '[
+      {"id":"positioning","label":"Positioning","sub":"ICP & narrative"},
+      {"id":"assets","label":"Assets","sub":"Content & pages"},
+      {"id":"launch","label":"Launch","sub":"Go live"},
+      {"id":"growth","label":"Growth","sub":"Demand gen"},
+      {"id":"retention","label":"Retention","sub":"Ongoing"}
+    ]'::jsonb,
+    '[
+      {"id":"product","label":"Product","owner":"Andres"},
+      {"id":"growth","label":"Growth","owner":"Growth Agent"},
+      {"id":"content","label":"Content","owner":"Content Agent"}
+    ]'::jsonb,
+    '[
+      {"role":"product","stage":"positioning","title":"ICP Definition","desc":"Ideal customer profile, JTBD","agent":"Strategist","skill":"strategist","playbook":"icp-definition","triggers":[{"type":"manual","label":"New launch"}],"gates":[{"type":"checkpoint","label":"Human approves ICP"}]},
+      {"role":"content","stage":"assets","title":"Landing Page","desc":"Copy, design, analytics wiring","agent":"Growth","skill":"growth","playbook":"landing-page","triggers":[{"type":"after_task","taskRef":"ICP Definition","label":"ICP confirmed"}],"gates":[{"type":"checkpoint","label":"Human reviews page"}]},
+      {"role":"growth","stage":"growth","title":"Outbound Sequence","desc":"Cold email + LinkedIn","agent":"Sales Ops","skill":"sales-ops","playbook":"outbound-sequence","triggers":[{"type":"after_task","taskRef":"Landing Page","label":"Page live"}],"gates":[{"type":"playbook_done","label":"Sequence launched"}]}
+    ]'::jsonb
+  ),
+  -- Operations
+  (
+    'operations',
+    'Operations',
+    '#06b6d4',
+    true,
+    '[
+      {"id":"monitor","label":"Monitor","sub":"Observability"},
+      {"id":"triage","label":"Triage","sub":"Issues"},
+      {"id":"resolve","label":"Resolve","sub":"Fix & deploy"},
+      {"id":"learn","label":"Learn","sub":"Retro & improve"}
+    ]'::jsonb,
+    '[
+      {"id":"infra","label":"Infra","owner":"Robert"},
+      {"id":"support","label":"Support","owner":"Support Agent"},
+      {"id":"finance","label":"Finance","owner":"Joanna"}
+    ]'::jsonb,
+    '[
+      {"role":"infra","stage":"monitor","title":"Observability Sweep","desc":"Check dashboards, alerts, error budgets","agent":"DevOps","skill":"devops","playbook":"observability-sweep","triggers":[{"type":"manual","label":"Daily / on-call"}],"gates":[{"type":"playbook_done","label":"Sweep complete"}]},
+      {"role":"support","stage":"triage","title":"Issue Triage","desc":"Scope, urgency, affected users","agent":"Support","skill":"support","playbook":"issue-triage","triggers":[{"type":"after_task","taskRef":"Observability Sweep","label":"Issues detected"}],"gates":[{"type":"checkpoint","label":"Triage P0/P1"}]},
+      {"role":"infra","stage":"resolve","title":"Fix & Deploy","desc":"Investigate, patch, deploy","agent":"Builder","skill":"builder","playbook":"incident-resolution","triggers":[{"type":"after_task","taskRef":"Issue Triage","label":"Triage done"}],"gates":[{"type":"playbook_done","label":"Fix deployed"}]},
+      {"role":"infra","stage":"learn","title":"Retro & Improve","desc":"Postmortem, action items","agent":"PM","skill":"pm","playbook":"postmortem","triggers":[{"type":"after_task","taskRef":"Fix & Deploy","label":"Incident closed"}],"gates":[{"type":"playbook_done","label":"Action items filed"}]}
+    ]'::jsonb
+  )
+on conflict (id) do update set
+  label          = excluded.label,
+  color          = excluded.color,
+  multi_instance = excluded.multi_instance,
+  stages         = excluded.stages,
+  roles          = excluded.roles,
+  task_templates = excluded.task_templates,
+  updated_at     = now();
+
+-- ---------------------------------------------------------------------------
+-- Framework items (Skills + Playbooks library)
+-- Source: pc-components.jsx FRAMEWORK_ITEMS_DEFAULT.
+-- ---------------------------------------------------------------------------
+insert into public.framework_items (id, type, name, description, icon, content)
+values
+  ('sk-pm','skill','PM','Product management, spec authoring, prioritization','📋',
+    E'# PM Skill\n\n## When to use\nShaping a requested change into scope, rationale, acceptance criteria, and implementation guidance.\n\n## Inputs\n- Goal, constraints, selected concept, affected surfaces\n\n## Outputs\n- Concise change brief, scope, non-goals, acceptance criteria\n\n## Steps\n1. Read relevant spec and decision log\n2. Clarify goal and constraints\n3. Define scope and non-goals\n4. Write testable acceptance criteria\n5. Flag risks and dependencies'),
+  ('sk-designer','skill','Designer','UI/UX design, visual explorations, hi-fi prototypes','🎨',
+    E'# Designer Skill\n\n## When to use\nCreating or refining visual assets, brand elements, and design directions.\n\n## Inputs\n- Goal, brand intent, target surface, references\n\n## Outputs\n- Concrete design directions, implementation-ready handoff\n\n## Steps\n1. Read design system tokens\n2. Explore 3+ directions\n3. Produce hi-fi variations\n4. Request human review\n5. Deliver specs'),
+  ('sk-builder','skill','Builder','Implementation, vertical slices, tests','⚡',
+    E'# Builder Skill\n\n## When to use\nImplementing changes and carrying them through validation, PR review, and merge.\n\n## Inputs\n- Approved scope, affected files, constraints\n\n## Outputs\n- Implementation, verification evidence, published PR\n\n## Steps\n1. Read spec and acceptance criteria\n2. Implement vertical slice\n3. Write tests\n4. Run validation gates\n5. Submit PR'),
+  ('sk-devops','skill','DevOps','Infrastructure, deployment, environments','🔧',
+    E'# DevOps Skill\n\n## When to use\nConfiguring infrastructure, deployment pipelines, environment separation.\n\n## Steps\n1. Survey current infrastructure\n2. Define requirements per service\n3. Configure environments\n4. Wire observability tools\n5. Document and verify'),
+  ('sk-researcher','skill','Researcher','Market research, ICP analysis, discovery','🔍',
+    E'# Researcher Skill\n\n## When to use\nMapped to discovery workflows, user interview synthesis, or competitive analysis.\n\n## Steps\n1. Define research questions\n2. Gather data\n3. Synthesize findings\n4. Produce structured report\n5. Flag assumptions'),
+  ('sk-strategist','skill','Strategist','Strategic positioning, ICP, go-to-market','🧭',
+    E'# Strategist Skill\n\n## When to use\nShaping positioning, ICP definition, and market strategy.\n\n## Steps\n1. Analyze market segments\n2. Define ICP and JTBD\n3. Map competitive landscape\n4. Produce positioning recommendations\n5. Validate with founder'),
+  ('sk-qa','skill','QA Engineer','Testing, quality gates, regression coverage','✅',
+    E'# QA Engineer Skill\n\n## When to use\nWriting tests, triaging CI failures, quality gates.\n\n## Steps\n1. Read spec and acceptance criteria\n2. Identify test layers\n3. Write unit, integration, E2E tests\n4. Run full suite\n5. Produce evidence bundle'),
+  ('sk-project','skill','Project','Project management, planning, coordination','🗂️',
+    E'# Project Skill\n\n## When to use\nManaging project timelines, coordination, and stakeholder alignment.\n\n## Steps\n1. Read project brief\n2. Define phases and timeline\n3. Identify dependencies\n4. Align stakeholders\n5. Track progress'),
+  ('pb-presales','playbook','presales-qualification','Qualify new client opportunities','📄',
+    E'# Presales Qualification\n\n## Objective\nAssess whether a new opportunity should proceed to PDR review.\n\n## Steps\n1. Gather project description\n2. Assess fit against ICP\n3. Estimate scope\n4. Produce qualification document\n5. Deliver to Product for review\n\n## Human checkpoints\n- None for standard qualification\n- Escalate for unusually large scope'),
+  ('pb-backlog','playbook','backlog-refinement','Groom and estimate sprint backlog','📄',
+    E'# Backlog Refinement\n\n## Objective\nPrepare a prioritized, estimated backlog for sprint kick-off.\n\n## Steps\n1. Read product spec\n2. Map requirements to epics\n3. Generate stories with acceptance criteria\n4. Estimate effort (SP)\n5. Flag overflow\n6. Request human approval\n\n## Human checkpoints\n- Approval required before sprint starts'),
+  ('pb-devexec','playbook','dev-execution','Implement a vertical slice end to end','📄',
+    E'# Dev Execution\n\n## Objective\nDeliver a complete vertical slice: UI + API + persistence + telemetry.\n\n## Steps\n1. Set up branch\n2. Implement UI\n3. Implement API\n4. Wire persistence\n5. Add telemetry\n6. Write tests\n7. Run gates\n8. Submit PR\n\n## Human checkpoints\n- PR review before merge'),
+  ('pb-quality','playbook','quality-gate','Run all quality gates before shipping','📄',
+    E'# Quality Gate\n\n## Objective\nEnsure production-readiness before merge.\n\n## Steps\n1. Run unit tests\n2. Run integration tests\n3. Run E2E (Playwright)\n4. Check accessibility\n5. Run evals\n6. Produce evidence bundle\n\n## Human checkpoints\n- Spot-check for high-risk changes')
+on conflict (id) do update set
+  type        = excluded.type,
+  name        = excluded.name,
+  description = excluded.description,
+  icon        = excluded.icon,
+  content     = excluded.content,
+  updated_at  = now();


### PR DESCRIPTION
## Summary

Stand up the data layer for workflows so subsequent UI work can read/write real state instead of mock data. **No UI changes in this PR.**

Closes [AEL-47](https://linear.app/aelizondo/issue/AEL-47).

### Migrations (`products/dashboard/supabase/migrations/`)
- `20260419120000_workflow_persistence.sql` — `workflow_templates`, `workflow_instances`, `workflow_tasks`, `workflow_events`, `framework_items`, `updated_at` triggers, indexes, and RLS for `authenticated` per **DEC-002** (single-user V1).
- `20260419120100_workflow_seed.sql` — idempotent seed for the four canonical templates and the founder Skills + Playbooks library. **Client Project Delivery** is the TransportBand01-aligned version (8 stages incl. Closure, 7 roles incl. Marketing/Support+Infra, full task templates derived from the v2 design canvas CompanyX instance).

### Interfaces (`interfaces/interfaces.yaml`)
- New `workflow_repository` logical interface with operations: `get_templates`, `get_instance`, `list_instances`, `create_instance`, `update_task`, `add_event`, `get_framework_items`, `upsert_framework_item`.
- New `supabase_workflow_repository` adapter pinning the V1 implementation. Business logic targets the interface, not Supabase directly, per §5.1 Layer 1.

### Implementation (`products/dashboard/lib/workflows/`)
- `types.ts` — domain types mirroring the SQL schema (camelCase).
- `repository.ts` — thin Supabase wrapper implementing the interface. `createInstance` materializes per-instance task rows from the template's `task_templates` JSON and copies default roles. snake_case ↔ camelCase mapping is centralized.
- `repository.server.ts` — server-side factory using the cookie-aware `@supabase/ssr` client so RLS sees the signed-in user (mirrors the existing auth adapter pattern).

### Tests (`products/dashboard/__tests__/lib/workflows/repository.test.ts`)
9 unit tests with an in-memory fake Supabase client (no Docker, no network):
- `getTemplates` returns mapped, ordered templates
- `createInstance` materializes tasks, handles empty templates, rejects unknown template ids
- `updateTask` patches mutable fields and rejects empty patches
- `addEvent` + `getInstance` round-trip
- `getFrameworkItems` filtering by type
- `upsertFrameworkItem` replaces existing rows

## Test plan

- [x] `npm run validate` green (interfaces.yaml + spec examples parse and validate)
- [x] `npm test` green in `products/dashboard` (16 files, 129 tests)
- [x] No UI changes in this PR
- [ ] CodeRabbit threads resolved
- [ ] Mergify gates green and merged

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow persistence and management capabilities to the dashboard.
  * Introduced four workflow templates: client-delivery, product-dev, gtm, and operations.
  * Enabled workflow instance creation, task management, and event tracking.
  * Added framework items library with predefined skills and playbooks.

* **Tests**
  * Added comprehensive test suite for workflow repository operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->