### PR TITLE
feat(dashboard): workflow tree + create-instance modal (AEL-48)

### DIFF
--- a/products/dashboard/__tests__/components/sidebar-workflow-tree.test.tsx
+++ b/products/dashboard/__tests__/components/sidebar-workflow-tree.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * Component test for components/workflows/sidebar-workflow-tree.tsx.
+ * Spec anchor: AEL-48 — Workflow tree + create-instance modal.
+ *
+ * Covers:
+ *   - Workflow tree renders one section per template, expanded by default,
+ *     with the count pill reflecting instance count.
+ *   - Each instance gets a navigable link to /workflows/{id}.
+ *   - Clicking "+ New instance" opens the create-instance modal scoped to
+ *     the clicked template, the create button is disabled until a label
+ *     is typed, and submitting calls the server action, captures the
+ *     `workflow.instance_created` analytics event, and navigates to the
+ *     new instance's detail page.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRouter } from "next/navigation";
+import posthog from "posthog-js";
+
+import type { WorkflowTemplate } from "@/lib/workflows/types";
+
+const { mockCreateInstanceAction } = vi.hoisted(() => ({
+  mockCreateInstanceAction: vi.fn(),
+}));
+
+vi.mock("@/app/(dashboard)/workflows/actions", () => ({
+  createInstanceAction: mockCreateInstanceAction,
+}));
+
+import { SidebarWorkflowTree } from "@/components/workflows/sidebar-workflow-tree";
+
+const TEMPLATE_A: WorkflowTemplate = {
+  id: "client-delivery",
+  label: "Client Project Delivery",
+  color: "#6366f1",
+  multiInstance: true,
+  stages: [
+    { id: "pre-sales", label: "Pre-Sales" },
+    { id: "validation", label: "Validation" },
+  ],
+  roles: [
+    { id: "sales", label: "Sales" },
+    { id: "product", label: "Product" },
+  ],
+  taskTemplates: [
+    { role: "sales", stage: "pre-sales", title: "Project Description" },
+    { role: "product", stage: "validation", title: "PDR Review" },
+  ],
+  createdAt: "2026-04-19T12:00:00Z",
+  updatedAt: "2026-04-19T12:00:00Z",
+};
+
+const TEMPLATE_B: WorkflowTemplate = {
+  id: "product-dev",
+  label: "Product Development",
+  color: "#10b981",
+  multiInstance: false,
+  stages: [],
+  roles: [],
+  taskTemplates: [],
+  createdAt: "2026-04-19T12:00:00Z",
+  updatedAt: "2026-04-19T12:00:00Z",
+};
+
+describe("SidebarWorkflowTree", () => {
+  const pushSpy = vi.fn();
+
+  beforeEach(() => {
+    mockCreateInstanceAction.mockReset();
+    pushSpy.mockReset();
+    vi.mocked(posthog.capture).mockClear();
+    vi.mocked(useRouter).mockReturnValue({
+      push: pushSpy,
+      replace: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+    });
+  });
+
+  it("falls back to the empty state placeholder when there are no templates", () => {
+    render(
+      <SidebarWorkflowTree templates={[]} instancesByTemplate={{}} />,
+    );
+    expect(screen.getByTestId("sidebar-workflows-empty")).toBeInTheDocument();
+  });
+
+  it("renders one section per template with an instance count and per-instance links", () => {
+    render(
+      <SidebarWorkflowTree
+        templates={[TEMPLATE_A, TEMPLATE_B]}
+        instancesByTemplate={{
+          "client-delivery": [
+            {
+              id: "inst-1",
+              templateId: "client-delivery",
+              label: "Acme Corp",
+              status: "active",
+              roles: TEMPLATE_A.roles,
+              createdAt: "2026-04-19T12:00:00Z",
+              updatedAt: "2026-04-19T12:00:00Z",
+            },
+            {
+              id: "inst-2",
+              templateId: "client-delivery",
+              label: "Globex Co",
+              status: "not_started",
+              roles: TEMPLATE_A.roles,
+              createdAt: "2026-04-19T12:00:00Z",
+              updatedAt: "2026-04-19T12:00:00Z",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Client Project Delivery")).toBeInTheDocument();
+    expect(screen.getByText("Product Development")).toBeInTheDocument();
+
+    // Default-expanded → instance links are visible
+    expect(
+      screen.getByTestId("workflow-instance-link-inst-1"),
+    ).toHaveAttribute("href", "/workflows/inst-1");
+    expect(
+      screen.getByTestId("workflow-instance-link-inst-2"),
+    ).toHaveAttribute("href", "/workflows/inst-2");
+
+    // Count pill shows instance count for the populated template
+    expect(
+      screen.getByTestId("workflow-template-count-client-delivery"),
+    ).toHaveTextContent("2");
+  });
+
+  it("opens the create-instance modal scoped to the clicked template", async () => {
+    const user = userEvent.setup();
+    render(
+      <SidebarWorkflowTree
+        templates={[TEMPLATE_A]}
+        instancesByTemplate={{ "client-delivery": [] }}
+      />,
+    );
+
+    await user.click(screen.getByTestId("workflow-new-instance-client-delivery"));
+
+    const modal = await screen.findByTestId("create-instance-modal");
+    expect(modal).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: /new client project delivery instance/i }),
+    ).toBeInTheDocument();
+    // The "N stages · N roles · N tasks" line reflects the scoped template
+    expect(screen.getByTestId("create-instance-info")).toHaveTextContent(
+      /2 stages.*2 roles.*2 tasks/i,
+    );
+  });
+
+  it("disables Create until the label is non-empty, then submits, captures, and navigates", async () => {
+    const user = userEvent.setup();
+    mockCreateInstanceAction.mockResolvedValue({
+      instance: {
+        id: "inst-new",
+        templateId: "client-delivery",
+        label: "Acme Corp",
+        status: "active",
+        roles: TEMPLATE_A.roles,
+        createdAt: "2026-04-19T12:00:00Z",
+        updatedAt: "2026-04-19T12:00:00Z",
+      },
+    });
+
+    render(
+      <SidebarWorkflowTree
+        templates={[TEMPLATE_A]}
+        instancesByTemplate={{ "client-delivery": [] }}
+      />,
+    );
+
+    await user.click(screen.getByTestId("workflow-new-instance-client-delivery"));
+
+    const create = screen.getByRole("button", { name: /^create\s*→?$/i });
+    expect(create).toBeDisabled();
+
+    const input = screen.getByRole("textbox", { name: /instance name/i });
+    await user.type(input, "  Acme Corp  ");
+    expect(create).toBeEnabled();
+
+    await user.click(create);
+
+    await waitFor(() =>
+      expect(mockCreateInstanceAction).toHaveBeenCalledWith(
+        "client-delivery",
+        "Acme Corp",
+      ),
+    );
+
+    await waitFor(() =>
+      expect(posthog.capture).toHaveBeenCalledWith(
+        "workflow.instance_created",
+        { instance_id: "inst-new", template_id: "client-delivery" },
+      ),
+    );
+
+    await waitFor(() =>
+      expect(pushSpy).toHaveBeenCalledWith("/workflows/inst-new"),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("create-instance-modal")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("surfaces server-action errors inline and keeps the modal open", async () => {
+    const user = userEvent.setup();
+    mockCreateInstanceAction.mockRejectedValue(
+      new Error("createInstance: unknown template_id"),
+    );
+
+    render(
+      <SidebarWorkflowTree
+        templates={[TEMPLATE_A]}
+        instancesByTemplate={{ "client-delivery": [] }}
+      />,
+    );
+
+    await user.click(screen.getByTestId("workflow-new-instance-client-delivery"));
+    await user.type(
+      screen.getByRole("textbox", { name: /instance name/i }),
+      "Acme",
+    );
+    await user.click(screen.getByRole("button", { name: /^create\s*→?$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/unknown template_id/i),
+    );
+    expect(screen.getByTestId("create-instance-modal")).toBeInTheDocument();
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+});

--- a/products/dashboard/app/(dashboard)/layout.tsx
+++ b/products/dashboard/app/(dashboard)/layout.tsx
@@ -1,8 +1,47 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/service.server";
 import { Sidebar } from "@/components/sidebar";
+import type { SidebarInstanceView } from "@/components/workflows/sidebar-workflow-tree";
 import { TopBar } from "@/components/top-bar";
 import { AuthIdentitySync } from "@/components/auth-identity-sync";
+import { captureError } from "@/lib/monitoring";
+import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
+import type { WorkflowInstance, WorkflowTemplate } from "@/lib/workflows/types";
+
+/**
+ * Server-side load of the workflow tree data the sidebar renders.
+ *
+ * Returns empty arrays / maps on failure so a transient Supabase error
+ * never takes down the entire dashboard chrome — the sidebar renders the
+ * dashed empty-state placeholder instead. Sentry still receives the
+ * error via the canonical `captureError` so we can see it in production.
+ */
+async function loadSidebarWorkflowTree(): Promise<{
+  templates: WorkflowTemplate[];
+  instancesByTemplate: Record<string, SidebarInstanceView[]>;
+}> {
+  try {
+    const repo = await getServerWorkflowRepository();
+    const [templates, instances] = await Promise.all([
+      repo.getTemplates(),
+      repo.listInstances(),
+    ]);
+
+    const instancesByTemplate: Record<string, SidebarInstanceView[]> = {};
+    for (const instance of instances satisfies WorkflowInstance[]) {
+      const bucket = instancesByTemplate[instance.templateId] ?? [];
+      // PR 5 has no per-task aggregation yet; `hasPending` and `progress`
+      // light up automatically when PR 8 wires task state.
+      bucket.push({ ...instance });
+      instancesByTemplate[instance.templateId] = bucket;
+    }
+
+    return { templates, instancesByTemplate };
+  } catch (error) {
+    captureError(error, { feature: "sidebar.workflow_tree" });
+    return { templates: [], instancesByTemplate: {} };
+  }
+}
 
 /**
  * Authenticated dashboard shell.
@@ -24,10 +63,16 @@ export default async function DashboardLayout({
     redirect("/login");
   }
 
+  const { templates, instancesByTemplate } = await loadSidebarWorkflowTree();
+
   return (
     <>
       <AuthIdentitySync user={user} provider={user.provider} />
-      <Sidebar user={user} />
+      <Sidebar
+        user={user}
+        templates={templates}
+        instancesByTemplate={instancesByTemplate}
+      />
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         <TopBar />
         <main className="min-h-0 flex-1 overflow-y-auto bg-bg">{children}</main>

--- a/products/dashboard/app/(dashboard)/workflows/[instanceId]/page.tsx
+++ b/products/dashboard/app/(dashboard)/workflows/[instanceId]/page.tsx
@@ -1,0 +1,69 @@
+import { notFound } from "next/navigation";
+
+import { ShellEvents } from "@/components/shell-events";
+import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
+
+/**
+ * Workflow instance route — stub.
+ *
+ * PR 5 lands the routing target so the create-instance modal has
+ * somewhere to navigate after a successful insert. The Process Matrix
+ * canvas itself ships in PR 7; for now we render the instance label
+ * and a placeholder note so the page is discoverable in QA without
+ * inventing matrix UI we'd just throw away.
+ */
+
+interface Params {
+  instanceId: string;
+}
+
+export default async function WorkflowInstancePage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { instanceId } = await params;
+
+  const repo = await getServerWorkflowRepository();
+  const instance = await repo.getInstance(instanceId);
+
+  if (!instance) {
+    notFound();
+  }
+
+  return (
+    <>
+      <ShellEvents route="/workflows/[instanceId]" />
+
+      <div className="overflow-y-auto p-6">
+        <header className="mb-5">
+          <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+            Workflow instance
+          </p>
+          <h1 className="mt-1 text-[20px] font-bold tracking-tight text-t1">
+            {instance.label}
+          </h1>
+          <p className="mt-1 text-[13px] text-t2">
+            {instance.tasks.length}{" "}
+            {instance.tasks.length === 1 ? "task" : "tasks"} ·{" "}
+            {instance.roles.length}{" "}
+            {instance.roles.length === 1 ? "role" : "roles"} · status{" "}
+            <span className="font-medium text-t1">{instance.status}</span>
+          </p>
+        </header>
+
+        <section className="rounded-[10px] border border-dashed border-border bg-bg-2 px-6 py-10 text-center">
+          <h2 className="text-[14px] font-semibold text-t1">
+            Matrix coming in PR 7
+          </h2>
+          <p className="mx-auto mt-1.5 max-w-md text-[12px] text-t2">
+            The Process Matrix view (sticky stage headers, role rows, task
+            cards with state pills) lands once the core canvas component
+            is ready. This page exists today so create-instance flows
+            have a routing target.
+          </p>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
+import type { WorkflowInstance } from "@/lib/workflows/types";
+
+/**
+ * Server action invoked by the create-instance modal.
+ *
+ * Calls into the cookie-aware Supabase repository so RLS sees the signed-in
+ * user (DEC-002), then `revalidatePath('/', 'layout')` so the next render
+ * of the dashboard layout (and therefore the sidebar workflow tree fed by
+ * `getServerWorkflowRepository().listInstances()`) picks up the new row.
+ *
+ * Returns the persisted instance so the modal can navigate to
+ * `/workflows/{id}` without a second round-trip.
+ *
+ * Inputs are trimmed and length-clamped here so untrusted client input
+ * cannot smuggle blank labels or pathological strings into the database.
+ */
+
+const MAX_LABEL_LENGTH = 120;
+
+export interface CreateInstanceResult {
+  instance: WorkflowInstance;
+}
+
+export async function createInstanceAction(
+  templateId: string,
+  rawLabel: string,
+): Promise<CreateInstanceResult> {
+  if (typeof templateId !== "string" || !templateId.trim()) {
+    throw new Error("createInstanceAction: templateId is required");
+  }
+  if (typeof rawLabel !== "string") {
+    throw new Error("createInstanceAction: label must be a string");
+  }
+
+  const label = rawLabel.trim().slice(0, MAX_LABEL_LENGTH);
+  if (!label) {
+    throw new Error("createInstanceAction: label cannot be empty");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const detail = await repo.createInstance(templateId.trim(), label);
+
+  revalidatePath("/", "layout");
+
+  // Strip the heavy `tasks`/`events` arrays before returning to the client —
+  // the modal only needs the persisted id + label to navigate.
+  const { tasks: _tasks, events: _events, ...instance } = detail;
+  return { instance };
+}

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -225,3 +225,26 @@ body {
   padding: 8px;
   justify-content: center;
 }
+
+/*
+ * Tooltip enter animation. Used by the collapsed-mode workflow dots
+ * (`SidebarWorkflowTree.CollapsedInstanceDot`) which render their
+ * tooltip via a portal, so the keyframe lives in global CSS rather
+ * than inline. Cubic curve matches the prototype's general "settle"
+ * easing; honors `prefers-reduced-motion`.
+ */
+@keyframes ainative-tooltip-in {
+  from {
+    opacity: 0;
+    transform: translate(-4px, -50%);
+  }
+  to {
+    opacity: 1;
+    transform: translate(0, -50%);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  [role="tooltip"] {
+    animation: none !important;
+  }
+}

--- a/products/dashboard/components/sidebar.tsx
+++ b/products/dashboard/components/sidebar.tsx
@@ -23,6 +23,11 @@ import { useSidebarCollapsed } from "@/lib/sidebar";
 import { useTheme } from "@/lib/theme";
 import { useSignOut } from "@/lib/auth/use-sign-out";
 import type { AuthUser } from "@/lib/auth/types";
+import type { WorkflowTemplate } from "@/lib/workflows/types";
+import {
+  SidebarWorkflowTree,
+  type SidebarInstanceView,
+} from "@/components/workflows/sidebar-workflow-tree";
 
 /**
  * Dashboard left rail.
@@ -182,7 +187,28 @@ function UserMenu({
   );
 }
 
-export function Sidebar({ user }: { user: AuthUser }) {
+export interface SidebarProps {
+  user: AuthUser;
+  /**
+   * Workflow templates fetched server-side in `app/(dashboard)/layout.tsx`
+   * via `getServerWorkflowRepository().getTemplates()`. Defaults to an
+   * empty array so legacy callers (and tests that don't care about the
+   * tree) still render the empty-state placeholder.
+   */
+  templates?: WorkflowTemplate[];
+  /**
+   * Instances grouped by `template_id`. Each instance may carry an
+   * optional `hasPending` flag (derived once the parent has task data
+   * — currently always `false` — and a `progress` ratio.
+   */
+  instancesByTemplate?: Record<string, SidebarInstanceView[]>;
+}
+
+export function Sidebar({
+  user,
+  templates = [],
+  instancesByTemplate = {},
+}: SidebarProps) {
   const pathname = usePathname();
   const { collapsed, toggleCollapsed } = useSidebarCollapsed();
   const { theme, toggleTheme } = useTheme();
@@ -264,29 +290,30 @@ export function Sidebar({ user }: { user: AuthUser }) {
           <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.13em] text-t3">
             Workflows
           </span>
-          <button
-            type="button"
-            disabled
-            title="New workflow — coming soon"
-            aria-label="New workflow (coming soon)"
-            className="flex h-[18px] w-[18px] cursor-not-allowed items-center justify-center rounded-[5px] border border-border text-t3 opacity-60"
+          {/*
+           * "+ New workflow" — opens the template editor. PR 12 wires the
+           * actual editor route, but the link is in place so the affordance
+           * is keyboard- and screen-reader-reachable today.
+           */}
+          <Link
+            href="/workflows/templates/new"
+            aria-label="New workflow"
+            title="New workflow"
+            data-testid="sidebar-new-workflow"
+            className="flex h-[18px] w-[18px] items-center justify-center rounded-[5px] border border-border text-t3 hover:border-accent hover:text-accent transition-colors"
           >
             <Plus className="h-3 w-3" />
-          </button>
+          </Link>
         </div>
       </div>
 
-      {/* Scrollable middle: workflow tree placeholder.
-          Real tree lands in PR 4 / PR 5 when workflow templates + instances exist. */}
+      {/* Scrollable middle: workflow tree (templates + instances), or the
+          dashed placeholder when no templates exist yet. */}
       <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-1.5 py-1">
-        <div
-          data-sidebar-collapsible
-          data-testid="sidebar-workflows-empty"
-          className="rounded-md border border-dashed border-border px-3 py-3 text-[11px] leading-relaxed text-t3"
-        >
-          No workflows yet. Define a workflow template to start tracking
-          instances here.
-        </div>
+        <SidebarWorkflowTree
+          templates={templates}
+          instancesByTemplate={instancesByTemplate}
+        />
       </div>
 
       {/* Fixed bottom: workspace nav */}

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -22,6 +22,9 @@ const ROUTE_LABELS: ReadonlyArray<{ test: (path: string) => boolean; crumbs: str
   { test: (p) => p === "/framework/playbooks" || p.startsWith("/framework/playbooks/"), crumbs: ["Playbooks"] },
   { test: (p) => p === "/events" || p.startsWith("/events/"), crumbs: ["Event Feed"] },
   { test: (p) => p === "/settings" || p.startsWith("/settings/"), crumbs: ["Settings"] },
+  // Workflow instance routes carry the instance label in the page itself,
+  // so the breadcrumb stays generic until per-instance metadata is wired.
+  { test: (p) => p.startsWith("/workflows/"), crumbs: ["Workflows", "Instance"] },
 ];
 
 function deriveCrumbs(pathname: string | null): string[] {

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -24,7 +24,9 @@ const ROUTE_LABELS: ReadonlyArray<{ test: (path: string) => boolean; crumbs: str
   { test: (p) => p === "/settings" || p.startsWith("/settings/"), crumbs: ["Settings"] },
   // Workflow instance routes carry the instance label in the page itself,
   // so the breadcrumb stays generic until per-instance metadata is wired.
-  { test: (p) => p.startsWith("/workflows/"), crumbs: ["Workflows", "Instance"] },
+  // Match exactly one segment after `/workflows/` so sub-routes like
+  // `/workflows/templates/new` (PR12 stub) don't pick up the instance crumb.
+  { test: (p) => /^\/workflows\/[^/]+\/?$/.test(p), crumbs: ["Workflows", "Instance"] },
 ];
 
 function deriveCrumbs(pathname: string | null): string[] {

--- a/products/dashboard/components/workflows/create-instance-modal.tsx
+++ b/products/dashboard/components/workflows/create-instance-modal.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useId, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { createInstanceAction } from "@/app/(dashboard)/workflows/actions";
+import { useAnalytics } from "@/lib/analytics/events";
+import { cn } from "@/lib/utils";
+import type { WorkflowTemplate } from "@/lib/workflows/types";
+
+/**
+ * Dialog that creates a new `WorkflowInstance` from a template.
+ *
+ * Visual contract: prototype `CreateInstanceModal` (`Process Canvas.html`
+ * lines 616-628 + `.modal*` tokens lines 329-344). 460px wide card,
+ * blurred overlay, title (no template-color tint), prototype subtitle,
+ * info row with bold counts, "Cancel" / "Create →" buttons.
+ *
+ * The modal is rendered by the sidebar (where the trigger lives) and
+ * controlled via `open` / `onClose`, so the sidebar owns the open
+ * template selection and we don't have to reach into a global store.
+ *
+ * Behavior:
+ * - Backdrop click and Escape close the modal (unless a create is in
+ *   flight — we don't want to drop a half-finished mutation).
+ * - Enter inside the input submits when the trimmed name is non-empty
+ *   (mirrors the prototype's `onKeyDown` behavior).
+ * - On success: `capture('workflow.instance_created', ...)`, then
+ *   `router.push('/workflows/{id}')`. The server action also revalidates
+ *   the dashboard layout so the sidebar reflects the new row when the
+ *   matrix route renders.
+ * - The Create button is disabled until the trimmed label is non-empty,
+ *   matching the issue's "disabled until name non-empty" requirement.
+ */
+function placeholderForTemplate(templateId: string, label: string): string {
+  if (templateId === "client-delivery") return "e.g. CompanyZ";
+  if (templateId === "product-dev") return "e.g. Dashboard v2";
+  if (templateId === "gtm") return "e.g. Q2 launch";
+  if (templateId === "operations") return "e.g. Q3 ops cycle";
+  return `e.g. ${label} — Q3`;
+}
+export function CreateInstanceModal({
+  template,
+  open,
+  onClose,
+}: {
+  template: WorkflowTemplate | null;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [label, setLabel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+  const { capture } = useAnalytics();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const titleId = useId();
+  const errorId = useId();
+
+  // Reset transient state every time the dialog re-opens for a (possibly
+  // different) template. Without this the previous label would leak into
+  // the next "+ New instance" click.
+  useEffect(() => {
+    if (open) {
+      setLabel("");
+      setError(null);
+    }
+  }, [open, template?.id]);
+
+  useEffect(() => {
+    if (!open) return;
+    const id = window.setTimeout(() => inputRef.current?.focus(), 0);
+    return () => window.clearTimeout(id);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape" && !isPending) {
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose, isPending]);
+
+  if (!open || !template) return null;
+
+  const trimmed = label.trim();
+  const canSubmit = trimmed.length > 0 && !isPending;
+
+  const stageCount = template.stages.length;
+  const roleCount = template.roles.length;
+  const taskCount = template.taskTemplates.length;
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit || !template) return;
+    setError(null);
+
+    const submittedLabel = trimmed;
+    const templateId = template.id;
+
+    startTransition(async () => {
+      try {
+        const { instance } = await createInstanceAction(templateId, submittedLabel);
+        capture("workflow.instance_created", {
+          instance_id: instance.id,
+          template_id: instance.templateId,
+        });
+        onClose();
+        router.push(`/workflows/${instance.id}`);
+      } catch (err) {
+        // Surface the message inline; the action throws human-readable
+        // strings for validation failures and a generic message for
+        // repository errors.
+        setError(
+          err instanceof Error && err.message
+            ? err.message
+            : "Could not create the instance. Try again.",
+        );
+      }
+    });
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      data-testid="create-instance-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--overlay)] p-4 backdrop-blur-[3px]"
+      onMouseDown={(event) => {
+        // Close only on direct backdrop clicks, not on clicks inside the
+        // dialog that bubble up. Block while a request is in flight.
+        if (event.target === event.currentTarget && !isPending) {
+          onClose();
+        }
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        // Prototype `.modal`: 460px wide, 28px padding, 14px radius.
+        className="w-full max-w-[460px] rounded-[14px] border border-border-hi bg-bg-2 p-7 shadow-[var(--shadow-canvas)]"
+      >
+        <h2
+          id={titleId}
+          // Prototype `.modal-title`: 16px, weight 700, tight letter-spacing.
+          className="text-[16px] font-bold tracking-tight text-t1"
+        >
+          New {template.label} instance
+        </h2>
+        <p className="mt-1 text-[12.5px] text-t3">
+          Creates an instance with all default stages, roles, and tasks.
+        </p>
+
+        <label className="mt-[22px] block">
+          <span className="mb-1.5 block text-[11px] font-medium text-t2">
+            Instance name
+          </span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={label}
+            onChange={(event) => setLabel(event.target.value)}
+            placeholder={placeholderForTemplate(template.id, template.label)}
+            maxLength={120}
+            required
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? errorId : undefined}
+            className="block w-full rounded-lg border border-border bg-bg-3 px-3 py-2.5 text-[13px] text-t1 placeholder:text-t3 focus:border-primary focus:outline-none"
+          />
+        </label>
+
+        <p
+          data-testid="create-instance-info"
+          className="mt-3.5 rounded-lg border border-border bg-bg-3 px-3 py-2.5 text-[12px] leading-[1.6] text-t2"
+        >
+          <strong className="text-t1">
+            {stageCount} {stageCount === 1 ? "stage" : "stages"}
+          </strong>{" "}
+          ·{" "}
+          <strong className="text-t1">
+            {roleCount} {roleCount === 1 ? "role" : "roles"}
+          </strong>{" "}
+          ·{" "}
+          <strong className="text-t1">
+            {taskCount} {taskCount === 1 ? "task" : "tasks"}
+          </strong>{" "}
+          — pre-configured. Roles and tasks editable after creation.
+        </p>
+
+        {error && (
+          <p
+            id={errorId}
+            role="alert"
+            className="mt-3 text-[11.5px] text-[color:var(--pill-blocked-t)]"
+          >
+            {error}
+          </p>
+        )}
+
+        <footer className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isPending}
+            className="rounded-lg border border-border bg-bg-3 px-[18px] py-2 text-[13px] font-medium text-t2 transition-colors hover:bg-bg-4 hover:text-t1 disabled:opacity-60"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className={cn(
+              "rounded-lg bg-primary px-5 py-2 text-[13px] font-semibold text-white transition-opacity",
+              canSubmit ? "hover:opacity-90" : "cursor-not-allowed opacity-40",
+            )}
+          >
+            {isPending ? "Creating…" : "Create →"}
+          </button>
+        </footer>
+      </form>
+    </div>
+  );
+}

--- a/products/dashboard/components/workflows/create-instance-modal.tsx
+++ b/products/dashboard/components/workflows/create-instance-modal.tsx
@@ -59,6 +59,11 @@ export function CreateInstanceModal({
   const { capture } = useAnalytics();
   const inputRef = useRef<HTMLInputElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
+  // Imperative submit lock. Without this, rapid Enter/Enter or
+  // click/click can re-enter `handleSubmit` before React flushes the
+  // `isPending` state update from `startTransition`, double-firing
+  // `createInstanceAction` and creating duplicate instances.
+  const submitLockRef = useRef(false);
   const titleId = useId();
   const errorId = useId();
 
@@ -127,45 +132,47 @@ export function CreateInstanceModal({
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!canSubmit || !template) return;
+    if (!canSubmit || !template || submitLockRef.current) return;
+    submitLockRef.current = true;
     setError(null);
 
     const submittedLabel = trimmed;
     const templateId = template.id;
 
     startTransition(async () => {
-      let created;
       try {
-        created = await createInstanceAction(templateId, submittedLabel);
+        const created = await createInstanceAction(templateId, submittedLabel);
+
+        // Best-effort analytics: a tracker failure (network blocked,
+        // PostHog bootstrap error, etc.) must never break the success
+        // path or the user will see a misleading error for an instance
+        // that already exists.
+        try {
+          capture("workflow.instance_created", {
+            instance_id: created.instance.id,
+            template_id: created.instance.templateId,
+          });
+        } catch {
+          // Intentionally swallow; the create already succeeded.
+        }
+
+        onClose();
+        router.push(`/workflows/${created.instance.id}`);
       } catch (err) {
         // Surface the message inline; the action throws human-readable
         // strings for validation failures and a generic message for
-        // repository errors. Only mutation failures land here — analytics
-        // is handled separately below so a PostHog hiccup can never
-        // shadow a successful create.
+        // repository errors. Only mutation failures land here —
+        // analytics errors are swallowed by the inner try/catch above.
         setError(
           err instanceof Error && err.message
             ? err.message
             : "Could not create the instance. Try again.",
         );
-        return;
+      } finally {
+        // Always release the lock so a fixed validation error or a
+        // retry after a transient failure can submit again.
+        submitLockRef.current = false;
       }
-
-      // Best-effort analytics: a tracker failure (network blocked,
-      // PostHog bootstrap error, etc.) must never break the success
-      // path or the user will see a misleading error for an instance
-      // that already exists.
-      try {
-        capture("workflow.instance_created", {
-          instance_id: created.instance.id,
-          template_id: created.instance.templateId,
-        });
-      } catch {
-        // Intentionally swallow; the create already succeeded.
-      }
-
-      onClose();
-      router.push(`/workflows/${created.instance.id}`);
     });
   }
 

--- a/products/dashboard/components/workflows/create-instance-modal.tsx
+++ b/products/dashboard/components/workflows/create-instance-modal.tsx
@@ -23,12 +23,16 @@ import type { WorkflowTemplate } from "@/lib/workflows/types";
  * Behavior:
  * - Backdrop click and Escape close the modal (unless a create is in
  *   flight — we don't want to drop a half-finished mutation).
+ * - Tab/Shift+Tab are trapped inside the dialog (focusable elements
+ *   are recomputed on each Tab so dynamic state — disabled buttons,
+ *   the error region — doesn't leak focus into the page behind).
  * - Enter inside the input submits when the trimmed name is non-empty
  *   (mirrors the prototype's `onKeyDown` behavior).
- * - On success: `capture('workflow.instance_created', ...)`, then
- *   `router.push('/workflows/{id}')`. The server action also revalidates
- *   the dashboard layout so the sidebar reflects the new row when the
- *   matrix route renders.
+ * - On success: `router.push('/workflows/{id}')` runs unconditionally
+ *   so an analytics-side failure (e.g., PostHog blocked) cannot cause
+ *   us to surface an error for an instance that was actually persisted
+ *   or invite a duplicate submission. `capture(...)` is a best-effort
+ *   call inside its own try/catch.
  * - The Create button is disabled until the trimmed label is non-empty,
  *   matching the issue's "disabled until name non-empty" requirement.
  */
@@ -54,6 +58,7 @@ export function CreateInstanceModal({
   const router = useRouter();
   const { capture } = useAnalytics();
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
   const titleId = useId();
   const errorId = useId();
 
@@ -78,6 +83,33 @@ export function CreateInstanceModal({
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape" && !isPending) {
         onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      // Focus trap: keep keyboard focus inside the dialog. Recompute
+      // the focusable list on every Tab so disabled-state changes
+      // (e.g., the Create button toggling on/off) and conditionally
+      // rendered nodes (the error alert) don't leak focus.
+      const root = dialogRef.current;
+      if (!root) return;
+      const focusables = Array.from(
+        root.querySelectorAll<HTMLElement>(
+          'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((el) => !el.hasAttribute("inert") && el.offsetParent !== null);
+      if (focusables.length === 0) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (e.shiftKey && (active === first || !root.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !root.contains(active))) {
+        e.preventDefault();
+        first.focus();
       }
     }
     window.addEventListener("keydown", onKey);
@@ -102,29 +134,44 @@ export function CreateInstanceModal({
     const templateId = template.id;
 
     startTransition(async () => {
+      let created;
       try {
-        const { instance } = await createInstanceAction(templateId, submittedLabel);
-        capture("workflow.instance_created", {
-          instance_id: instance.id,
-          template_id: instance.templateId,
-        });
-        onClose();
-        router.push(`/workflows/${instance.id}`);
+        created = await createInstanceAction(templateId, submittedLabel);
       } catch (err) {
         // Surface the message inline; the action throws human-readable
         // strings for validation failures and a generic message for
-        // repository errors.
+        // repository errors. Only mutation failures land here — analytics
+        // is handled separately below so a PostHog hiccup can never
+        // shadow a successful create.
         setError(
           err instanceof Error && err.message
             ? err.message
             : "Could not create the instance. Try again.",
         );
+        return;
       }
+
+      // Best-effort analytics: a tracker failure (network blocked,
+      // PostHog bootstrap error, etc.) must never break the success
+      // path or the user will see a misleading error for an instance
+      // that already exists.
+      try {
+        capture("workflow.instance_created", {
+          instance_id: created.instance.id,
+          template_id: created.instance.templateId,
+        });
+      } catch {
+        // Intentionally swallow; the create already succeeded.
+      }
+
+      onClose();
+      router.push(`/workflows/${created.instance.id}`);
     });
   }
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-labelledby={titleId}

--- a/products/dashboard/components/workflows/sidebar-workflow-tree.tsx
+++ b/products/dashboard/components/workflows/sidebar-workflow-tree.tsx
@@ -1,0 +1,450 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChevronRight, Pencil, Plus } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type {
+  WorkflowInstance,
+  WorkflowTemplate,
+} from "@/lib/workflows/types";
+
+import { CreateInstanceModal } from "./create-instance-modal";
+
+/**
+ * Sidebar workflow tree — one collapsible section per template, with the
+ * template's instances listed underneath and a per-template "+ New
+ * instance" trigger that opens the create-instance modal scoped to that
+ * template.
+ *
+ * Visual contract: prototype `Sidebar.WorkflowTree` block (`Process
+ * Canvas.html` lines 494-538) and the `pt-*` class definitions in the
+ * same file (lines 75-103). The shape mirrored here:
+ *
+ *   pt-header  → arrow · name(flex-1) · count-pill · [pending-dot]
+ *   pt-instances (indent 16px)
+ *     pt-instance → 5px dot · name(flex-1) · progress-bar(36px)
+ *     pt-new     → "+ New instance" (always last)
+ *
+ * Per the issue acceptance criteria the workflow name uses the template
+ * color (the prototype uses `--t2`); every other token follows the
+ * prototype literally so the visual matches Process Canvas. Two further
+ * deliberate tweaks vs. the prototype:
+ *   - the active-instance label is left at `--t2` (prototype paints it
+ *     `--accent`); the indigo row background already signals selection
+ *     and the colored dot reinforces the template grouping;
+ *   - every instance dot stays at the template color regardless of
+ *     active/pending state — this matches the collapsed-mode rendering
+ *     (one template-colored dot per instance) so the visual language
+ *     stays consistent across collapsed/expanded.
+ *
+ * Pending state: if any task on an instance is in `pending_approval`,
+ * the parent template header surfaces a small amber pending dot. The
+ * instance dot itself does not change color; the row's amber pip is
+ * what calls the user's attention. PR 5 has no live task aggregation,
+ * so `hasPending` defaults to `false` and the visual stays inactive
+ * until PR 8 wires the task drawer.
+ */
+
+export interface SidebarInstanceView extends WorkflowInstance {
+  /** True when any task on the instance is `pending_approval`. */
+  hasPending?: boolean;
+  /**
+   * Completion ratio in [0, 1]. Optional because we don't have task
+   * counts yet in PR 5; falls back to a status-derived approximation.
+   */
+  progress?: number;
+}
+
+interface Props {
+  templates: WorkflowTemplate[];
+  instancesByTemplate: Record<string, SidebarInstanceView[]>;
+}
+
+/**
+ * Status → progress fallback used when the parent hasn't computed an
+ * exact ratio. Intentionally coarse so the bar matches the prototype's
+ * "feels right" look for empty instances.
+ */
+function fallbackProgress(status: WorkflowInstance["status"]): number {
+  switch (status) {
+    case "complete":
+      return 1;
+    case "active":
+      return 0.4;
+    case "blocked":
+      return 0.25;
+    case "not_started":
+    default:
+      return 0;
+  }
+}
+
+function instanceHref(instanceId: string): string {
+  return `/workflows/${instanceId}`;
+}
+
+function isActive(pathname: string | null, href: string): boolean {
+  if (!pathname) return false;
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+/**
+ * Collapsed-mode instance dot. The visible dot is small (10–14px) but the
+ * link itself is a 24×24 hit-box for comfortable clicking. Hover/focus
+ * grows the dot, brightens it, and surfaces a tooltip with the
+ * "Template · Instance" label.
+ *
+ * The tooltip is rendered via `createPortal(..., document.body)` so it
+ * escapes the sidebar's `overflow-x-hidden` scroll container; without
+ * the portal, an absolutely-positioned tooltip would be clipped by the
+ * sidebar walls. Position is computed from the link's bounding rect on
+ * each show, so we don't have to subscribe to scroll/resize events
+ * (the tooltip only lives while the user hovers/focuses, and we
+ * reposition on show).
+ */
+interface CollapsedInstanceDotProps {
+  instance: SidebarInstanceView;
+  template: WorkflowTemplate;
+  active: boolean;
+}
+
+function CollapsedInstanceDot({
+  instance,
+  template,
+  active,
+}: CollapsedInstanceDotProps) {
+  const [mounted, setMounted] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState({ top: 0, left: 0 });
+  const linkRef = useRef<HTMLAnchorElement>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  function reveal() {
+    const rect = linkRef.current?.getBoundingClientRect();
+    if (rect) {
+      setCoords({
+        top: rect.top + rect.height / 2,
+        left: rect.right + 8,
+      });
+    }
+    setOpen(true);
+  }
+
+  const tooltip = `${template.label} · ${instance.label}`;
+  const href = instanceHref(instance.id);
+
+  return (
+    <>
+      <Link
+        ref={linkRef}
+        href={href}
+        aria-label={tooltip}
+        aria-current={active ? "page" : undefined}
+        data-testid={`workflow-instance-dot-${instance.id}`}
+        onMouseEnter={reveal}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={reveal}
+        onBlur={() => setOpen(false)}
+        className={cn(
+          "group/dot flex h-6 w-6 items-center justify-center rounded-full",
+          "transition-transform duration-150 ease-out",
+          "hover:scale-110 focus-visible:scale-110",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg-2",
+        )}
+      >
+        <span
+          aria-hidden
+          className={cn(
+            "block h-2.5 w-2.5 rounded-full",
+            "transition-[width,height,box-shadow,filter] duration-150 ease-out",
+            "group-hover/dot:h-3.5 group-hover/dot:w-3.5",
+            "group-focus-visible/dot:h-3.5 group-focus-visible/dot:w-3.5",
+            !active && "opacity-80 group-hover/dot:opacity-100",
+          )}
+          style={{
+            backgroundColor: template.color,
+            boxShadow: active
+              ? `0 0 0 2px var(--bg-2), 0 0 0 3px ${template.color}`
+              : undefined,
+          }}
+        />
+      </Link>
+      {mounted &&
+        open &&
+        createPortal(
+          <div
+            role="tooltip"
+            data-testid={`workflow-instance-tooltip-${instance.id}`}
+            style={{
+              position: "fixed",
+              top: coords.top,
+              left: coords.left,
+              // The dot is anchored at the right edge of the link's
+              // bounding rect; offset by 8px (set in `reveal`) so the
+              // tooltip floats just past the dot. Translate up by half
+              // its own height to vertically center on the dot.
+              transform: "translate(0, -50%)",
+              zIndex: 60,
+              animation:
+                "ainative-tooltip-in 120ms cubic-bezier(0.16, 1, 0.3, 1) both",
+            }}
+            className={cn(
+              "pointer-events-none whitespace-nowrap rounded-md border border-border-hi bg-bg-2 px-2 py-1",
+              "text-[11px] font-medium text-t1 shadow-[var(--shadow-canvas)]",
+            )}
+          >
+            <span className="text-t3">{template.label}</span>
+            <span className="mx-1 text-t3">·</span>
+            <span>{instance.label}</span>
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+export function SidebarWorkflowTree({ templates, instancesByTemplate }: Props) {
+  const pathname = usePathname();
+
+  // Default every template to expanded — the prototype shows them open
+  // and there are usually <10 templates, so collapse-all-by-default
+  // would feel empty.
+  const defaultExpanded = useMemo(() => {
+    const acc: Record<string, boolean> = {};
+    for (const t of templates) acc[t.id] = true;
+    return acc;
+  }, [templates]);
+
+  const [expanded, setExpanded] = useState<Record<string, boolean>>(defaultExpanded);
+  const [modalTemplate, setModalTemplate] = useState<WorkflowTemplate | null>(null);
+
+  function toggle(id: string) {
+    setExpanded((prev) => ({ ...prev, [id]: prev[id] === false }));
+  }
+
+  if (templates.length === 0) {
+    return (
+      <>
+        <div
+          data-sidebar-collapsible
+          data-testid="sidebar-workflows-empty"
+          className="rounded-md border border-dashed border-border px-3 py-3 text-[11px] leading-relaxed text-t3"
+        >
+          No workflows yet. Define a workflow template to start tracking
+          instances here.
+        </div>
+        {/* Collapsed-mode placeholder — keeps vertical rhythm without
+            rendering text the user can't read in icon-only mode. */}
+        <div data-sidebar-when-collapsed className="hidden" aria-hidden />
+      </>
+    );
+  }
+
+  return (
+    <>
+      {/* Collapsed mode: one template-colored dot per instance.
+          Clicking a dot navigates to that instance. Templates with no
+          instances render nothing — the "+ New workflow" button in the
+          sidebar header is the collapsed-mode affordance for adding
+          work. See `CollapsedInstanceDot` for the dot/hit-box/tooltip
+          contract (portal-rendered tooltip to escape the sidebar's
+          horizontal-overflow clipping). */}
+      <div
+        data-sidebar-when-collapsed
+        className="flex flex-col items-center gap-1 py-1"
+      >
+        {templates.flatMap((template) => {
+          const instances = instancesByTemplate[template.id] ?? [];
+          return instances.map((instance) => (
+            <CollapsedInstanceDot
+              key={instance.id}
+              instance={instance}
+              template={template}
+              active={isActive(pathname, instanceHref(instance.id))}
+            />
+          ));
+        })}
+      </div>
+
+      <div data-sidebar-collapsible className="space-y-1.5">
+        {templates.map((template) => {
+          const instances = instancesByTemplate[template.id] ?? [];
+          const isOpen = expanded[template.id] !== false;
+          const templateHasPending = instances.some((i) => i.hasPending);
+
+          return (
+            <section key={template.id} aria-label={`${template.label} workflow`}>
+              <div
+                role="button"
+                tabIndex={0}
+                onClick={() => toggle(template.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    toggle(template.id);
+                  }
+                }}
+                aria-expanded={isOpen}
+                aria-controls={`tpl-${template.id}-list`}
+                data-testid={`workflow-template-toggle-${template.id}`}
+                className="group flex cursor-pointer select-none items-center gap-1.5 rounded-md px-2 py-[5px] hover:bg-bg-3 transition-colors"
+              >
+                <span
+                  className={cn(
+                    "flex h-4 w-4 shrink-0 items-center justify-center text-t3 transition-transform duration-150",
+                    isOpen && "rotate-90",
+                  )}
+                >
+                  <ChevronRight className="h-3 w-3" />
+                </span>
+                <span
+                  className="min-w-0 flex-1 truncate text-[12.5px] font-semibold"
+                  // Acceptance-criteria override: the prototype renders
+                  // the workflow name in `--t2`, but the AEL-48 issue
+                  // explicitly requires "workflow name colored with
+                  // template color" so glanceable scanning works.
+                  style={{ color: template.color }}
+                >
+                  {template.label}
+                </span>
+
+                {/* Count pill — number by default, pen icon on hover.
+                    Mirrors prototype's `pt-count-pill`/`pt-count-edit`
+                    pair (lines 86-90). The pen click navigates to the
+                    template-editor stub (PR 12 wires the real route). */}
+                <Link
+                  href={`/workflows/templates/${template.id}/edit`}
+                  onClick={(e) => e.stopPropagation()}
+                  aria-label={`Edit ${template.label} template (${instances.length} ${
+                    instances.length === 1 ? "instance" : "instances"
+                  })`}
+                  data-testid={`workflow-template-count-${template.id}`}
+                  className="ml-1.5 flex h-[18px] min-w-[22px] shrink-0 items-center justify-center rounded-full border border-border bg-bg-4 px-1.5 font-mono text-[9px] font-semibold text-t3 transition-colors group-hover:border-accent group-hover:bg-primary-bg group-hover:text-accent"
+                >
+                  <span className="block group-hover:hidden">
+                    {instances.length}
+                  </span>
+                  <span className="hidden group-hover:block">
+                    <Pencil className="h-2.5 w-2.5" />
+                  </span>
+                </Link>
+
+                {templateHasPending && (
+                  <span
+                    aria-label="Pending checkpoints"
+                    title="Pending checkpoints"
+                    className="ml-[3px] inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                    style={{
+                      backgroundColor: "var(--pill-pending-d)",
+                      boxShadow: "0 0 4px rgba(245,158,11,0.6)",
+                    }}
+                  />
+                )}
+              </div>
+
+              {isOpen && (
+                <ul
+                  id={`tpl-${template.id}-list`}
+                  className="mb-0.5 space-y-0 pl-4"
+                >
+                  {instances.map((instance) => {
+                    const href = instanceHref(instance.id);
+                    const active = isActive(pathname, href);
+                    // Always template color so the dot reads as "this
+                    // instance belongs to <template>" regardless of
+                    // active/pending — matches the collapsed-mode dots.
+                    const dotColor = template.color;
+                    const ratio = Math.max(
+                      0,
+                      Math.min(
+                        1,
+                        typeof instance.progress === "number"
+                          ? instance.progress
+                          : fallbackProgress(instance.status),
+                      ),
+                    );
+
+                    return (
+                      <li key={instance.id}>
+                        <Link
+                          href={href}
+                          aria-current={active ? "page" : undefined}
+                          data-testid={`workflow-instance-link-${instance.id}`}
+                          className={cn(
+                            "flex items-center gap-[7px] rounded-md px-2 py-[5px] transition-colors",
+                            active
+                              ? "bg-primary-bg"
+                              : "hover:bg-bg-3",
+                          )}
+                        >
+                          <span
+                            aria-hidden
+                            className="inline-block h-[5px] w-[5px] shrink-0 rounded-full"
+                            style={{ backgroundColor: dotColor }}
+                          />
+                          <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-t2">
+                            {instance.label}
+                          </span>
+                          {instance.hasPending && (
+                            <span
+                              aria-label="Pending checkpoints"
+                              title="Pending checkpoints"
+                              className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                              style={{
+                                backgroundColor: "#f59e0b",
+                                boxShadow: "0 0 5px rgba(245,158,11,0.5)",
+                              }}
+                            />
+                          )}
+                          <span
+                            aria-hidden
+                            className="block h-[2.5px] w-9 shrink-0 overflow-hidden rounded-[2px] bg-bg-4"
+                          >
+                            <span
+                              className="block h-full rounded-[2px] transition-[width] duration-300"
+                              style={{
+                                width: `${Math.round(ratio * 100)}%`,
+                                backgroundColor: template.color,
+                              }}
+                            />
+                          </span>
+                        </Link>
+                      </li>
+                    );
+                  })}
+
+                  <li>
+                    <button
+                      type="button"
+                      onClick={() => setModalTemplate(template)}
+                      data-testid={`workflow-new-instance-${template.id}`}
+                      className="flex w-full items-center gap-1.5 rounded-md px-2 py-[5px] text-left text-[11.5px] font-medium text-t3 transition-colors hover:bg-bg-3 hover:text-accent"
+                    >
+                      <span className="opacity-50">
+                        <Plus className="h-3 w-3" />
+                      </span>
+                      New instance
+                    </button>
+                  </li>
+                </ul>
+              )}
+            </section>
+          );
+        })}
+      </div>
+
+      <CreateInstanceModal
+        template={modalTemplate}
+        open={modalTemplate !== null}
+        onClose={() => setModalTemplate(null)}
+      />
+    </>
+  );
+}

--- a/products/dashboard/e2e/workflows.spec.ts
+++ b/products/dashboard/e2e/workflows.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * E2E coverage for AEL-48 — workflow tree + create-instance modal.
+ *
+ * The full happy-path (open modal → type label → create → see in sidebar
+ * → land on instance route) requires a live Supabase project with the
+ * PR 4 migration applied AND seeded templates AND the auth bypass cookie
+ * for an authenticated session. CI environments without those credentials
+ * skip the test rather than fail it; the test still encodes the expected
+ * surface so any regression on a runner that does have credentials trips
+ * immediately.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+const baseURL = process.env.BASE_URL || "http://localhost:3000";
+const bypassSecret = process.env.AUTH_E2E_BYPASS_SECRET;
+const hasSupabaseRuntime =
+  !!process.env.NEXT_PUBLIC_SUPABASE_URL &&
+  !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+async function authenticateWithBypass(page: Page) {
+  test.skip(
+    !bypassSecret,
+    "AUTH_E2E_BYPASS_SECRET is required for authenticated E2E",
+  );
+
+  await page.context().addCookies([
+    {
+      name: "dashboard_e2e_auth",
+      value: `${bypassSecret}:e2e-user:${encodeURIComponent("e2e@example.com")}`,
+      url: baseURL,
+    },
+  ]);
+}
+
+test.describe("workflows — create-instance modal", () => {
+  test("opens the modal, creates a new instance, and lands on the matrix route", async ({
+    page,
+  }) => {
+    test.skip(
+      !hasSupabaseRuntime,
+      "Supabase runtime credentials required for the workflow tree happy path",
+    );
+
+    await authenticateWithBypass(page);
+    await page.goto("/");
+
+    // Sidebar workflow tree should expose at least one template seeded by
+    // PR 4. Click the "+ New instance" trigger for the first template
+    // present in the tree.
+    const newInstance = page
+      .locator('[data-testid^="workflow-new-instance-"]')
+      .first();
+    await expect(newInstance).toBeVisible();
+    await newInstance.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // Create button is disabled until the user types a non-empty label.
+    const createBtn = dialog.getByRole("button", { name: /^create\s*→?$/i });
+    await expect(createBtn).toBeDisabled();
+
+    const uniqueLabel = `E2E Acme ${Date.now()}`;
+    await dialog.getByRole("textbox", { name: /instance name/i }).fill(uniqueLabel);
+    await expect(createBtn).toBeEnabled();
+
+    await createBtn.click();
+
+    // The modal closes, the user lands on /workflows/{id}, and the
+    // sidebar reflects the new instance.
+    await expect(dialog).toBeHidden();
+    await expect(page).toHaveURL(/\/workflows\/[0-9a-f-]+$/);
+    await expect(
+      page.getByRole("heading", { name: uniqueLabel }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: new RegExp(uniqueLabel) }),
+    ).toBeVisible();
+  });
+});

--- a/products/dashboard/e2e/workflows.spec.ts
+++ b/products/dashboard/e2e/workflows.spec.ts
@@ -75,7 +75,7 @@ test.describe("workflows — create-instance modal", () => {
       page.getByRole("heading", { name: uniqueLabel }),
     ).toBeVisible();
     await expect(
-      page.getByRole("link", { name: new RegExp(uniqueLabel) }),
+      page.getByRole("link", { name: uniqueLabel }),
     ).toBeVisible();
   });
 });

--- a/products/dashboard/lib/analytics/events.ts
+++ b/products/dashboard/lib/analytics/events.ts
@@ -26,7 +26,17 @@ export type AnalyticsEvent =
       properties: { feature_name: string; action: string };
     }
   // ── Dashboard shell ───────────────────────────────────────────────────────
-  | { event: "dashboard.shell_viewed"; properties: { route: string } };
+  | { event: "dashboard.shell_viewed"; properties: { route: string } }
+  // ── Workflows ─────────────────────────────────────────────────────────────
+  // Catalog source of truth: spec/examples/platform-product.yaml → events
+  // catalog → workflow.instance_created. The PostHog payload intentionally
+  // drops `company_id` (DEC-002 — single tenant) and `occurred_at` (the
+  // structured /api/events envelope owns timestamping); both can rejoin the
+  // catalog ingestion path without changing this surface.
+  | {
+      event: "workflow.instance_created";
+      properties: { instance_id: string; template_id: string };
+    };
 
 // ─── PART B — Client-side capture hook ───────────────────────────────────────
 //


### PR DESCRIPTION
## Summary

Slice 5 of the [Platform Dashboard MVP](https://linear.app/aelizondo/project/platform-dashboard-mvp-70a12d18de1c). Replaces the static sidebar "No workflows yet" placeholder with a live workflow tree fed by the Supabase repository (PR4 / AEL-47), and adds a per-template create-instance modal that emits `workflow.instance_created` on success.

Linear: [AEL-48 — PR 5: Workflow tree + create-instance modal](https://linear.app/aelizondo/issue/AEL-48)
Stacks on: #119 (AEL-47, persistence)
Visual contract: `Process Canvas.html` `Sidebar.WorkflowTree` block + `CreateInstanceModal` (lines 494-538, 616-628). The bundle isn't checked in but lives at `/tmp/design-canvas/ai-native-dashboard/project/Process Canvas.html`.

### What's in

**Sidebar workflow tree** (`components/workflows/sidebar-workflow-tree.tsx`)
- One collapsible `<section>` per template; arrow toggle, template-colored name, count pill on the right that flips to a pen-edit icon on hover (links to the PR12 template-editor stub).
- Template-color dot · instance label · 36px progress bar per instance row; small amber pip on the right when the instance has any task in `pending_approval`.
- Collapsed-mode rail: one template-colored 24×24 hit-box per instance with a 10–14px animated dot. Tooltip (`Template · Instance`) is rendered via `createPortal(..., document.body)` to escape the sidebar's `overflow-x-hidden` clipping; honors `prefers-reduced-motion`.
- Templates with no instances render no collapsed dot — the "+ New workflow" button at the top of the Workflows section is the collapsed-mode add-affordance.

**Create-instance modal** (`components/workflows/create-instance-modal.tsx`)
- 460px card, blurred overlay, prototype-matching copy and "Create →" button.
- Focus-trapped, Escape + backdrop close (blocked while creating). Enter inside the input submits when the trimmed name is non-empty.
- On success: `capture('workflow.instance_created', { instance_id, template_id })`, then `router.push('/workflows/{id}')`. Server action revalidates `/` (layout) so the sidebar reflects the new row.

**Server action** (`app/(dashboard)/workflows/actions.ts`)
- `createInstanceAction(templateId, label)` — validates input, trims to 120 chars, calls `repo.createInstance`, revalidates the dashboard layout.

**Layout + breadcrumbs**
- `app/(dashboard)/layout.tsx` fetches templates + instances server-side and passes them to the sidebar. Repository errors render the empty placeholder.
- `top-bar.tsx` learns about `/workflows/{id}` so the breadcrumb reads "Workflows › Instance".

**Stub instance route** (`app/(dashboard)/workflows/[instanceId]/page.tsx`)
- Server component renders label, role/task counts, and a placeholder for the matrix that lands in PR7. 404s on unknown ids.

**Analytics catalog**
- Adds `workflow.instance_created` to the `AnalyticsEvent` union with the spec-aligned payload (`instance_id`, `template_id`). The structured-events envelope (`/api/events`) is intentionally out of scope for this slice; PR13 wires it.

### Deliberate divergences from the prototype

Two acceptance-criteria-driven tweaks vs. `Process Canvas.html`:

1. **Workflow name color** — prototype uses `--t2`; AEL-48 explicitly says "workflow name colored with template color" so the name picks up `template.color`. Trivial to flip back if the issue text was a miss.
2. **Active instance label** — prototype turns it `--accent` when active; we leave it at `--t2` because the indigo row background already signals selection and the colored dot reinforces the template grouping.

Both decisions are documented in the component docstring.

### Out of scope (deferred per the 14-slice plan)

- Real task-status aggregation feeding `hasPending` / `progress` — PR7/PR8.
- Template editor route is a stub link — PR12.
- Sentry error boundaries on workflow routes — PR14.

## Test plan

- [x] `npm run validate` — green.
- [x] `npm test` — 134/134 pass (5 new in `sidebar-workflow-tree.test.tsx`).
- [x] `npx next build` — green; new `/workflows/[instanceId]` route appears.
- [x] `npx tsc --noEmit` — only the two pre-existing errors from `4b1621b` (auth slice), out of scope here.
- [ ] CI: `p1-validate` + `p1-policy` green on the head SHA.
- [ ] CodeRabbit review thread closure on the head SHA.
- [ ] Manual smoke (deferred to staging preview): expand each template → click "New instance" → enter name → verify sidebar updates and route navigates to `/workflows/{id}`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create-instance modal with validation, error states, analytics capture, and navigation to the new instance.
  * Sidebar shows templates and instances (collapsed/expanded), per-template counts, and quick-create controls.
  * New workflow instance detail page with header summary and placeholder for the Process Matrix.
  * Breadcrumbs now show "Workflows › Instance" for instance routes.

* **Tests**
  * Unit tests for the sidebar/tree and create flow; E2E test for the create-instance happy path.

* **Bug Fixes**
  * Dashboard layout tolerates workflow-load failures and logs errors.

* **Style**
  * Added tooltip enter animation with reduced-motion support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->