### PR TITLE
feat(dashboard): overview screen with real data (AEL-49)

### DIFF
--- a/products/dashboard/__tests__/components/overview/overview-screen.test.tsx
+++ b/products/dashboard/__tests__/components/overview/overview-screen.test.tsx
@@ -175,7 +175,7 @@ describe("OverviewScreen", () => {
       /Good morning, Andres\./,
     );
     expect(
-      screen.getByText(/1 task need your decision/i),
+      screen.getByText(/1 task needs your decision/i),
     ).toBeInTheDocument();
   });
 

--- a/products/dashboard/__tests__/components/overview/overview-screen.test.tsx
+++ b/products/dashboard/__tests__/components/overview/overview-screen.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * Component tests for components/overview/overview-screen.tsx.
+ * Spec anchor: AEL-49 — PR 6 Overview screen with real data.
+ *
+ * Covers:
+ *   - Greeting + subtitle adapt to pending count
+ *   - Stat cards render the four numbers (active instances · my tasks ·
+ *     active tasks · completion %)
+ *   - Process Health rows render one chip per instance, each chip being
+ *     a navigable link to /workflows/{id}
+ *   - dashboard.overview_viewed fires on mount with the four numbers
+ *   - My Tasks card surfaces pending checkpoints with Approve/Reject
+ *   - Empty state collapses to "All clear ✓"
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import posthog from "posthog-js";
+
+import type { AuthUser } from "@/lib/auth/types";
+import type { OverviewSnapshot } from "@/lib/workflows/aggregate";
+
+const { mockResolveCheckpointAction } = vi.hoisted(() => ({
+  mockResolveCheckpointAction: vi.fn(),
+}));
+
+vi.mock("@/app/(dashboard)/workflows/actions", () => ({
+  resolveCheckpointAction: mockResolveCheckpointAction,
+  // Keep `createInstanceAction` mockable if other tests in the file
+  // import it via the same module path in the future.
+  createInstanceAction: vi.fn(),
+}));
+
+import { OverviewScreen } from "@/components/overview/overview-screen";
+
+const USER: AuthUser = {
+  id: "user-123",
+  email: "andres@example.com",
+  provider: "magic_link",
+};
+
+// Pinned to local 10:00 (morning) so the greeting is timezone-stable
+// regardless of the runner's TZ setting.
+const NOW = new Date(2026, 3, 19, 10, 0, 0);
+
+const TEMPLATE_DELIVERY = {
+  id: "delivery",
+  label: "Client Delivery",
+  color: "#6366f1",
+  multiInstance: true,
+  stages: [],
+  roles: [],
+  taskTemplates: [],
+  createdAt: "2026-04-19T12:00:00Z",
+  updatedAt: "2026-04-19T12:00:00Z",
+};
+
+const TEMPLATE_GTM = {
+  ...TEMPLATE_DELIVERY,
+  id: "gtm",
+  label: "GTM",
+  color: "#f59e0b",
+};
+
+function snapshotWithData(): OverviewSnapshot {
+  return {
+    templates: [TEMPLATE_DELIVERY, TEMPLATE_GTM],
+    instances: [
+      {
+        id: "i-acme",
+        templateId: "delivery",
+        label: "Acme Corp",
+        status: "active",
+        roles: [],
+        createdAt: "2026-04-19T12:00:00Z",
+        updatedAt: "2026-04-19T12:00:00Z",
+      },
+      {
+        id: "i-globex",
+        templateId: "delivery",
+        label: "Globex Co",
+        status: "blocked",
+        roles: [],
+        createdAt: "2026-04-19T12:00:00Z",
+        updatedAt: "2026-04-19T12:00:00Z",
+      },
+    ],
+    tasks: [
+      {
+        id: "k-1",
+        instanceId: "i-acme",
+        roleId: "pm",
+        stageId: "discovery",
+        title: "Backlog ready for sprint",
+        description: "",
+        status: "pending_approval",
+        substatus: "",
+        checkpoint: true,
+        triggers: [],
+        gates: [],
+        agent: "PM Agent",
+        skill: null,
+        playbook: null,
+        createdAt: "2026-04-19T12:00:00Z",
+        updatedAt: "2026-04-19T12:00:00Z",
+      },
+      {
+        id: "k-2",
+        instanceId: "i-acme",
+        roleId: "pm",
+        stageId: "discovery",
+        title: "Phase 2 timeline",
+        description: "",
+        status: "complete",
+        substatus: "",
+        checkpoint: false,
+        triggers: [],
+        gates: [],
+        agent: null,
+        skill: null,
+        playbook: null,
+        createdAt: "2026-04-19T12:00:00Z",
+        updatedAt: "2026-04-19T12:00:00Z",
+      },
+      {
+        id: "k-3",
+        instanceId: "i-globex",
+        roleId: "designer",
+        stageId: "design",
+        title: "Prototype review",
+        description: "",
+        status: "active",
+        substatus: "",
+        checkpoint: false,
+        triggers: [],
+        gates: [],
+        agent: null,
+        skill: null,
+        playbook: null,
+        createdAt: "2026-04-19T12:00:00Z",
+        updatedAt: "2026-04-19T12:00:00Z",
+      },
+    ],
+    events: [
+      {
+        id: "ev-1",
+        instanceId: "i-acme",
+        taskId: "k-1",
+        name: "workflow.checkpoint_requested",
+        description: "PM Agent: backlog ready for sprint",
+        payload: {},
+        createdAt: "2026-04-19T09:58:00Z",
+      },
+    ],
+  };
+}
+
+describe("OverviewScreen", () => {
+  beforeEach(() => {
+    mockResolveCheckpointAction.mockReset();
+    vi.mocked(posthog.capture).mockClear();
+  });
+
+  it("renders the greeting with the user handle and a pending-task subtitle", () => {
+    render(
+      <OverviewScreen
+        snapshot={snapshotWithData()}
+        user={USER}
+        now={NOW}
+      />,
+    );
+
+    expect(screen.getByTestId("overview-greeting")).toHaveTextContent(
+      /Good morning, Andres\./,
+    );
+    expect(
+      screen.getByText(/1 task need your decision/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the four stat cards with the computed numbers", () => {
+    render(
+      <OverviewScreen
+        snapshot={snapshotWithData()}
+        user={USER}
+        now={NOW}
+      />,
+    );
+
+    const stats = screen.getByTestId("overview-stats");
+    // 2 instances active (none completed)
+    expect(stats).toHaveTextContent("2");
+    // 1 pending checkpoint
+    expect(stats).toHaveTextContent(/My tasks/);
+    // 33% completion (1 of 3 tasks complete)
+    expect(stats).toHaveTextContent("33%");
+    expect(stats).toHaveTextContent(/1 \/ 3 tasks/);
+  });
+
+  it("renders one Process Health row per template, with chips that link into the matrix", () => {
+    render(
+      <OverviewScreen
+        snapshot={snapshotWithData()}
+        user={USER}
+        now={NOW}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("overview-process-health-row-delivery"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("overview-process-health-row-gtm"),
+    ).toBeInTheDocument();
+
+    const acmeChip = screen.getByTestId("overview-instance-chip-i-acme");
+    expect(acmeChip).toHaveAttribute("href", "/workflows/i-acme");
+    const globexChip = screen.getByTestId("overview-instance-chip-i-globex");
+    expect(globexChip).toHaveAttribute("href", "/workflows/i-globex");
+  });
+
+  it("captures dashboard.overview_viewed on mount with the stat numbers", async () => {
+    render(
+      <OverviewScreen
+        snapshot={snapshotWithData()}
+        user={USER}
+        now={NOW}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(posthog.capture).toHaveBeenCalledWith(
+        "dashboard.overview_viewed",
+        {
+          instance_count: 2,
+          pending_count: 1,
+          active_count: 1,
+          completion_pct: 33,
+        },
+      ),
+    );
+  });
+
+  it("approves a pending checkpoint via the server action", async () => {
+    mockResolveCheckpointAction.mockResolvedValue({
+      task: { id: "k-1", status: "complete" },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <OverviewScreen
+        snapshot={snapshotWithData()}
+        user={USER}
+        now={NOW}
+      />,
+    );
+
+    await user.click(screen.getByTestId("overview-my-task-approve-k-1"));
+
+    await waitFor(() =>
+      expect(mockResolveCheckpointAction).toHaveBeenCalledWith(
+        "k-1",
+        "approved",
+      ),
+    );
+  });
+
+  it("falls back to 'All clear ✓' when no checkpoints are pending", () => {
+    const snapshot = snapshotWithData();
+    snapshot.tasks = snapshot.tasks.map((t) =>
+      t.status === "pending_approval" ? { ...t, status: "complete" } : t,
+    );
+
+    render(
+      <OverviewScreen snapshot={snapshot} user={USER} now={NOW} />,
+    );
+
+    expect(screen.getByText(/all clear ✓/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/all processes running smoothly/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/products/dashboard/__tests__/lib/workflows/aggregate.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/aggregate.test.ts
@@ -1,0 +1,269 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import {
+  computeOverviewStats,
+  computeTemplateHealth,
+  percentComplete,
+  pickPendingCheckpoints,
+  pickRecentEvents,
+  type OverviewSnapshot,
+} from "@/lib/workflows/aggregate";
+import type {
+  WorkflowEvent,
+  WorkflowInstance,
+  WorkflowTask,
+  WorkflowTemplate,
+} from "@/lib/workflows/types";
+
+/**
+ * Pure-function tests for the Overview aggregations.
+ *
+ * Spec anchor: AEL-49 — Overview screen with real data ("Unit:
+ * aggregation math (completion %)"). The math underpins both the four
+ * stat-card numbers and the Process Health rollup, so tests cover
+ * empty / partial / fully-complete denominators and per-template
+ * grouping.
+ */
+
+function template(
+  id: string,
+  label: string,
+  color: string,
+): WorkflowTemplate {
+  return {
+    id,
+    label,
+    color,
+    multiInstance: true,
+    stages: [],
+    roles: [],
+    taskTemplates: [],
+    createdAt: "2026-04-19T12:00:00Z",
+    updatedAt: "2026-04-19T12:00:00Z",
+  };
+}
+
+function instance(
+  id: string,
+  templateId: string,
+  status: WorkflowInstance["status"] = "active",
+): WorkflowInstance {
+  return {
+    id,
+    templateId,
+    label: id,
+    status,
+    roles: [],
+    createdAt: "2026-04-19T12:00:00Z",
+    updatedAt: "2026-04-19T12:00:00Z",
+  };
+}
+
+function task(
+  id: string,
+  instanceId: string,
+  status: WorkflowTask["status"] = "not_started",
+  overrides: Partial<WorkflowTask> = {},
+): WorkflowTask {
+  return {
+    id,
+    instanceId,
+    roleId: "role-x",
+    stageId: "stage-x",
+    title: id,
+    description: "",
+    status,
+    substatus: "",
+    checkpoint: false,
+    triggers: [],
+    gates: [],
+    agent: null,
+    skill: null,
+    playbook: null,
+    createdAt: "2026-04-19T12:00:00Z",
+    updatedAt: "2026-04-19T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function event(
+  id: string,
+  instanceId: string,
+  name: string,
+  createdAt: string,
+): WorkflowEvent {
+  return {
+    id,
+    instanceId,
+    taskId: null,
+    name,
+    description: name,
+    payload: {},
+    createdAt,
+  };
+}
+
+describe("percentComplete", () => {
+  it("returns 0 when total is 0 to keep the UI free of NaN", () => {
+    expect(percentComplete(0, 0)).toBe(0);
+  });
+
+  it("rounds half-up to the nearest integer", () => {
+    expect(percentComplete(1, 3)).toBe(33);
+    expect(percentComplete(2, 3)).toBe(67);
+    expect(percentComplete(1, 2)).toBe(50);
+  });
+
+  it("clamps non-finite inputs to 0", () => {
+    expect(percentComplete(Number.NaN, 10)).toBe(0);
+    expect(percentComplete(10, Number.POSITIVE_INFINITY)).toBe(0);
+    expect(percentComplete(10, -1)).toBe(0);
+  });
+});
+
+describe("computeOverviewStats", () => {
+  it("returns all-zero stats for an empty snapshot", () => {
+    const snapshot: OverviewSnapshot = {
+      templates: [],
+      instances: [],
+      tasks: [],
+      events: [],
+    };
+    expect(computeOverviewStats(snapshot)).toEqual({
+      activeInstances: 0,
+      pendingTasks: 0,
+      activeTasks: 0,
+      completedTasks: 0,
+      totalTasks: 0,
+      completionPct: 0,
+    });
+  });
+
+  it("counts active instances (anything not 'complete') and bucketed tasks", () => {
+    const snapshot: OverviewSnapshot = {
+      templates: [template("t-1", "Delivery", "#6366f1")],
+      instances: [
+        instance("i-1", "t-1", "active"),
+        instance("i-2", "t-1", "blocked"),
+        instance("i-3", "t-1", "complete"),
+      ],
+      tasks: [
+        task("k-1", "i-1", "complete"),
+        task("k-2", "i-1", "active"),
+        task("k-3", "i-2", "pending_approval"),
+        task("k-4", "i-2", "not_started"),
+        task("k-5", "i-3", "complete"),
+      ],
+      events: [],
+    };
+
+    const stats = computeOverviewStats(snapshot);
+    expect(stats.activeInstances).toBe(2);
+    expect(stats.activeTasks).toBe(1);
+    expect(stats.pendingTasks).toBe(1);
+    expect(stats.completedTasks).toBe(2);
+    expect(stats.totalTasks).toBe(5);
+    expect(stats.completionPct).toBe(40);
+  });
+});
+
+describe("computeTemplateHealth", () => {
+  const t1 = template("delivery", "Client Delivery", "#6366f1");
+  const t2 = template("product", "Product Dev", "#10b981");
+  const t3 = template("gtm", "GTM", "#f59e0b");
+
+  it("groups instances under templates, including templates with zero instances", () => {
+    const snapshot: OverviewSnapshot = {
+      templates: [t1, t2, t3],
+      instances: [instance("i-a", "delivery"), instance("i-b", "product")],
+      tasks: [
+        task("k-1", "i-a", "complete"),
+        task("k-2", "i-a", "active"),
+        task("k-3", "i-a", "complete"),
+        task("k-4", "i-b", "not_started"),
+      ],
+      events: [],
+    };
+
+    const health = computeTemplateHealth(snapshot);
+    expect(health).toHaveLength(3);
+
+    const delivery = health.find((h) => h.template.id === "delivery")!;
+    expect(delivery.instances).toHaveLength(1);
+    expect(delivery.totalTasks).toBe(3);
+    expect(delivery.completedTasks).toBe(2);
+    expect(delivery.completionPct).toBe(67);
+
+    const product = health.find((h) => h.template.id === "product")!;
+    expect(product.totalTasks).toBe(1);
+    expect(product.completedTasks).toBe(0);
+    expect(product.completionPct).toBe(0);
+
+    const gtm = health.find((h) => h.template.id === "gtm")!;
+    expect(gtm.instances).toEqual([]);
+    expect(gtm.completionPct).toBe(0);
+  });
+});
+
+describe("pickPendingCheckpoints", () => {
+  it("returns only pending_approval tasks with their parent template attached", () => {
+    const t1 = template("delivery", "Client Delivery", "#6366f1");
+    const i1 = instance("i-1", "delivery");
+    const snapshot: OverviewSnapshot = {
+      templates: [t1],
+      instances: [i1],
+      tasks: [
+        task("k-1", "i-1", "pending_approval"),
+        task("k-2", "i-1", "active"),
+      ],
+      events: [],
+    };
+
+    const pending = pickPendingCheckpoints(snapshot);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.task.id).toBe("k-1");
+    expect(pending[0]!.instance.id).toBe("i-1");
+    expect(pending[0]!.template?.id).toBe("delivery");
+  });
+
+  it("drops orphaned tasks whose instance no longer exists", () => {
+    const snapshot: OverviewSnapshot = {
+      templates: [],
+      instances: [],
+      tasks: [task("k-orphan", "ghost", "pending_approval")],
+      events: [],
+    };
+    expect(pickPendingCheckpoints(snapshot)).toEqual([]);
+  });
+});
+
+describe("pickRecentEvents", () => {
+  const snapshot: OverviewSnapshot = {
+    templates: [],
+    instances: [],
+    tasks: [],
+    events: [
+      event("e-1", "i-1", "workflow.checkpoint_requested", "2026-04-19T15:00:00Z"),
+      event("e-2", "i-1", "workflow.task_updated", "2026-04-19T14:00:00Z"),
+      event("e-3", "i-2", "workflow.task_started", "2026-04-19T13:00:00Z"),
+      event("e-4", "i-2", "workflow.instance_created", "2026-04-19T12:00:00Z"),
+      event("e-5", "i-2", "workflow.task_completed", "2026-04-19T11:00:00Z"),
+    ],
+  };
+
+  it("returns the first N events from the already-sorted feed", () => {
+    expect(pickRecentEvents(snapshot, 4).map((e) => e.id)).toEqual([
+      "e-1",
+      "e-2",
+      "e-3",
+      "e-4",
+    ]);
+  });
+
+  it("returns an empty list for non-positive limits", () => {
+    expect(pickRecentEvents(snapshot, 0)).toEqual([]);
+    expect(pickRecentEvents(snapshot, -3)).toEqual([]);
+  });
+});

--- a/products/dashboard/app/(dashboard)/page.tsx
+++ b/products/dashboard/app/(dashboard)/page.tsx
@@ -1,110 +1,60 @@
 import { ShellEvents } from "@/components/shell-events";
+import { OverviewScreen } from "@/components/overview/overview-screen";
+import { getCurrentUser } from "@/lib/auth/service.server";
+import { captureError } from "@/lib/monitoring";
+import type { OverviewSnapshot } from "@/lib/workflows/aggregate";
+import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
 
 /**
  * Overview — default authenticated route.
  *
- * Layout mirrors the AI-Native Process Canvas prototype's Overview
- * screen (`Process Canvas.html → OverviewScreen`): a greeting band,
- * four stat cards across the top, then a two-column grid of "Process
- * health", "Recent events", "My tasks", and "Agent pulse" cards.
+ * Reads templates / instances / tasks / recent events from the
+ * workflow repository (cookie-aware Supabase, RLS in effect) and hands
+ * the snapshot to `<OverviewScreen />` for rendering. The screen
+ * itself is the single source of truth for layout and aggregation.
  *
- * PR-3 ships the structure with zero-value stat cards and explicit
- * empty states. The data wiring (workflow instances, agent pulse,
- * checkpoint queue, event feed) lands in later PRs once the
- * underlying domain models exist.
+ * Failure mode: if the repo throws (Supabase down, mis-applied RLS,
+ * network blip), we capture the error to Sentry and fall back to an
+ * empty snapshot so the chrome (sidebar, top bar, greeting) still
+ * renders. The user sees the "All clear" + dashed empty-state cards
+ * instead of a 500.
  */
+export const dynamic = "force-dynamic";
 
-const STATS: ReadonlyArray<{ value: string; label: string; hint: string }> = [
-  { value: "0", label: "Active instances", hint: "No workflows running" },
-  { value: "0", label: "My tasks", hint: "All clear" },
-  { value: "0", label: "Active tasks", hint: "No agents running" },
-  { value: "0%", label: "Completion", hint: "0 / 0 tasks" },
-];
+const RECENT_EVENT_LIMIT = 4;
 
-function StatCard({ value, label, hint }: { value: string; label: string; hint: string }) {
-  return (
-    <div className="rounded-[10px] border border-border bg-bg-2 px-4 py-3.5">
-      <div className="font-mono text-[26px] font-extrabold leading-none tracking-tight text-t1">
-        {value}
-      </div>
-      {/*
-       * Use `text-t2` (not `text-t3`) for the small stat metadata. In the
-       * light theme `--t3` (#94a3b8) on `--bg`/`--bg-2` lands at ~2.5:1,
-       * below the WCAG-AA 4.5:1 floor for body text. Bumping to `--t2`
-       * (#475569) clears 7:1 in light and 9:1+ in dark.
-       */}
-      <div className="mt-1.5 text-[11px] text-t2">{label}</div>
-      <div className="mt-1 font-mono text-[10px] text-t2">{hint}</div>
-    </div>
-  );
+async function loadOverviewSnapshot(): Promise<OverviewSnapshot> {
+  try {
+    const repo = await getServerWorkflowRepository();
+    const [templates, instances, tasks, events] = await Promise.all([
+      repo.getTemplates(),
+      repo.listInstances(),
+      repo.listAllTasks(),
+      repo.listRecentEvents(RECENT_EVENT_LIMIT),
+    ]);
+    return { templates, instances, tasks, events };
+  } catch (error) {
+    captureError(error, { feature: "overview.snapshot" });
+    return { templates: [], instances: [], tasks: [], events: [] };
+  }
 }
 
-function EmptyCard({
-  title,
-  body,
-}: {
-  title: string;
-  body: string;
-}) {
-  return (
-    <section className="overflow-hidden rounded-[10px] border border-border bg-bg-2">
-      <header className="flex items-center justify-between border-b border-border px-4 py-3">
-        <h2 className="text-[12px] font-semibold text-t1">{title}</h2>
-      </header>
-      {/* See note in `StatCard` — empty-state copy uses `text-t2` so light
-          theme stays above the WCAG-AA 4.5:1 contrast floor. */}
-      <p className="px-4 py-7 text-center text-[12px] text-t2">{body}</p>
-    </section>
-  );
-}
+export default async function HomePage() {
+  // Layout already redirects unauthenticated users; we still read the
+  // user here to personalize the greeting without re-validating auth.
+  const [user, snapshot] = await Promise.all([
+    getCurrentUser(),
+    loadOverviewSnapshot(),
+  ]);
 
-export default function HomePage() {
   return (
     <>
-      {/* Emits dashboard.shell_viewed on mount and tags Sentry with the
-          workflow_canvas component for this shell. */}
       <ShellEvents route="/" />
-
-      <div className="overflow-y-auto p-6">
-        <header className="mb-5">
-          <h1 className="text-[20px] font-bold tracking-tight text-t1">
-            Welcome back.
-          </h1>
-          <p className="mt-1 text-[13px] text-t2">
-            No workflows running yet. Define a workflow template to start
-            tracking instances here.
-          </p>
-        </header>
-
-        <div className="mb-5 grid grid-cols-2 gap-2.5 lg:grid-cols-4">
-          {STATS.map((stat) => (
-            <StatCard key={stat.label} {...stat} />
-          ))}
-        </div>
-
-        <div className="grid grid-cols-1 gap-3.5 lg:grid-cols-[1fr_320px]">
-          <div className="flex flex-col gap-3">
-            <EmptyCard
-              title="Process health"
-              body="No workflow templates yet — process health will appear here once you define one."
-            />
-            <EmptyCard
-              title="Recent events"
-              body="No events captured yet. The shell, auth, and future workflow events will surface here."
-            />
-          </div>
-          <div className="flex flex-col gap-3">
-            <EmptyCard
-              title="My tasks"
-              body="All clear. Pending checkpoint approvals will land here as workflows run."
-            />
-            <EmptyCard
-              title="Agent pulse"
-              body="No agents running. Active and idle agents will appear here once workflows execute."
-            />
-          </div>
-        </div>
-      </div>
+      <OverviewScreen
+        snapshot={snapshot}
+        user={user}
+        recentEventLimit={RECENT_EVENT_LIMIT}
+      />
     </>
   );
 }

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 
 import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
-import type { WorkflowInstance } from "@/lib/workflows/types";
+import type { WorkflowInstance, WorkflowTask } from "@/lib/workflows/types";
 
 /**
  * Server action invoked by the create-instance modal.
@@ -51,4 +51,72 @@ export async function createInstanceAction(
   // the modal only needs the persisted id + label to navigate.
   const { tasks: _tasks, events: _events, ...instance } = detail;
   return { instance };
+}
+
+/**
+ * Inline checkpoint resolution from the Overview "My Tasks" card.
+ *
+ * PR-6 surfaces pending-approval tasks with Approve / Reject buttons so
+ * the founder can clear the queue without opening the matrix. The full
+ * Task Drawer (Details + Events + audit trail) lands in PR-8 (AEL-51);
+ * this action is the minimum write path needed to make the buttons in
+ * the Overview do real work and emit a domain event for downstream
+ * analytics.
+ *
+ * Side effects:
+ *   1. `updateTask` flips the task to `complete` (approve) or `blocked`
+ *      (reject — keeps the task visible in the matrix so the agent can
+ *      iterate; canonical "back to active" semantics will land with the
+ *      drawer that lets the founder leave a note).
+ *   2. `addEvent` writes a `workflow.checkpoint_approved|rejected`
+ *      domain event so the Recent Events card and PostHog feeds reflect
+ *      the change immediately.
+ *   3. `revalidatePath('/', 'layout')` so the Overview rerenders with
+ *      one fewer pending row and the new event at the top of the feed.
+ */
+export type CheckpointResolution = "approved" | "rejected";
+
+export interface ResolveCheckpointResult {
+  task: WorkflowTask;
+}
+
+export async function resolveCheckpointAction(
+  taskId: string,
+  resolution: CheckpointResolution,
+): Promise<ResolveCheckpointResult> {
+  if (typeof taskId !== "string" || !taskId.trim()) {
+    throw new Error("resolveCheckpointAction: taskId is required");
+  }
+  if (resolution !== "approved" && resolution !== "rejected") {
+    throw new Error(
+      `resolveCheckpointAction: unknown resolution "${resolution}"`,
+    );
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const nextStatus = resolution === "approved" ? "complete" : "blocked";
+  const task = await repo.updateTask(taskId.trim(), { status: nextStatus });
+
+  await repo.addEvent(task.id, {
+    name:
+      resolution === "approved"
+        ? "workflow.checkpoint_approved"
+        : "workflow.checkpoint_rejected",
+    description:
+      resolution === "approved"
+        ? `Approved checkpoint: ${task.title}`
+        : `Rejected checkpoint: ${task.title}`,
+    payload: {
+      task_id: task.id,
+      instance_id: task.instanceId,
+      // resolved_by deliberately omitted from the action payload here —
+      // the shell does not have the founder identifier in this context;
+      // the catalog accepts the field as required only at the gateway
+      // ingestion layer where the request is authenticated end-to-end.
+    },
+  });
+
+  revalidatePath("/", "layout");
+
+  return { task };
 }

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
+import { captureError } from "@/lib/monitoring";
 import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
 import type { WorkflowInstance, WorkflowTask } from "@/lib/workflows/types";
 
@@ -97,24 +98,43 @@ export async function resolveCheckpointAction(
   const nextStatus = resolution === "approved" ? "complete" : "blocked";
   const task = await repo.updateTask(taskId.trim(), { status: nextStatus });
 
-  await repo.addEvent(task.id, {
-    name:
-      resolution === "approved"
-        ? "workflow.checkpoint_approved"
-        : "workflow.checkpoint_rejected",
-    description:
-      resolution === "approved"
-        ? `Approved checkpoint: ${task.title}`
-        : `Rejected checkpoint: ${task.title}`,
-    payload: {
-      task_id: task.id,
-      instance_id: task.instanceId,
-      // resolved_by deliberately omitted from the action payload here —
-      // the shell does not have the founder identifier in this context;
-      // the catalog accepts the field as required only at the gateway
-      // ingestion layer where the request is authenticated end-to-end.
-    },
-  });
+  // The status mutation already committed. If the audit-event write fails
+  // we MUST NOT swallow that silently — but we also can't let the throw
+  // skip `revalidatePath`, or the Overview would keep showing the task
+  // as pending while the database has already moved on. So: log the
+  // event-write failure to Sentry, refresh the cache, then return the
+  // updated task. The Recent Events card will be missing one entry until
+  // the next write, but the task state in My Tasks / Process Health is
+  // consistent with the database.
+  try {
+    await repo.addEvent(task.id, {
+      name:
+        resolution === "approved"
+          ? "workflow.checkpoint_approved"
+          : "workflow.checkpoint_rejected",
+      description:
+        resolution === "approved"
+          ? `Approved checkpoint: ${task.title}`
+          : `Rejected checkpoint: ${task.title}`,
+      payload: {
+        task_id: task.id,
+        instance_id: task.instanceId,
+        // resolved_by deliberately omitted from the action payload here —
+        // the shell does not have the founder identifier in this context;
+        // the catalog accepts the field as required only at the gateway
+        // ingestion layer where the request is authenticated end-to-end.
+      },
+    });
+  } catch (eventError) {
+    captureError(eventError, {
+      feature: "workflows.resolve_checkpoint",
+      action: `addEvent.${resolution}`,
+      extra: {
+        task_id: task.id,
+        instance_id: task.instanceId,
+      },
+    });
+  }
 
   revalidatePath("/", "layout");
 

--- a/products/dashboard/components/overview/agent-pulse-card.tsx
+++ b/products/dashboard/components/overview/agent-pulse-card.tsx
@@ -1,0 +1,125 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Agent Pulse card — static seed data for PR-6.
+ *
+ * The live agent runtime wires up in PR-8 (Task Drawer / Agent Run
+ * panel). For now, this card mirrors the prototype's `AGENTS` seed
+ * (`pc-components.jsx` lines 775-781) so the Overview shows what the
+ * eventual surface will look like and PR-8 has a stable target to
+ * replace.
+ *
+ * Visual contract: prototype `.agent-row` block (`Process Canvas.html`
+ * lines 406-415).
+ */
+
+type AgentStatus = "active" | "waiting" | "idle";
+
+interface AgentRow {
+  name: string;
+  icon: string;
+  status: AgentStatus;
+  task: string;
+}
+
+// Seed data mirrors the prototype OverviewScreen so QA and analytics
+// can compare against the design source. PR-8 (AEL-51) replaces this
+// with `repo.listAgentRuns()` once that surface exists.
+const SEED_AGENTS: ReadonlyArray<AgentRow> = [
+  {
+    name: "PM Agent",
+    icon: "📋",
+    status: "active",
+    task: "Backlog refinement · CompanyX",
+  },
+  {
+    name: "Designer Agent",
+    icon: "🎨",
+    status: "waiting",
+    task: "Awaiting design review approval",
+  },
+  {
+    name: "Project Agent",
+    icon: "🗂️",
+    status: "active",
+    task: "Scope planning · CompanyX",
+  },
+  {
+    name: "DevOps Agent",
+    icon: "🔧",
+    status: "active",
+    task: "Infra requirements · CompanyX",
+  },
+  {
+    name: "Strategist Agent",
+    icon: "🧭",
+    status: "active",
+    task: "ICP definition · GTM",
+  },
+];
+
+const pulseClass: Record<AgentStatus, string> = {
+  active:
+    "bg-[color:#10b981] shadow-[0_0_6px_rgba(16,185,129,0.5)]",
+  waiting:
+    "bg-[color:#f59e0b] shadow-[0_0_6px_rgba(245,158,11,0.4)]",
+  idle: "bg-border-2",
+};
+
+export interface AgentPulseCardProps {
+  /** Override seed agents in tests / future live wiring. */
+  agents?: ReadonlyArray<AgentRow>;
+}
+
+export function AgentPulseCard({ agents = SEED_AGENTS }: AgentPulseCardProps) {
+  return (
+    <section
+      data-testid="overview-agent-pulse"
+      className="overflow-hidden rounded-[10px] border border-border bg-bg-2"
+    >
+      <header className="flex items-center justify-between border-b border-border px-4 py-3">
+        <h2 className="text-[12px] font-semibold text-t1">Agent pulse</h2>
+        <span className="font-mono text-[10px] text-t3">
+          {agents.filter((a) => a.status === "active").length} active
+        </span>
+      </header>
+
+      {agents.length === 0 ? (
+        <p className="px-4 py-7 text-center text-[12px] text-t2">
+          No agents running.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border-2">
+          {agents.map((agent) => (
+            <li
+              key={agent.name}
+              className="flex items-center gap-2.5 px-4 py-2.5"
+            >
+              <span
+                aria-hidden
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] bg-bg-4 text-[14px]"
+              >
+                {agent.icon}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="text-[12px] font-semibold text-t1">
+                  {agent.name}
+                </div>
+                <div className="truncate font-mono text-[11px] text-t3">
+                  {agent.task}
+                </div>
+              </div>
+              <span
+                aria-label={`status ${agent.status}`}
+                className={cn(
+                  "block h-[7px] w-[7px] shrink-0 rounded-full",
+                  pulseClass[agent.status],
+                )}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/products/dashboard/components/overview/my-tasks-card.tsx
+++ b/products/dashboard/components/overview/my-tasks-card.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { resolveCheckpointAction } from "@/app/(dashboard)/workflows/actions";
+import { captureError } from "@/lib/monitoring";
+import { cn } from "@/lib/utils";
+import type { PendingCheckpoint } from "@/lib/workflows/aggregate";
+
+/**
+ * My Tasks card — pending checkpoint list with inline Approve / Reject.
+ *
+ * Visual contract: prototype `.cp-ov-item` block (`Process Canvas.html`
+ * lines 396-405) and the `OverviewScreen` checkpoint markup
+ * (`pc-components.jsx` line 810).
+ *
+ * Action wiring:
+ *   - Approve  → `resolveCheckpointAction(taskId, 'approved')` (sets the
+ *     task to `complete`, emits `workflow.checkpoint_approved`).
+ *   - Reject   → `resolveCheckpointAction(taskId, 'rejected')` (sets the
+ *     task to `blocked`, emits `workflow.checkpoint_rejected`).
+ *   PR-8 (AEL-51) replaces this with a richer drawer flow including a
+ *   reason note; the buttons here are the minimum write path needed to
+ *   make the Overview close the loop without leaving the screen.
+ */
+export interface MyTasksCardProps {
+  checkpoints: PendingCheckpoint[];
+}
+
+export function MyTasksCard({ checkpoints }: MyTasksCardProps) {
+  const [isPending, startTransition] = useTransition();
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function resolve(taskId: string, resolution: "approved" | "rejected") {
+    setError(null);
+    setPendingId(taskId);
+    startTransition(async () => {
+      try {
+        await resolveCheckpointAction(taskId, resolution);
+      } catch (err) {
+        captureError(err, {
+          feature: "overview.my_tasks",
+          action: `checkpoint.${resolution}`,
+        });
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Could not resolve this checkpoint. Try again.",
+        );
+      } finally {
+        setPendingId(null);
+      }
+    });
+  }
+
+  return (
+    <section
+      data-testid="overview-my-tasks"
+      className="overflow-hidden rounded-[10px] border border-border bg-bg-2"
+    >
+      <header className="flex items-center justify-between border-b border-border px-4 py-3">
+        <h2 className="text-[12px] font-semibold text-t1">My tasks</h2>
+        {checkpoints.length > 0 && (
+          <span className="rounded-full bg-primary-bg px-2 py-[1px] font-mono text-[10px] font-semibold text-accent">
+            {checkpoints.length}
+          </span>
+        )}
+      </header>
+
+      {error && (
+        <p
+          role="alert"
+          className="border-b border-border bg-[color:var(--pill-blocked-bg)] px-4 py-2 text-[11px] text-[color:var(--pill-blocked-t)]"
+        >
+          {error}
+        </p>
+      )}
+
+      {checkpoints.length === 0 ? (
+        <p className="px-4 py-7 text-center text-[12px] text-t2">All clear ✓</p>
+      ) : (
+        <ul className="divide-y divide-border-2">
+          {checkpoints.map(({ task, instance, template }) => {
+            const busy = isPending && pendingId === task.id;
+            return (
+              <li
+                key={task.id}
+                data-testid={`overview-my-task-${task.id}`}
+                className="px-4 py-3"
+              >
+                <p
+                  className="font-mono text-[9.5px] font-semibold uppercase tracking-[0.1em] text-t3"
+                  style={template ? { color: template.color } : undefined}
+                >
+                  {template?.label ?? "Workflow"} · {instance.label}
+                </p>
+                <p className="mt-1 text-[12.5px] font-semibold text-t1">
+                  {task.title}
+                </p>
+                {task.agent && (
+                  <p className="mt-1 text-[11px] text-t3">By {task.agent}</p>
+                )}
+                <div className="mt-2 flex gap-1.5">
+                  <button
+                    type="button"
+                    onClick={() => resolve(task.id, "approved")}
+                    disabled={busy}
+                    data-testid={`overview-my-task-approve-${task.id}`}
+                    className={cn(
+                      "rounded-md bg-[color:#10b981] px-3.5 py-1.5 text-[11.5px] font-semibold text-white transition-opacity",
+                      "hover:opacity-85 disabled:opacity-60",
+                    )}
+                  >
+                    {busy ? "…" : "Approve"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => resolve(task.id, "rejected")}
+                    disabled={busy}
+                    data-testid={`overview-my-task-reject-${task.id}`}
+                    className={cn(
+                      "rounded-md border border-border bg-bg-3 px-3.5 py-1.5 text-[11.5px] text-t2 transition-colors",
+                      "hover:bg-bg-4 hover:text-t1 disabled:opacity-60",
+                    )}
+                  >
+                    Reject
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/products/dashboard/components/overview/my-tasks-card.tsx
+++ b/products/dashboard/components/overview/my-tasks-card.tsx
@@ -27,35 +27,42 @@ export interface MyTasksCardProps {
   checkpoints: PendingCheckpoint[];
 }
 
+interface PendingAction {
+  taskId: string;
+  resolution: "approved" | "rejected";
+}
+
 export function MyTasksCard({ checkpoints }: MyTasksCardProps) {
   const [isPending, startTransition] = useTransition();
-  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
 
   function resolve(taskId: string, resolution: "approved" | "rejected") {
     // Guard against double-fires while a previous action is still in
     // flight. Without this, clicking Approve on row A then Reject on
     // row B would start a second transition; when A finished it would
-    // reset `pendingId` to null and re-enable B's controls before B's
-    // server action returned.
+    // reset `pendingAction` to null and re-enable B's controls before
+    // B's server action returned.
     if (isPending) return;
     setError(null);
-    setPendingId(taskId);
+    setPendingAction({ taskId, resolution });
     startTransition(async () => {
       try {
         await resolveCheckpointAction(taskId, resolution);
       } catch (err) {
+        // Always log the real error to Sentry so we can diagnose it,
+        // but never surface raw server-action error messages to the
+        // user — they can leak repository/RLS details. The user gets a
+        // generic, actionable message instead.
         captureError(err, {
           feature: "overview.my_tasks",
           action: `checkpoint.${resolution}`,
         });
-        setError(
-          err instanceof Error
-            ? err.message
-            : "Could not resolve this checkpoint. Try again.",
-        );
+        setError("Could not resolve this checkpoint. Try again.");
       } finally {
-        setPendingId(null);
+        setPendingAction(null);
       }
     });
   }
@@ -89,9 +96,15 @@ export function MyTasksCard({ checkpoints }: MyTasksCardProps) {
         <ul className="divide-y divide-border-2">
           {checkpoints.map(({ task, instance, template }) => {
             // Disable every row while ANY resolve is pending so a second
-            // click can't race the in-flight action; highlight the row
-            // that's actually doing the work with the `…` label.
-            const rowBusy = isPending && pendingId === task.id;
+            // click can't race the in-flight action; the busy `…` label
+            // is shown only on the specific button the user clicked
+            // (Approve OR Reject), not both, so the indicator can't
+            // mislead about which action is executing.
+            const rowBusy = isPending && pendingAction?.taskId === task.id;
+            const approveBusy =
+              rowBusy && pendingAction?.resolution === "approved";
+            const rejectBusy =
+              rowBusy && pendingAction?.resolution === "rejected";
             const disabled = isPending;
             return (
               <li
@@ -122,7 +135,7 @@ export function MyTasksCard({ checkpoints }: MyTasksCardProps) {
                       "hover:opacity-85 disabled:opacity-60",
                     )}
                   >
-                    {rowBusy ? "…" : "Approve"}
+                    {approveBusy ? "…" : "Approve"}
                   </button>
                   <button
                     type="button"
@@ -134,7 +147,7 @@ export function MyTasksCard({ checkpoints }: MyTasksCardProps) {
                       "hover:bg-bg-4 hover:text-t1 disabled:opacity-60",
                     )}
                   >
-                    Reject
+                    {rejectBusy ? "…" : "Reject"}
                   </button>
                 </div>
               </li>

--- a/products/dashboard/components/overview/my-tasks-card.tsx
+++ b/products/dashboard/components/overview/my-tasks-card.tsx
@@ -33,6 +33,12 @@ export function MyTasksCard({ checkpoints }: MyTasksCardProps) {
   const [error, setError] = useState<string | null>(null);
 
   function resolve(taskId: string, resolution: "approved" | "rejected") {
+    // Guard against double-fires while a previous action is still in
+    // flight. Without this, clicking Approve on row A then Reject on
+    // row B would start a second transition; when A finished it would
+    // reset `pendingId` to null and re-enable B's controls before B's
+    // server action returned.
+    if (isPending) return;
     setError(null);
     setPendingId(taskId);
     startTransition(async () => {
@@ -82,7 +88,11 @@ export function MyTasksCard({ checkpoints }: MyTasksCardProps) {
       ) : (
         <ul className="divide-y divide-border-2">
           {checkpoints.map(({ task, instance, template }) => {
-            const busy = isPending && pendingId === task.id;
+            // Disable every row while ANY resolve is pending so a second
+            // click can't race the in-flight action; highlight the row
+            // that's actually doing the work with the `…` label.
+            const rowBusy = isPending && pendingId === task.id;
+            const disabled = isPending;
             return (
               <li
                 key={task.id}
@@ -105,19 +115,19 @@ export function MyTasksCard({ checkpoints }: MyTasksCardProps) {
                   <button
                     type="button"
                     onClick={() => resolve(task.id, "approved")}
-                    disabled={busy}
+                    disabled={disabled}
                     data-testid={`overview-my-task-approve-${task.id}`}
                     className={cn(
                       "rounded-md bg-[color:#10b981] px-3.5 py-1.5 text-[11.5px] font-semibold text-white transition-opacity",
                       "hover:opacity-85 disabled:opacity-60",
                     )}
                   >
-                    {busy ? "…" : "Approve"}
+                    {rowBusy ? "…" : "Approve"}
                   </button>
                   <button
                     type="button"
                     onClick={() => resolve(task.id, "rejected")}
-                    disabled={busy}
+                    disabled={disabled}
                     data-testid={`overview-my-task-reject-${task.id}`}
                     className={cn(
                       "rounded-md border border-border bg-bg-3 px-3.5 py-1.5 text-[11.5px] text-t2 transition-colors",

--- a/products/dashboard/components/overview/overview-events.tsx
+++ b/products/dashboard/components/overview/overview-events.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import { useAnalytics } from "@/lib/analytics/events";
 
@@ -13,7 +13,9 @@ import { useAnalytics } from "@/lib/analytics/events";
  *
  * Numbers are passed in (not recomputed) so PostHog matches whatever
  * the user actually saw at first paint, not a value re-derived after
- * hydration changes.
+ * hydration changes. A ref guard ensures the event is emitted once per
+ * mount even when the parent re-renders with new prop values (e.g. the
+ * Overview re-fetches after `revalidatePath` from a checkpoint resolve).
  */
 export interface OverviewEventsProps {
   instanceCount: number;
@@ -29,8 +31,12 @@ export function OverviewEvents({
   completionPct,
 }: OverviewEventsProps) {
   const { capture } = useAnalytics();
+  const didCaptureRef = useRef(false);
 
   useEffect(() => {
+    if (didCaptureRef.current) return;
+    didCaptureRef.current = true;
+
     capture("dashboard.overview_viewed", {
       instance_count: instanceCount,
       pending_count: pendingCount,

--- a/products/dashboard/components/overview/overview-events.tsx
+++ b/products/dashboard/components/overview/overview-events.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useAnalytics } from "@/lib/analytics/events";
+
+/**
+ * OverviewEvents — fires `dashboard.overview_viewed` once per mount.
+ *
+ * Kept as a tiny client component so the parent server component can
+ * stay async/server-rendered. Mirrors the `<ShellEvents />` pattern in
+ * `components/shell-events.tsx`.
+ *
+ * Numbers are passed in (not recomputed) so PostHog matches whatever
+ * the user actually saw at first paint, not a value re-derived after
+ * hydration changes.
+ */
+export interface OverviewEventsProps {
+  instanceCount: number;
+  pendingCount: number;
+  activeCount: number;
+  completionPct: number;
+}
+
+export function OverviewEvents({
+  instanceCount,
+  pendingCount,
+  activeCount,
+  completionPct,
+}: OverviewEventsProps) {
+  const { capture } = useAnalytics();
+
+  useEffect(() => {
+    capture("dashboard.overview_viewed", {
+      instance_count: instanceCount,
+      pending_count: pendingCount,
+      active_count: activeCount,
+      completion_pct: completionPct,
+    });
+  }, [capture, instanceCount, pendingCount, activeCount, completionPct]);
+
+  return null;
+}

--- a/products/dashboard/components/overview/overview-screen.tsx
+++ b/products/dashboard/components/overview/overview-screen.tsx
@@ -66,7 +66,9 @@ export function OverviewScreen({
   const greeting = `${timeOfDayGreeting(now)}, ${firstNameFromUser(user)}.`;
   const subtitle =
     stats.pendingTasks > 0
-      ? `${stats.pendingTasks} task${stats.pendingTasks === 1 ? "" : "s"} need your decision.`
+      ? stats.pendingTasks === 1
+        ? "1 task needs your decision."
+        : `${stats.pendingTasks} tasks need your decision.`
       : "All processes running smoothly.";
 
   // Pre-format the four stat cards so the JSX reads top-to-bottom.

--- a/products/dashboard/components/overview/overview-screen.tsx
+++ b/products/dashboard/components/overview/overview-screen.tsx
@@ -1,0 +1,158 @@
+import { OverviewEvents } from "./overview-events";
+import { ProcessHealthCard } from "./process-health-card";
+import { MyTasksCard } from "./my-tasks-card";
+import { AgentPulseCard } from "./agent-pulse-card";
+import { RecentEventsCard } from "./recent-events-card";
+import { StatCard } from "./stat-card";
+import type { AuthUser } from "@/lib/auth/types";
+import {
+  computeOverviewStats,
+  computeTemplateHealth,
+  pickPendingCheckpoints,
+  pickRecentEvents,
+  type OverviewSnapshot,
+} from "@/lib/workflows/aggregate";
+
+/**
+ * OverviewScreen — full Overview surface composed from the snapshot
+ * the page server component fetched.
+ *
+ * Visual contract: prototype `OverviewScreen` (`pc-components.jsx`
+ * lines 771-819, CSS lines 368-422 in `Process Canvas.html`):
+ * greeting + 4 stat cards across the top, then a 2-col grid:
+ *   - left column: Process health + Recent events
+ *   - right column: My tasks + Agent pulse
+ *
+ * Pure server component; the only interactive children are
+ * `<OverviewEvents />` (mount analytics) and `<MyTasksCard />`
+ * (Approve/Reject server-action wiring).
+ */
+function timeOfDayGreeting(now: Date): string {
+  const h = now.getHours();
+  if (h < 5) return "Working late";
+  if (h < 12) return "Good morning";
+  if (h < 18) return "Good afternoon";
+  return "Good evening";
+}
+
+function firstNameFromUser(user: AuthUser | null): string {
+  const handle = (user?.email?.split("@")[0] ?? "").trim();
+  if (!handle) return "there";
+  // Capitalize the first letter only — the email handle is typically
+  // lowercase ("andres") and a sentence-cased greeting reads warmer.
+  return handle.charAt(0).toUpperCase() + handle.slice(1);
+}
+
+export interface OverviewScreenProps {
+  snapshot: OverviewSnapshot;
+  user: AuthUser | null;
+  /** Pinned to keep SSR + tests deterministic. */
+  now?: Date;
+  /** How many recent events to render. Defaults to 4 per the issue. */
+  recentEventLimit?: number;
+}
+
+export function OverviewScreen({
+  snapshot,
+  user,
+  now = new Date(),
+  recentEventLimit = 4,
+}: OverviewScreenProps) {
+  const stats = computeOverviewStats(snapshot);
+  const health = computeTemplateHealth(snapshot);
+  const checkpoints = pickPendingCheckpoints(snapshot);
+  const recentEvents = pickRecentEvents(snapshot, recentEventLimit);
+
+  const greeting = `${timeOfDayGreeting(now)}, ${firstNameFromUser(user)}.`;
+  const subtitle =
+    stats.pendingTasks > 0
+      ? `${stats.pendingTasks} task${stats.pendingTasks === 1 ? "" : "s"} need your decision.`
+      : "All processes running smoothly.";
+
+  // Pre-format the four stat cards so the JSX reads top-to-bottom.
+  const statCards = [
+    {
+      key: "instances",
+      value: String(stats.activeInstances),
+      label: "Active instances",
+      hint:
+        snapshot.instances.length === 0
+          ? "No workflows yet"
+          : `${snapshot.instances.length} total`,
+      tone: snapshot.instances.length === 0 ? "mute" : "up",
+    },
+    {
+      key: "pending",
+      value: String(stats.pendingTasks),
+      label: "My tasks",
+      hint: stats.pendingTasks > 0 ? "Action required" : "All clear",
+      tone: stats.pendingTasks > 0 ? "warn" : "up",
+    },
+    {
+      key: "active",
+      value: String(stats.activeTasks),
+      label: "Active tasks",
+      hint:
+        stats.activeTasks > 0
+          ? `${stats.activeTasks} in flight`
+          : "No tasks running",
+      tone: stats.activeTasks > 0 ? "up" : "mute",
+    },
+    {
+      key: "completion",
+      value: `${stats.completionPct}%`,
+      label: "Completion",
+      hint: `${stats.completedTasks} / ${stats.totalTasks} tasks`,
+      tone: stats.totalTasks === 0 ? "mute" : "up",
+    },
+  ] as const;
+
+  return (
+    <>
+      <OverviewEvents
+        instanceCount={stats.activeInstances}
+        pendingCount={stats.pendingTasks}
+        activeCount={stats.activeTasks}
+        completionPct={stats.completionPct}
+      />
+
+      <div className="overflow-y-auto p-6">
+        <header className="mb-5">
+          <h1
+            data-testid="overview-greeting"
+            className="text-[20px] font-bold tracking-tight text-t1"
+          >
+            {greeting}
+          </h1>
+          <p className="mt-1 text-[13px] text-t2">{subtitle}</p>
+        </header>
+
+        <div
+          data-testid="overview-stats"
+          className="mb-5 grid grid-cols-2 gap-2.5 lg:grid-cols-4"
+        >
+          {statCards.map((card) => (
+            <StatCard
+              key={card.key}
+              value={card.value}
+              label={card.label}
+              hint={card.hint}
+              tone={card.tone}
+            />
+          ))}
+        </div>
+
+        <div className="grid grid-cols-1 gap-3.5 lg:grid-cols-[1fr_320px]">
+          <div className="flex flex-col gap-3">
+            <ProcessHealthCard health={health} />
+            <RecentEventsCard events={recentEvents} now={now} />
+          </div>
+          <div className="flex flex-col gap-3">
+            <MyTasksCard checkpoints={checkpoints} />
+            <AgentPulseCard />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/products/dashboard/components/overview/process-health-card.tsx
+++ b/products/dashboard/components/overview/process-health-card.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+
+import type { TemplateHealth } from "@/lib/workflows/aggregate";
+
+/**
+ * Process Health card — one row per template summarising rollup
+ * completion across that template's instances. Instance chips are
+ * `<Link>`s into `/workflows/[id]` so the founder can jump from the
+ * stat surface straight into the matrix view (instances chip click
+ * requirement on AEL-49).
+ *
+ * Visual contract: prototype `.proc-health-row` block + chip styling
+ * (`Process Canvas.html` lines 383-395). Rendered server-side; chips
+ * are anchor tags so right-click / open-in-new-tab still works.
+ *
+ * Empty workspaces fall back to a single dashed placeholder row so the
+ * card never collapses to zero height during onboarding.
+ */
+export interface ProcessHealthCardProps {
+  health: TemplateHealth[];
+}
+
+export function ProcessHealthCard({ health }: ProcessHealthCardProps) {
+  return (
+    <section
+      data-testid="overview-process-health"
+      className="overflow-hidden rounded-[10px] border border-border bg-bg-2"
+    >
+      <header className="flex items-center justify-between border-b border-border px-4 py-3">
+        <h2 className="text-[12px] font-semibold text-t1">Process health</h2>
+      </header>
+
+      {health.length === 0 ? (
+        <p className="px-4 py-7 text-center text-[12px] text-t2">
+          No workflow templates yet — process health will appear here once you
+          define one.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border-2">
+          {health.map(({ template, instances, completionPct }) => (
+            <li
+              key={template.id}
+              data-testid={`overview-process-health-row-${template.id}`}
+              className="flex items-center gap-3 px-4 py-3"
+            >
+              <span
+                aria-hidden
+                className="block h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: template.color }}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="text-[13px] font-semibold text-t1">
+                  {template.label}
+                </div>
+                {instances.length === 0 ? (
+                  <p className="mt-1 font-mono text-[10px] text-t3">
+                    No instances yet
+                  </p>
+                ) : (
+                  <ul className="mt-1 flex flex-wrap gap-1">
+                    {instances.map((instance) => (
+                      <li key={instance.id}>
+                        <Link
+                          href={`/workflows/${instance.id}`}
+                          data-testid={`overview-instance-chip-${instance.id}`}
+                          className="inline-flex items-center rounded-[5px] border border-border bg-bg-3 px-1.5 py-[2px] text-[10px] text-t2 transition-colors hover:border-primary hover:bg-primary-bg hover:text-accent"
+                        >
+                          {instance.label}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+              <div className="flex shrink-0 flex-col items-end gap-1">
+                <span className="font-mono text-[10px] text-t3">
+                  {completionPct}%
+                </span>
+                <span
+                  aria-hidden
+                  className="block h-[3px] w-20 overflow-hidden rounded-[2px] bg-bg-4"
+                >
+                  <span
+                    className="block h-full rounded-[2px]"
+                    style={{
+                      width: `${completionPct}%`,
+                      backgroundColor: template.color,
+                    }}
+                  />
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/products/dashboard/components/overview/recent-events-card.tsx
+++ b/products/dashboard/components/overview/recent-events-card.tsx
@@ -1,0 +1,89 @@
+import type { WorkflowEvent } from "@/lib/workflows/types";
+
+/**
+ * Recent Events card — last N rows from `workflow_events`.
+ *
+ * Visual contract: prototype `.ev-row` block (`Process Canvas.html`
+ * lines 416-422) and the OverviewScreen events list
+ * (`pc-components.jsx` line 805). The accent dot · monospace event
+ * name · description · relative timestamp pattern stays intact.
+ *
+ * Server-rendered. Timestamps render as a stable absolute value
+ * (`HH:mm`) plus a relative hint computed against the current request
+ * time so SSR and client hydration agree even when the user keeps the
+ * tab open for hours.
+ */
+export interface RecentEventsCardProps {
+  events: WorkflowEvent[];
+  /** Used as `now` so server and any test harness can pin time. */
+  now?: Date;
+}
+
+function formatRelative(then: Date, now: Date): string {
+  const diffMs = now.getTime() - then.getTime();
+  if (diffMs < 0) return "just now";
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min} min ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  return then.toISOString().slice(0, 10);
+}
+
+export function RecentEventsCard({
+  events,
+  now = new Date(),
+}: RecentEventsCardProps) {
+  return (
+    <section
+      data-testid="overview-recent-events"
+      className="overflow-hidden rounded-[10px] border border-border bg-bg-2"
+    >
+      <header className="flex items-center justify-between border-b border-border px-4 py-3">
+        <h2 className="text-[12px] font-semibold text-t1">Recent events</h2>
+      </header>
+
+      {events.length === 0 ? (
+        <p className="px-4 py-7 text-center text-[12px] text-t2">
+          No events yet. Workflow domain events will land here as agents run.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border-2">
+          {events.map((event) => {
+            const ts = new Date(event.createdAt);
+            return (
+              <li
+                key={event.id}
+                data-testid={`overview-event-${event.id}`}
+                className="flex gap-2.5 px-4 py-2.5"
+              >
+                <span
+                  aria-hidden
+                  className="mt-[5px] block h-[5px] w-[5px] shrink-0 rounded-full bg-accent"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="font-mono text-[11px] text-accent">
+                    {event.name}
+                  </div>
+                  {event.description && (
+                    <div className="text-[11px] text-t2">
+                      {event.description}
+                    </div>
+                  )}
+                  <div className="font-mono text-[10px] text-t3">
+                    <time dateTime={event.createdAt}>
+                      {formatRelative(ts, now)}
+                    </time>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/products/dashboard/components/overview/stat-card.tsx
+++ b/products/dashboard/components/overview/stat-card.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * StatCard — one of the four numbers across the top of the Overview.
+ *
+ * Visual contract: prototype `.stat-card` block in
+ * `/tmp/design-canvas/ai-native-dashboard/project/Process Canvas.html`
+ * (lines 372-377). The delta row recolors based on `tone`:
+ *   - `up`   → emerald (`#34d399`)
+ *   - `warn` → amber  (`#fbbf24`)
+ *   - `mute` → `--t3` (used for neutral metadata like "0 / 0 tasks")
+ *
+ * Light-theme contrast note: hint text uses `text-t2` (and the tone
+ * classes pin colors that read on both bg-2 and bg-light-2). PR-3's
+ * empty stub bumped from `--t3` to `--t2` for the same reason.
+ */
+
+export type StatCardTone = "up" | "warn" | "mute";
+
+export interface StatCardProps {
+  value: string;
+  label: string;
+  hint: string;
+  tone?: StatCardTone;
+}
+
+const toneClass: Record<StatCardTone, string> = {
+  up: "text-[color:#34d399]",
+  warn: "text-[color:#fbbf24]",
+  mute: "text-t2",
+};
+
+export function StatCard({
+  value,
+  label,
+  hint,
+  tone = "mute",
+}: StatCardProps) {
+  return (
+    <div className="rounded-[10px] border border-border bg-bg-2 px-4 py-3.5">
+      <div className="font-mono text-[26px] font-extrabold leading-none tracking-tight text-t1">
+        {value}
+      </div>
+      <div className="mt-1.5 text-[11px] text-t2">{label}</div>
+      <div className={cn("mt-1 font-mono text-[10px]", toneClass[tone])}>
+        {hint}
+      </div>
+    </div>
+  );
+}

--- a/products/dashboard/e2e/overview.spec.ts
+++ b/products/dashboard/e2e/overview.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * E2E coverage for AEL-49 — Overview screen with real data.
+ *
+ * Mirrors the bypass + Supabase-runtime guard pattern in
+ * `e2e/workflows.spec.ts`: a CI runner without the auth bypass cookie
+ * or live Supabase credentials skips these checks rather than failing.
+ * The expectations encode the AEL-49 acceptance criteria so any
+ * regression on a fully-credentialed runner trips immediately.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+const baseURL = process.env.BASE_URL || "http://localhost:3000";
+const bypassSecret = process.env.AUTH_E2E_BYPASS_SECRET;
+const hasSupabaseRuntime =
+  !!process.env.NEXT_PUBLIC_SUPABASE_URL &&
+  !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+async function authenticateWithBypass(page: Page) {
+  test.skip(
+    !bypassSecret,
+    "AUTH_E2E_BYPASS_SECRET is required for authenticated E2E",
+  );
+
+  await page.context().addCookies([
+    {
+      name: "dashboard_e2e_auth",
+      value: `${bypassSecret}:e2e-user:${encodeURIComponent("e2e@example.com")}`,
+      url: baseURL,
+    },
+  ]);
+}
+
+test.describe("overview — live workflow data", () => {
+  test("renders greeting, stat cards, and process-health chips that navigate", async ({
+    page,
+  }) => {
+    test.skip(
+      !hasSupabaseRuntime,
+      "Supabase runtime credentials required for the Overview happy path",
+    );
+
+    await authenticateWithBypass(page);
+    await page.goto("/");
+
+    // Greeting is always rendered, even when the workspace is empty.
+    await expect(page.getByTestId("overview-greeting")).toBeVisible();
+
+    // Four stat cards present, each with a numeric value (zero is fine
+    // for an empty workspace; the contract is "they render", not "they
+    // are non-zero", since seed state varies per environment).
+    const stats = page.getByTestId("overview-stats");
+    await expect(stats).toBeVisible();
+    await expect(stats).toContainText(/Active instances/);
+    await expect(stats).toContainText(/My tasks/);
+    await expect(stats).toContainText(/Active tasks/);
+    await expect(stats).toContainText(/Completion/);
+
+    // Process Health card is always present; chips are conditional on
+    // there being at least one instance in the workspace.
+    await expect(page.getByTestId("overview-process-health")).toBeVisible();
+
+    const firstChip = page
+      .locator('[data-testid^="overview-instance-chip-"]')
+      .first();
+
+    if (await firstChip.count()) {
+      const href = await firstChip.getAttribute("href");
+      expect(href).toMatch(/^\/workflows\/[^/]+$/);
+      await firstChip.click();
+      await expect(page).toHaveURL(/\/workflows\/[^/]+$/);
+    }
+  });
+});

--- a/products/dashboard/lib/analytics/events.ts
+++ b/products/dashboard/lib/analytics/events.ts
@@ -27,6 +27,19 @@ export type AnalyticsEvent =
     }
   // ── Dashboard shell ───────────────────────────────────────────────────────
   | { event: "dashboard.shell_viewed"; properties: { route: string } }
+  // Overview screen — fired once on mount of `app/(dashboard)/page.tsx`.
+  // Carries the four stat-card numbers so analytics can answer "how many
+  // founders see N pending tasks on load?" without joining additional
+  // tables. Catalog source: spec/examples/dashboard-product.yaml.
+  | {
+      event: "dashboard.overview_viewed";
+      properties: {
+        instance_count: number;
+        pending_count: number;
+        active_count: number;
+        completion_pct: number;
+      };
+    }
   // ── Workflows ─────────────────────────────────────────────────────────────
   // Catalog source of truth: spec/examples/platform-product.yaml → events
   // catalog → workflow.instance_created. The PostHog payload intentionally

--- a/products/dashboard/lib/workflows/aggregate.ts
+++ b/products/dashboard/lib/workflows/aggregate.ts
@@ -1,0 +1,178 @@
+import type {
+  WorkflowEvent,
+  WorkflowInstance,
+  WorkflowTask,
+  WorkflowTemplate,
+} from "./types";
+
+/**
+ * Pure aggregation helpers that turn a workflow snapshot (templates +
+ * instances + tasks + recent events) into the numbers the Overview
+ * screen renders. Kept side-effect free and Supabase-agnostic so unit
+ * tests can drive every counting/percentage edge case without spinning
+ * up a database.
+ *
+ * Source design: `OverviewScreen` in
+ * `/tmp/design-canvas/ai-native-dashboard/project/pc-components.jsx`
+ * (lines 771-819) — the prototype counted live, hard-coded `CHECKPOINTS`
+ * for pending approvals; we treat any task in `pending_approval` as a
+ * pending decision (the `checkpoint` flag describes the *template*
+ * intent of the slot, not whether the task is currently awaiting one).
+ */
+
+export interface OverviewSnapshot {
+  templates: WorkflowTemplate[];
+  instances: WorkflowInstance[];
+  tasks: WorkflowTask[];
+  events: WorkflowEvent[];
+}
+
+export interface OverviewStats {
+  /** Number of instances whose status is anything other than `complete`. */
+  activeInstances: number;
+  /** Tasks awaiting a human decision (status === "pending_approval"). */
+  pendingTasks: number;
+  /** Tasks currently active (status === "active"). */
+  activeTasks: number;
+  /** Tasks that have reached the `complete` state. */
+  completedTasks: number;
+  /** Total tasks across every instance. */
+  totalTasks: number;
+  /**
+   * Completion percent, rounded to the nearest integer.
+   * Defined as 0 when there are no tasks to avoid NaN in the UI.
+   */
+  completionPct: number;
+}
+
+export interface TemplateHealth {
+  template: WorkflowTemplate;
+  instances: WorkflowInstance[];
+  totalTasks: number;
+  completedTasks: number;
+  /** Per-template completion percent, rounded; 0 when no tasks exist. */
+  completionPct: number;
+}
+
+/**
+ * Round a 0-1 ratio to a 0-100 integer, treating empty denominators as 0.
+ *
+ * The Overview screen uses these numbers to drive both copy ("3 / 12 tasks")
+ * and progress bars; a NaN slipping through here would render as `NaN%` and
+ * break the bar fill — keeping the floor at 0 protects both surfaces.
+ */
+export function percentComplete(complete: number, total: number): number {
+  if (!Number.isFinite(complete) || !Number.isFinite(total) || total <= 0) {
+    return 0;
+  }
+  return Math.round((complete / total) * 100);
+}
+
+/**
+ * Compute the four stat-card numbers + completion percent from a snapshot.
+ *
+ * Mirrors the prototype's stat-row math (`pc-components.jsx` line 793) with
+ * one substantive shift: "active instances" excludes completed instances so
+ * the stat tracks live work, not lifetime totals. A founder glancing at the
+ * Overview should see what is currently in flight.
+ */
+export function computeOverviewStats(snapshot: OverviewSnapshot): OverviewStats {
+  const tasks = snapshot.tasks;
+  const completedTasks = tasks.filter((t) => t.status === "complete").length;
+  const activeTasks = tasks.filter((t) => t.status === "active").length;
+  const pendingTasks = tasks.filter((t) => t.status === "pending_approval").length;
+  const activeInstances = snapshot.instances.filter(
+    (i) => i.status !== "complete",
+  ).length;
+
+  return {
+    activeInstances,
+    pendingTasks,
+    activeTasks,
+    completedTasks,
+    totalTasks: tasks.length,
+    completionPct: percentComplete(completedTasks, tasks.length),
+  };
+}
+
+/**
+ * Group instances by template and roll up per-template completion so the
+ * Process Health card can render a row per template.
+ *
+ * Templates are returned in their input order so callers control sort
+ * (the repository orders by `label` ASC today). Templates with no
+ * instances are still included — the prototype shows them with a 0%
+ * bar so the grid stays predictable as a workspace grows.
+ */
+export function computeTemplateHealth(snapshot: OverviewSnapshot): TemplateHealth[] {
+  const tasksByInstance = new Map<string, WorkflowTask[]>();
+  for (const task of snapshot.tasks) {
+    const bucket = tasksByInstance.get(task.instanceId) ?? [];
+    bucket.push(task);
+    tasksByInstance.set(task.instanceId, bucket);
+  }
+
+  return snapshot.templates.map((template) => {
+    const instances = snapshot.instances.filter(
+      (i) => i.templateId === template.id,
+    );
+    let completedTasks = 0;
+    let totalTasks = 0;
+    for (const instance of instances) {
+      const tasks = tasksByInstance.get(instance.id) ?? [];
+      totalTasks += tasks.length;
+      completedTasks += tasks.filter((t) => t.status === "complete").length;
+    }
+
+    return {
+      template,
+      instances,
+      totalTasks,
+      completedTasks,
+      completionPct: percentComplete(completedTasks, totalTasks),
+    };
+  });
+}
+
+/**
+ * Pick the most recent N events from a snapshot. The repository already
+ * orders events by `created_at` DESC, but callers may want to enforce
+ * the slice length here so the UI never overflows even if a future
+ * caller forgets the `.limit()` clause.
+ */
+export function pickRecentEvents(
+  snapshot: OverviewSnapshot,
+  limit: number,
+): WorkflowEvent[] {
+  if (limit <= 0) return [];
+  return snapshot.events.slice(0, limit);
+}
+
+/**
+ * Pending checkpoint tasks projected for the My Tasks card. Each entry
+ * carries the parent instance + template so the UI can render the
+ * "PROCESS · TASK · By <agent>" stack without a second lookup.
+ */
+export interface PendingCheckpoint {
+  task: WorkflowTask;
+  instance: WorkflowInstance;
+  template: WorkflowTemplate | null;
+}
+
+export function pickPendingCheckpoints(snapshot: OverviewSnapshot): PendingCheckpoint[] {
+  const instanceById = new Map(snapshot.instances.map((i) => [i.id, i]));
+  const templateById = new Map(snapshot.templates.map((t) => [t.id, t]));
+
+  return snapshot.tasks
+    .filter((t) => t.status === "pending_approval")
+    .map((task) => {
+      const instance = instanceById.get(task.instanceId);
+      if (!instance) return null;
+      return {
+        task,
+        instance,
+        template: templateById.get(instance.templateId) ?? null,
+      };
+    })
+    .filter((entry): entry is PendingCheckpoint => entry !== null);
+}

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -287,10 +287,13 @@ export function createWorkflowRepository(
     },
 
     async listRecentEvents(limit: number): Promise<WorkflowEvent[]> {
-      // Cap the limit defensively. Callers ask for "last 4" today; an
-      // unbounded request would still be safe but pull a lot over the
-      // wire as the events table grows.
-      const safeLimit = Math.max(0, Math.min(limit, 200));
+      // Normalize first: a `NaN` or fractional `limit` would otherwise
+      // poison `Math.min`/`Math.max` and reach Supabase as `NaN` /
+      // `1.5`, both of which produce confusing query errors. Treat
+      // anything non-finite as "0 rows requested" so the caller gets a
+      // clean empty result instead of a thrown error.
+      const normalizedLimit = Number.isFinite(limit) ? Math.trunc(limit) : 0;
+      const safeLimit = Math.max(0, Math.min(normalizedLimit, 200));
       if (safeLimit === 0) return [];
 
       const { data, error } = await client

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -274,6 +274,37 @@ export function createWorkflowRepository(
       return (data ?? []).map((row) => mapInstance(row as WorkflowInstanceRow));
     },
 
+    async listAllTasks(): Promise<WorkflowTask[]> {
+      const { data, error } = await client
+        .from("workflow_tasks")
+        .select("*")
+        .order("created_at", { ascending: true });
+
+      if (error) {
+        throw new WorkflowRepositoryError("listAllTasks failed", error);
+      }
+      return (data ?? []).map((row) => mapTask(row as WorkflowTaskRow));
+    },
+
+    async listRecentEvents(limit: number): Promise<WorkflowEvent[]> {
+      // Cap the limit defensively. Callers ask for "last 4" today; an
+      // unbounded request would still be safe but pull a lot over the
+      // wire as the events table grows.
+      const safeLimit = Math.max(0, Math.min(limit, 200));
+      if (safeLimit === 0) return [];
+
+      const { data, error } = await client
+        .from("workflow_events")
+        .select("*")
+        .order("created_at", { ascending: false })
+        .limit(safeLimit);
+
+      if (error) {
+        throw new WorkflowRepositoryError("listRecentEvents failed", error);
+      }
+      return (data ?? []).map((row) => mapEvent(row as WorkflowEventRow));
+    },
+
     async createInstance(
       templateId: string,
       label: string,

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -148,6 +148,17 @@ export interface WorkflowRepository {
   getTemplates(): Promise<WorkflowTemplate[]>;
   getInstance(id: string): Promise<WorkflowInstanceDetail | null>;
   listInstances(templateId?: string): Promise<WorkflowInstance[]>;
+  /**
+   * All tasks across every instance the caller can read (RLS still
+   * applies). Used by the Overview screen to compute completion stats
+   * without N+1 round-trips through `getInstance()`.
+   */
+  listAllTasks(): Promise<WorkflowTask[]>;
+  /**
+   * Most recent workflow events across every instance the caller can
+   * read. Ordered by `created_at` DESC; capped at `limit`.
+   */
+  listRecentEvents(limit: number): Promise<WorkflowEvent[]>;
   createInstance(templateId: string, label: string): Promise<WorkflowInstanceDetail>;
   updateTask(taskId: string, patch: WorkflowTaskPatch): Promise<WorkflowTask>;
   addEvent(taskId: string, event: WorkflowEventInput): Promise<WorkflowEvent>;

--- a/spec/examples/dashboard-product.yaml
+++ b/spec/examples/dashboard-product.yaml
@@ -223,6 +223,38 @@ events:
         properties:
           route:
             type: string
+    - name: "dashboard.overview_viewed"
+      description: "User loaded the Overview screen at /. Carries the four stat-card numbers so we can correlate engagement with workspace load (pending decisions, active work, completion)."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: none
+        ordering: at_least_once
+      emitted_by:
+        - "components.overview-screen"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - instance_count
+          - pending_count
+          - active_count
+          - completion_pct
+        properties:
+          instance_count:
+            type: integer
+            minimum: 0
+          pending_count:
+            type: integer
+            minimum: 0
+          active_count:
+            type: integer
+            minimum: 0
+          completion_pct:
+            type: integer
+            minimum: 0
+            maximum: 100
     - name: "auth.requested_magic_link"
       description: "User successfully requested a magic-link sign-in email."
       version: "1.0.0"
@@ -298,6 +330,9 @@ observability:
     core_metrics:
       - key: "dashboard.shell_viewed"
         description: "Total dashboard loads; baseline engagement signal."
+        type: event
+      - key: "dashboard.overview_viewed"
+        description: "Overview screen mounts; primary signal for founder daily-active engagement and the workload they observed at load."
         type: event
       - key: "auth.requested_magic_link"
         description: "Successful magic-link requests from the login surface."


### PR DESCRIPTION
## Summary

Replace the stub Overview placeholder with the live Overview screen described in AEL-49 / the Process Canvas design handoff. Loads templates / instances / tasks / recent events from the cookie-aware Supabase repository and renders them as the four stat cards + 2-column grid (Process Health · Recent Events · My Tasks · Agent Pulse).

- New `lib/workflows/aggregate.ts` — pure helpers for stat counts, per-template completion rollup, pending-checkpoint projection, and recent-event slicing. Unit-tested for empty / partial / fully complete denominators.
- `WorkflowRepository` extended with `listAllTasks()` and `listRecentEvents(limit)` so the page fetches the snapshot in one parallel round-trip.
- New `dashboard.overview_viewed` event in the typed `AnalyticsEvent` union and `spec/examples/dashboard-product.yaml` (catalog + observability core metrics) — payload carries the four stat numbers.
- New `resolveCheckpointAction` server action so the My Tasks card's Approve / Reject close the loop today (sets task status, emits `workflow.checkpoint_{approved,rejected}`); the richer drawer flow lands with PR-8 (AEL-51).
- Server page wraps the snapshot fetch in a try/catch that captures to Sentry and falls back to an empty snapshot so the chrome stays up if Supabase is degraded.

Visual contract: `/tmp/design-canvas/ai-native-dashboard/project/Process Canvas.html` lines 368-422 + `pc-components.jsx` lines 771-819.

Linear: [AEL-49](https://linear.app/aelizondo/issue/AEL-49/pr-6-overview-screen-with-real-data)

## Test plan

- [x] `npm run validate` — spec + types green
- [x] `npm test` — 19 files / 150 tests green (10 new unit cases for aggregate, 6 new component cases for OverviewScreen)
- [x] `npm run build` — clean type-check + production build
- [x] New Playwright spec `e2e/overview.spec.ts` mirrors the bypass + Supabase-runtime guard pattern from `e2e/workflows.spec.ts`; runs end-to-end on credentialed runners and skips otherwise

## Observability

- `dashboard.overview_viewed` PostHog event fires on mount with `{instance_count, pending_count, active_count, completion_pct}`
- Snapshot fetch failures route through `captureError({feature: "overview.snapshot"})`
- Checkpoint approval / rejection failures route through `captureError({feature: "overview.my_tasks", action: "checkpoint.{approved|rejected}"})`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Overview dashboard: realtime stats, process health, recent events, agent pulse, and “My tasks” with approve/reject controls and graceful empty/error states.

* **Tests**
  * New unit tests for aggregation and overview logic.
  * New end-to-end spec validating Overview screen and navigation.

* **Chores**
  * Added analytics event for overview views with payload schema and metrics entry.
  * Backend/read APIs extended and error-capture added for more resilient snapshot loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->