### PR TITLE
feat(workflows): task drawer with details/events tabs and approve/reject path (AEL-51)

### DIFF
--- a/products/dashboard/__tests__/components/workflows/task-drawer.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/task-drawer.test.tsx
@@ -1,0 +1,384 @@
+/**
+ * Unit tests for components/workflows/task-drawer.tsx (AEL-51 — PR 8).
+ *
+ * Coverage:
+ *   - Drawer renders with breadcrumb, title, and tab bar
+ *   - Details tab: primary action card variants per task status
+ *   - Approve → calls approveDrawerCheckpointAction + onTaskUpdate
+ *   - Reject  → calls rejectDrawerCheckpointAction
+ *   - Events tab shows task-scoped events; empty state when none
+ *   - Dependencies tab shows placeholder
+ *   - Overlay click calls onClose
+ *   - Escape key calls onClose
+ *   - TriggerGateEditor: add/remove triggers and gates
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  type MockedFunction,
+} from "vitest";
+import { render, screen, fireEvent, within, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type {
+  WorkflowEvent,
+  WorkflowInstanceDetail,
+  WorkflowRole,
+  WorkflowTask,
+  WorkflowTemplate,
+} from "@/lib/workflows/types";
+import { TaskDrawer } from "@/components/workflows/task-drawer";
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+const { mockApprove, mockReject, mockUpdateTG, mockEmitEvent, mockCaptureError } =
+  vi.hoisted(() => ({
+    mockApprove: vi.fn(),
+    mockReject: vi.fn(),
+    mockUpdateTG: vi.fn(),
+    mockEmitEvent: vi.fn(),
+    mockCaptureError: vi.fn(),
+  }));
+
+vi.mock("@/app/(dashboard)/workflows/actions", () => ({
+  approveDrawerCheckpointAction: mockApprove,
+  rejectDrawerCheckpointAction: mockReject,
+  updateTaskTriggerGatesAction: mockUpdateTG,
+}));
+
+vi.mock("@/lib/events", () => ({
+  emitEvent: mockEmitEvent,
+}));
+
+vi.mock("@/lib/monitoring", () => ({
+  captureError: mockCaptureError,
+}));
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const ROLES: WorkflowRole[] = [
+  { id: "sales", label: "Sales", owner: "Hans" },
+  { id: "product", label: "Product", owner: "Andres" },
+];
+
+const TEMPLATE: WorkflowTemplate = {
+  id: "tpl-1",
+  label: "Client Delivery",
+  color: "#6366f1",
+  multiInstance: true,
+  stages: [
+    { id: "pre-sales", label: "Pre-Sales" },
+    { id: "validation", label: "Validation" },
+  ],
+  roles: ROLES,
+  taskTemplates: [],
+  createdAt: "2026-04-19T12:00:00Z",
+  updatedAt: "2026-04-19T12:00:00Z",
+};
+
+function makeTask(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
+  return {
+    id: "task-1",
+    instanceId: "inst-1",
+    roleId: "sales",
+    stageId: "pre-sales",
+    title: "Scope review",
+    description: "",
+    status: "pending_approval",
+    substatus: "",
+    checkpoint: true,
+    triggers: [],
+    gates: [],
+    agent: "GPT-4o",
+    skill: "spec.review",
+    playbook: null,
+    createdAt: "2026-04-19T12:00:00Z",
+    updatedAt: "2026-04-19T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<WorkflowEvent> = {}): WorkflowEvent {
+  return {
+    id: "ev-1",
+    instanceId: "inst-1",
+    taskId: "task-1",
+    name: "workflow.checkpoint_approved",
+    description: "Approved checkpoint",
+    payload: {},
+    createdAt: "2026-04-19T13:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeInstance(
+  tasks: WorkflowTask[] = [],
+  events: WorkflowEvent[] = [],
+): WorkflowInstanceDetail {
+  return {
+    id: "inst-1",
+    templateId: "tpl-1",
+    label: "Acme Corp",
+    status: "active",
+    roles: ROLES,
+    createdAt: "2026-04-19T12:00:00Z",
+    updatedAt: "2026-04-19T12:00:00Z",
+    tasks,
+    events,
+  };
+}
+
+function renderDrawer(
+  taskOverrides: Partial<WorkflowTask> = {},
+  events: WorkflowEvent[] = [],
+  onClose = vi.fn(),
+  onTaskUpdate = vi.fn(),
+) {
+  const task = makeTask(taskOverrides);
+  const instance = makeInstance([task], events);
+
+  render(
+    <TaskDrawer
+      task={task}
+      instance={instance}
+      roles={ROLES}
+      template={TEMPLATE}
+      onClose={onClose}
+      onTaskUpdate={onTaskUpdate}
+    />,
+  );
+
+  return { task, onClose, onTaskUpdate };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("TaskDrawer", () => {
+  beforeEach(() => {
+    mockApprove.mockReset();
+    mockReject.mockReset();
+    mockUpdateTG.mockReset();
+    mockEmitEvent.mockReset();
+    mockCaptureError.mockReset();
+  });
+
+  it("renders the drawer with breadcrumb, title, and tab bar", () => {
+    renderDrawer();
+
+    const drawer = screen.getByTestId("task-drawer");
+    expect(drawer).toBeInTheDocument();
+    expect(drawer).toHaveAttribute("role", "dialog");
+
+    // Breadcrumb: instance › stage › role
+    const breadcrumb = within(drawer).getByText("Acme Corp");
+    expect(breadcrumb).toBeInTheDocument();
+    expect(within(drawer).getByText("Pre-Sales")).toBeInTheDocument();
+    expect(within(drawer).getByText("Sales")).toBeInTheDocument();
+
+    // Title
+    expect(within(drawer).getByText("Scope review")).toBeInTheDocument();
+
+    // Tabs
+    expect(screen.getByTestId("td-tab-details")).toBeInTheDocument();
+    expect(screen.getByTestId("td-tab-events")).toBeInTheDocument();
+    expect(screen.getByTestId("td-tab-dependencies")).toBeInTheDocument();
+  });
+
+  it("emits dashboard.task_drawer_opened on mount", () => {
+    renderDrawer({ id: "task-xyz" });
+    expect(mockEmitEvent).toHaveBeenCalledWith("dashboard.task_drawer_opened", {
+      task_id: "task-xyz",
+    });
+  });
+
+  describe("Details tab — primary action card", () => {
+    it("shows Approve + Reject buttons for pending_approval task", () => {
+      renderDrawer({ status: "pending_approval", checkpoint: true });
+      expect(screen.getByTestId("td-approve-btn")).toBeInTheDocument();
+      expect(screen.getByTestId("td-reject-btn")).toBeInTheDocument();
+    });
+
+    it("shows Start agent button for not_started task", () => {
+      renderDrawer({ status: "not_started", checkpoint: false });
+      expect(screen.getByTestId("td-start-btn")).toBeInTheDocument();
+    });
+
+    it("shows View live run button for active task", () => {
+      renderDrawer({ status: "active", checkpoint: false });
+      expect(screen.getByTestId("td-view-run-btn")).toBeInTheDocument();
+    });
+
+    it("shows no action card for complete task", () => {
+      renderDrawer({ status: "complete", checkpoint: false });
+      expect(screen.queryByTestId("td-action-card")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Approve flow", () => {
+    it("calls approveDrawerCheckpointAction and onTaskUpdate on success", async () => {
+      const updatedTask = makeTask({ status: "active" });
+      mockApprove.mockResolvedValue({ task: updatedTask });
+      const onTaskUpdate = vi.fn();
+      const { task } = renderDrawer({ status: "pending_approval" }, [], vi.fn(), onTaskUpdate);
+
+      const approveBtn = screen.getByTestId("td-approve-btn");
+      await act(async () => {
+        fireEvent.click(approveBtn);
+      });
+
+      expect(mockApprove).toHaveBeenCalledWith(task.id);
+      expect(onTaskUpdate).toHaveBeenCalledWith(updatedTask);
+      expect(mockEmitEvent).toHaveBeenCalledWith(
+        "workflow.checkpoint_approved",
+        { task_id: task.id, instance_id: task.instanceId },
+      );
+    });
+
+    it("captures error if approve action throws", async () => {
+      mockApprove.mockRejectedValue(new Error("Server error"));
+      renderDrawer({ status: "pending_approval" });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("td-approve-btn"));
+      });
+
+      expect(mockCaptureError).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Reject flow", () => {
+    it("calls rejectDrawerCheckpointAction on reject", async () => {
+      mockReject.mockResolvedValue(undefined);
+      const { task } = renderDrawer({ status: "pending_approval" });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("td-reject-btn"));
+      });
+
+      expect(mockReject).toHaveBeenCalledWith(task.id);
+      expect(mockEmitEvent).toHaveBeenCalledWith(
+        "workflow.checkpoint_rejected",
+        { task_id: task.id, instance_id: task.instanceId },
+      );
+    });
+  });
+
+  describe("Events tab", () => {
+    it("shows task-scoped events", async () => {
+      const user = userEvent.setup();
+      const taskEv = makeEvent({ id: "ev-task", taskId: "task-1" });
+      const otherEv = makeEvent({ id: "ev-other", taskId: "task-999" });
+      renderDrawer({}, [taskEv, otherEv]);
+
+      await user.click(screen.getByTestId("td-tab-events"));
+
+      expect(screen.getByTestId("td-event-ev-task")).toBeInTheDocument();
+      expect(screen.queryByTestId("td-event-ev-other")).not.toBeInTheDocument();
+    });
+
+    it("shows empty state when no events for the task", async () => {
+      const user = userEvent.setup();
+      renderDrawer({}, []);
+
+      await user.click(screen.getByTestId("td-tab-events"));
+
+      expect(screen.getByTestId("td-events-empty")).toBeInTheDocument();
+    });
+  });
+
+  describe("Dependencies tab", () => {
+    it("shows placeholder", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.click(screen.getByTestId("td-tab-dependencies"));
+
+      expect(screen.getByTestId("td-dependencies-placeholder")).toHaveTextContent(
+        /DepTree coming in PR 10/i,
+      );
+    });
+  });
+
+  describe("Close behaviour", () => {
+    it("calls onClose when overlay is clicked", () => {
+      const onClose = vi.fn();
+      renderDrawer({}, [], onClose);
+      fireEvent.click(screen.getByTestId("task-drawer-overlay"));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClose when the close button is clicked", () => {
+      const onClose = vi.fn();
+      renderDrawer({}, [], onClose);
+      fireEvent.click(screen.getByTestId("task-drawer-close"));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClose on Escape key", () => {
+      const onClose = vi.fn();
+      renderDrawer({}, [], onClose);
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("TriggerGateEditor — triggers", () => {
+    it("adds a trigger and calls updateTaskTriggerGatesAction", async () => {
+      const user = userEvent.setup();
+      const updatedTask = makeTask({
+        triggers: [{ type: "manual", label: "New trigger" }],
+      });
+      mockUpdateTG.mockResolvedValue({ task: updatedTask });
+      const onTaskUpdate = vi.fn();
+      renderDrawer({ triggers: [] }, [], vi.fn(), onTaskUpdate);
+
+      // Open inline form
+      await user.click(screen.getByTestId("tg-add-trigger"));
+
+      // Fill label
+      const input = screen.getByPlaceholderText("Label");
+      await user.type(input, "New trigger");
+
+      // Submit
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /^Add$/ }));
+      });
+
+      expect(mockUpdateTG).toHaveBeenCalledWith(
+        "task-1",
+        [{ type: expect.any(String), label: "New trigger" }],
+        [],
+      );
+      expect(onTaskUpdate).toHaveBeenCalledWith(updatedTask);
+    });
+
+    it("removes a trigger by index", async () => {
+      const user = userEvent.setup();
+      const updatedTask = makeTask({ triggers: [] });
+      mockUpdateTG.mockResolvedValue({ task: updatedTask });
+
+      renderDrawer(
+        { triggers: [{ type: "manual", label: "Old trigger" }] },
+        [],
+        vi.fn(),
+        vi.fn(),
+      );
+
+      expect(screen.getByTestId("tg-item-trigger-0")).toBeInTheDocument();
+
+      await act(async () => {
+        await user.click(
+          within(screen.getByTestId("tg-item-trigger-0")).getByRole("button", {
+            name: /Remove trigger/i,
+          }),
+        );
+      });
+
+      expect(mockUpdateTG).toHaveBeenCalledWith("task-1", [], []);
+    });
+  });
+});

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -187,6 +187,16 @@ export async function approveDrawerCheckpointAction(
   const repo = await getServerWorkflowRepository();
   const trimmedId = taskId.trim();
 
+  const current = await repo.getTask(trimmedId);
+  if (!current) {
+    throw new Error("approveDrawerCheckpointAction: task not found");
+  }
+  if (!current.checkpoint || current.status !== "pending_approval") {
+    throw new Error(
+      "approveDrawerCheckpointAction: task is not a pending checkpoint",
+    );
+  }
+
   const task = await repo.updateTask(trimmedId, { status: "active" });
 
   try {
@@ -227,6 +237,11 @@ export async function rejectDrawerCheckpointAction(
   const task = await repo.getTask(trimmedId);
   if (!task) {
     throw new Error("rejectDrawerCheckpointAction: task not found");
+  }
+  if (!task.checkpoint || task.status !== "pending_approval") {
+    throw new Error(
+      "rejectDrawerCheckpointAction: task is not a pending checkpoint",
+    );
   }
 
   try {

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -4,7 +4,12 @@ import { revalidatePath } from "next/cache";
 
 import { captureError } from "@/lib/monitoring";
 import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
-import type { WorkflowInstance, WorkflowTask } from "@/lib/workflows/types";
+import type {
+  WorkflowGate,
+  WorkflowInstance,
+  WorkflowTask,
+  WorkflowTrigger,
+} from "@/lib/workflows/types";
 
 /**
  * Server action invoked by the create-instance modal.
@@ -159,5 +164,120 @@ export async function resolveCheckpointAction(
 
   revalidatePath("/", "layout");
 
+  return { task };
+}
+
+/**
+ * Approve a checkpoint task from the Task Drawer.
+ *
+ * Semantically different from `resolveCheckpointAction` (Overview card):
+ * the drawer approval sets the task to `active` so the agent continues
+ * running, whereas the Overview card's approve sets it to `complete` (task done).
+ * The conditional update (`status = 'pending_approval'`) is enforced server-side
+ * via plain `updateTask` here — the drawer provides the human-visible context
+ * (audit trail, breadcrumb) that the Overview shortcut deliberately omits.
+ */
+export async function approveDrawerCheckpointAction(
+  taskId: string,
+): Promise<{ task: WorkflowTask }> {
+  if (typeof taskId !== "string" || !taskId.trim()) {
+    throw new Error("approveDrawerCheckpointAction: taskId is required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const trimmedId = taskId.trim();
+
+  const task = await repo.updateTask(trimmedId, { status: "active" });
+
+  try {
+    await repo.addEvent(trimmedId, {
+      name: "workflow.checkpoint_approved",
+      description: `Approved checkpoint: ${task.title}`,
+      payload: { task_id: task.id, instance_id: task.instanceId },
+    });
+  } catch (eventError) {
+    captureError(eventError, {
+      feature: "workflows.drawer_approve",
+      action: "addEvent",
+      extra: { task_id: task.id, instance_id: task.instanceId },
+    });
+  }
+
+  revalidatePath("/", "layout");
+  return { task };
+}
+
+/**
+ * Reject a checkpoint task from the Task Drawer.
+ *
+ * The task status remains `pending_approval` — the human must take manual
+ * action outside the system. Only a domain event is written so the audit
+ * trail reflects the rejection decision.
+ */
+export async function rejectDrawerCheckpointAction(
+  taskId: string,
+): Promise<void> {
+  if (typeof taskId !== "string" || !taskId.trim()) {
+    throw new Error("rejectDrawerCheckpointAction: taskId is required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const trimmedId = taskId.trim();
+
+  const task = await repo.getTask(trimmedId);
+  if (!task) {
+    throw new Error("rejectDrawerCheckpointAction: task not found");
+  }
+
+  try {
+    await repo.addEvent(trimmedId, {
+      name: "workflow.checkpoint_rejected",
+      description: `Rejected checkpoint: ${task.title}`,
+      payload: { task_id: task.id, instance_id: task.instanceId },
+    });
+  } catch (eventError) {
+    captureError(eventError, {
+      feature: "workflows.drawer_reject",
+      action: "addEvent",
+      extra: { task_id: task.id, instance_id: task.instanceId },
+    });
+  }
+
+  revalidatePath("/", "layout");
+}
+
+/**
+ * Persist trigger and gate lists for a task.
+ * Called by TriggerGateEditor after each inline add/remove.
+ */
+export async function updateTaskTriggerGatesAction(
+  taskId: string,
+  triggers: WorkflowTrigger[],
+  gates: WorkflowGate[],
+): Promise<{ task: WorkflowTask }> {
+  if (typeof taskId !== "string" || !taskId.trim()) {
+    throw new Error("updateTaskTriggerGatesAction: taskId is required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const trimmedId = taskId.trim();
+
+  const task = await repo.updateTask(trimmedId, { triggers, gates });
+
+  try {
+    await repo.addEvent(trimmedId, {
+      name: "workflow.task_updated",
+      description: `Updated triggers/gates for: ${task.title}`,
+      payload: { task_id: task.id, instance_id: task.instanceId },
+    });
+  } catch (eventError) {
+    captureError(eventError, {
+      feature: "workflows.trigger_gate_update",
+      action: "addEvent",
+      extra: { task_id: task.id, instance_id: task.instanceId },
+    });
+  }
+
+  revalidatePath("/", "layout");
   return { task };
 }

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -587,73 +587,60 @@ body {
 /*
  * Task Drawer.
  *
- * Source of truth: prototype `TaskDrawer` component (`pc-components.jsx`).
- * Fixed-position panel slides in from the right over an overlay. `position:
- * fixed` escapes the `.matrix-wrap { overflow: auto }` scroll container
- * correctly because that ancestor has no transform/perspective/filter.
+ * CSS faithfully mirrors prototype `Process Canvas.html` lines 221-269
+ * and `TaskDrawer` in `pc-components.jsx`. Fixed-position panel slides
+ * in from the right over an overlay. `position:fixed` escapes the
+ * `.matrix-wrap { overflow:auto }` scroll container correctly because
+ * that ancestor has no transform/perspective/filter.
+ *
+ * z-index ladder (from prototype): overlay=55, drawer=60.
  */
 .task-drawer-overlay {
   position: fixed;
   inset: 0;
+  z-index: 55;
   background: var(--overlay);
-  z-index: 40;
 }
 .task-drawer {
   position: fixed;
-  top: 0;
   right: 0;
+  top: 0;
   bottom: 0;
   width: 420px;
-  z-index: 41;
   background: var(--bg-2);
   border-left: 1px solid var(--border-hi);
   box-shadow: var(--shadow);
+  z-index: 60;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  animation: td-slide-in 0.22s cubic-bezier(0.25, 0, 0.25, 1);
+  transform: translateX(105%);
+  transition: transform 0.26s cubic-bezier(0.4, 0, 0.2, 1);
 }
-@keyframes td-slide-in {
-  from {
-    transform: translateX(100%);
-    opacity: 0;
-  }
-  to {
-    transform: translateX(0);
-    opacity: 1;
-  }
+.task-drawer.open {
+  transform: translateX(0);
 }
 @media (prefers-reduced-motion: reduce) {
   .task-drawer {
-    animation: none;
+    transition: none;
   }
 }
+/* Header */
 .td-header {
-  flex-shrink: 0;
+  padding: 18px 20px 0;
   border-bottom: 1px solid var(--border);
-  padding: 14px 16px 0;
+  flex-shrink: 0;
 }
 .td-header-top {
   display: flex;
   align-items: flex-start;
-  justify-content: space-between;
-  gap: 8px;
-}
-.td-breadcrumb {
-  font-size: 10px;
-  color: var(--t3);
-  font-family: "JetBrains Mono", monospace;
-  letter-spacing: 0.04em;
-  margin-bottom: 6px;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 8px;
 }
 .td-title {
   font-size: 15px;
   font-weight: 700;
   color: var(--t1);
+  letter-spacing: -0.02em;
   line-height: 1.3;
   flex: 1;
   margin: 0;
@@ -663,211 +650,235 @@ body {
   height: 26px;
   border-radius: 6px;
   border: 1px solid var(--border);
-  background: none;
-  color: var(--t3);
+  background: var(--bg-3);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  color: var(--t2);
   flex-shrink: 0;
   transition: all 0.14s;
   padding: 0;
 }
 .td-close:hover {
-  background: var(--bg-3);
+  background: var(--bg-4);
   color: var(--t1);
 }
 .td-close:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+.td-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+.td-crumb {
+  font-size: 11px;
+  color: var(--t3);
+  font-family: "JetBrains Mono", monospace;
+}
+.td-crumb-sep {
+  font-size: 11px;
+  color: var(--t3);
+}
+/* Tabs extend to edges with negative margin (mirrors prototype) */
 .td-tabs {
   display: flex;
-  gap: 0;
-  margin-top: 12px;
+  margin: 0 -20px;
+  padding: 0 20px;
 }
 .td-tab {
-  padding: 7px 14px;
   font-size: 12px;
   font-weight: 500;
   color: var(--t3);
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
+  padding: 7px 12px 9px;
   cursor: pointer;
+  border-bottom: 2px solid transparent;
+  background: none;
+  border-top: none;
+  border-left: none;
+  border-right: none;
   transition: all 0.14s;
   margin-bottom: -1px;
 }
 .td-tab:hover {
-  color: var(--t1);
+  color: var(--t2);
 }
 .td-tab.td-tab-active {
   color: var(--accent);
   border-bottom-color: var(--accent);
 }
+/* Body */
 .td-body {
   flex: 1;
   overflow-y: auto;
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  padding: 18px 20px;
 }
-.td-section {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+/* Section block — margin-bottom matches prototype's `.dr-sec` */
+.td-sec {
+  margin-bottom: 20px;
 }
-.td-section-label {
-  font-size: 9.5px;
+/* Section label with decorative `::after` line (from prototype `.dr-sec-lbl::after`) */
+.td-sec-lbl {
+  font-size: 9px;
   font-weight: 600;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.13em;
   text-transform: uppercase;
   color: var(--t3);
   font-family: "JetBrains Mono", monospace;
-}
-/* Primary action card */
-.td-action-card {
-  border-radius: 8px;
-  border: 1px solid var(--border-hi);
-  background: var(--bg-3);
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-.td-action-btns {
-  display: flex;
-  gap: 8px;
-}
-.td-btn {
-  padding: 7px 14px;
-  border-radius: 7px;
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.14s;
-  border: 1px solid transparent;
+  margin-bottom: 9px;
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 8px;
+}
+.td-sec-lbl::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--border-2);
+}
+/* Action card — sits at top of details tab before any sections */
+.td-action-top {
+  background: var(--bg-3);
+  border: 1px solid var(--border-hi);
+  border-radius: 9px;
+  padding: 12px;
+  margin-bottom: 18px;
+}
+/* Buttons — all full-width, stacked */
+.td-btn {
+  width: 100%;
+  padding: 9px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.15s;
+  margin-bottom: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+}
+.td-btn:last-child {
+  margin-bottom: 0;
 }
 .td-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
-.td-btn-approve {
-  background: rgba(16, 185, 129, 0.12);
-  color: #34d399;
-  border-color: rgba(16, 185, 129, 0.25);
-}
-.td-btn-approve:hover:not(:disabled) {
-  background: rgba(16, 185, 129, 0.2);
-}
-.td-btn-reject {
-  background: none;
-  color: var(--t2);
-  border-color: var(--border-hi);
-}
-.td-btn-reject:hover:not(:disabled) {
-  background: var(--bg-4);
-  color: var(--t1);
-}
 .td-btn-primary {
   background: var(--primary);
-  color: #fff;
+  border-color: var(--primary);
+  color: white;
 }
 .td-btn-primary:hover:not(:disabled) {
-  opacity: 0.88;
+  opacity: 0.9;
 }
-.td-btn-outline {
-  background: none;
-  color: var(--accent);
-  border-color: var(--accent);
+.td-btn-approve {
+  background: #10b981;
+  border-color: #10b981;
+  color: white;
 }
-.td-btn-outline:hover:not(:disabled) {
+.td-btn-approve:hover:not(:disabled) {
+  opacity: 0.9;
+}
+.td-btn-run {
   background: var(--primary-bg);
+  border-color: var(--primary);
+  color: var(--accent);
 }
-.td-approved-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 12px;
-  font-weight: 600;
-  color: #34d399;
-  padding: 6px 0;
+.td-btn-run:hover:not(:disabled) {
+  background: rgba(99, 102, 241, 0.18);
 }
-/* Status card */
-.td-status-card {
-  border-radius: 8px;
-  border: 1px solid var(--border);
+.td-btn-ghost {
+  background: transparent;
+  color: var(--t2);
+  border-color: transparent;
+}
+.td-btn-ghost:hover:not(:disabled) {
   background: var(--bg-3);
-  padding: 10px 12px;
-  border-left-width: 3px;
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
+  color: var(--t1);
 }
-.td-checkpoint-card {
-  border-radius: 8px;
-  border: 1px solid rgba(245, 158, 11, 0.3);
-  background: rgba(245, 158, 11, 0.06);
-  padding: 10px 12px;
-  font-size: 12px;
-  color: #fbbf24;
+/* "Approved — agent continuing" badge */
+.td-approved-badge {
   display: flex;
   align-items: center;
   gap: 7px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(16, 185, 129, 0.08);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  font-size: 12px;
+  font-weight: 500;
+  color: #34d399;
+  margin-bottom: 16px;
 }
-/* Skills / playbook rows */
-.td-row {
+/* Agent and playbook rows */
+.td-agent,
+.td-playbook {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
-  border-radius: 7px;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
   background: var(--bg-3);
   border: 1px solid var(--border);
+  min-height: 54px;
 }
-.td-row-icon {
-  width: 22px;
-  height: 22px;
-  border-radius: 5px;
+.td-agent-icon,
+.td-pb-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
   background: var(--bg-4);
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  color: var(--t3);
+  font-size: 16px;
 }
-.td-row-name {
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--t1);
+.td-agent-info {
   flex: 1;
-  min-width: 0;
 }
-.td-row-mono {
-  font-size: 10px;
+.td-agent-name {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--t1);
+}
+.td-agent-skill {
+  font-size: 10.5px;
+  color: var(--t3);
+  font-family: "JetBrains Mono", monospace;
+  margin-top: 2px;
+}
+.td-pb-name {
+  font-size: 12.5px;
+  font-weight: 600;
   font-family: "JetBrains Mono", monospace;
   color: var(--accent);
+  flex: 1;
 }
-.td-pulse-dot {
+.td-agent-pulse {
   width: 7px;
   height: 7px;
   border-radius: 50%;
   flex-shrink: 0;
 }
-.td-pulse-active {
-  background: #10b981;
-  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.25);
-}
-.td-pulse-pending {
-  background: #f59e0b;
-  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.25);
-}
-.td-pulse-idle {
-  background: var(--t3);
+/* Checkpoint notice */
+.td-checkpoint-notice {
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(245, 158, 11, 0.07);
+  border: 1px solid rgba(245, 158, 11, 0.18);
+  font-size: 12px;
+  color: var(--t2);
+  line-height: 1.6;
 }
 /* TriggerGateEditor */
 .tg-list {
@@ -927,11 +938,15 @@ body {
   transition: all 0.14s;
   text-align: left;
   width: 100%;
-  margin-top: 2px;
+  margin-top: 4px;
 }
 .tg-add-btn:hover {
   border-color: var(--accent);
   color: var(--accent);
+}
+.tg-add-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 .tg-inline-form {
   display: flex;
@@ -941,7 +956,7 @@ body {
   border-radius: 6px;
   background: var(--bg-3);
   border: 1px solid var(--border-hi);
-  margin-top: 2px;
+  margin-top: 4px;
 }
 .tg-inline-row {
   display: flex;
@@ -981,6 +996,10 @@ body {
 .tg-form-save:hover {
   opacity: 0.88;
 }
+.tg-form-save:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
 .tg-form-cancel {
   padding: 4px 10px;
   border-radius: 5px;
@@ -995,40 +1014,47 @@ body {
   color: var(--t1);
   border-color: var(--border-hi);
 }
-/* Events tab */
+/* Events tab — dot+line layout (prototype `.dr-ev-*`) */
 .td-event-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
 }
 .td-event-item {
-  padding: 10px 12px;
-  border-radius: 7px;
-  background: var(--bg-3);
-  border: 1px solid var(--border);
+  display: flex;
+  gap: 8px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border-2);
+}
+.td-event-item:last-child {
+  border-bottom: none;
+}
+.td-event-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-top: 5px;
+  flex-shrink: 0;
 }
 .td-event-name {
-  font-size: 11px;
-  font-weight: 600;
+  font-size: 10.5px;
   font-family: "JetBrains Mono", monospace;
   color: var(--accent);
-  margin-bottom: 3px;
 }
 .td-event-desc {
   font-size: 11px;
   color: var(--t2);
-  margin-bottom: 4px;
+  margin-top: 1px;
 }
 .td-event-time {
-  font-size: 9.5px;
+  font-size: 10px;
   color: var(--t3);
-  font-family: "JetBrains Mono", monospace;
+  margin-top: 1px;
 }
 .td-empty {
-  text-align: center;
+  font-size: 11.5px;
   color: var(--t3);
-  font-size: 12px;
-  padding: 24px 0;
+  padding-top: 4px;
 }
 
 /*

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -585,6 +585,453 @@ body {
 }
 
 /*
+ * Task Drawer.
+ *
+ * Source of truth: prototype `TaskDrawer` component (`pc-components.jsx`).
+ * Fixed-position panel slides in from the right over an overlay. `position:
+ * fixed` escapes the `.matrix-wrap { overflow: auto }` scroll container
+ * correctly because that ancestor has no transform/perspective/filter.
+ */
+.task-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay);
+  z-index: 40;
+}
+.task-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 420px;
+  z-index: 41;
+  background: var(--bg-2);
+  border-left: 1px solid var(--border-hi);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: td-slide-in 0.22s cubic-bezier(0.25, 0, 0.25, 1);
+}
+@keyframes td-slide-in {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .task-drawer {
+    animation: none;
+  }
+}
+.td-header {
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
+  padding: 14px 16px 0;
+}
+.td-header-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+.td-breadcrumb {
+  font-size: 10px;
+  color: var(--t3);
+  font-family: "JetBrains Mono", monospace;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.td-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--t1);
+  line-height: 1.3;
+  flex: 1;
+  margin: 0;
+}
+.td-close {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: none;
+  color: var(--t3);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: all 0.14s;
+  padding: 0;
+}
+.td-close:hover {
+  background: var(--bg-3);
+  color: var(--t1);
+}
+.td-close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.td-tabs {
+  display: flex;
+  gap: 0;
+  margin-top: 12px;
+}
+.td-tab {
+  padding: 7px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--t3);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: all 0.14s;
+  margin-bottom: -1px;
+}
+.td-tab:hover {
+  color: var(--t1);
+}
+.td-tab.td-tab-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.td-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.td-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.td-section-label {
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--t3);
+  font-family: "JetBrains Mono", monospace;
+}
+/* Primary action card */
+.td-action-card {
+  border-radius: 8px;
+  border: 1px solid var(--border-hi);
+  background: var(--bg-3);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.td-action-btns {
+  display: flex;
+  gap: 8px;
+}
+.td-btn {
+  padding: 7px 14px;
+  border-radius: 7px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.14s;
+  border: 1px solid transparent;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.td-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.td-btn-approve {
+  background: rgba(16, 185, 129, 0.12);
+  color: #34d399;
+  border-color: rgba(16, 185, 129, 0.25);
+}
+.td-btn-approve:hover:not(:disabled) {
+  background: rgba(16, 185, 129, 0.2);
+}
+.td-btn-reject {
+  background: none;
+  color: var(--t2);
+  border-color: var(--border-hi);
+}
+.td-btn-reject:hover:not(:disabled) {
+  background: var(--bg-4);
+  color: var(--t1);
+}
+.td-btn-primary {
+  background: var(--primary);
+  color: #fff;
+}
+.td-btn-primary:hover:not(:disabled) {
+  opacity: 0.88;
+}
+.td-btn-outline {
+  background: none;
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.td-btn-outline:hover:not(:disabled) {
+  background: var(--primary-bg);
+}
+.td-approved-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #34d399;
+  padding: 6px 0;
+}
+/* Status card */
+.td-status-card {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg-3);
+  padding: 10px 12px;
+  border-left-width: 3px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.td-checkpoint-card {
+  border-radius: 8px;
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.06);
+  padding: 10px 12px;
+  font-size: 12px;
+  color: #fbbf24;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+/* Skills / playbook rows */
+.td-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 7px;
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+}
+.td-row-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+  background: var(--bg-4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--t3);
+}
+.td-row-name {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--t1);
+  flex: 1;
+  min-width: 0;
+}
+.td-row-mono {
+  font-size: 10px;
+  font-family: "JetBrains Mono", monospace;
+  color: var(--accent);
+}
+.td-pulse-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.td-pulse-active {
+  background: #10b981;
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.25);
+}
+.td-pulse-pending {
+  background: #f59e0b;
+  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.25);
+}
+.td-pulse-idle {
+  background: var(--t3);
+}
+/* TriggerGateEditor */
+.tg-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.tg-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  border-radius: 5px;
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--t2);
+}
+.tg-item-type {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9.5px;
+  color: var(--t3);
+  background: var(--bg-4);
+  padding: 1px 5px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+.tg-item-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tg-item-remove {
+  background: none;
+  border: none;
+  color: var(--t3);
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 12px;
+  line-height: 1;
+  border-radius: 3px;
+  transition: color 0.12s;
+}
+.tg-item-remove:hover {
+  color: #f87171;
+}
+.tg-add-btn {
+  font-size: 11px;
+  color: var(--t3);
+  background: none;
+  border: 1px dashed var(--border);
+  border-radius: 5px;
+  padding: 5px 8px;
+  cursor: pointer;
+  transition: all 0.14s;
+  text-align: left;
+  width: 100%;
+  margin-top: 2px;
+}
+.tg-add-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.tg-inline-form {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 8px;
+  border-radius: 6px;
+  background: var(--bg-3);
+  border: 1px solid var(--border-hi);
+  margin-top: 2px;
+}
+.tg-inline-row {
+  display: flex;
+  gap: 5px;
+}
+.tg-select,
+.tg-input {
+  flex: 1;
+  background: var(--bg-2);
+  border: 1px solid var(--border-hi);
+  border-radius: 5px;
+  padding: 5px 8px;
+  font-size: 11px;
+  color: var(--t1);
+  outline: none;
+}
+.tg-select:focus,
+.tg-input:focus {
+  border-color: var(--accent);
+}
+.tg-form-btns {
+  display: flex;
+  gap: 5px;
+  justify-content: flex-end;
+}
+.tg-form-save {
+  padding: 4px 10px;
+  border-radius: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.12s;
+}
+.tg-form-save:hover {
+  opacity: 0.88;
+}
+.tg-form-cancel {
+  padding: 4px 10px;
+  border-radius: 5px;
+  font-size: 11px;
+  background: none;
+  color: var(--t3);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: all 0.12s;
+}
+.tg-form-cancel:hover {
+  color: var(--t1);
+  border-color: var(--border-hi);
+}
+/* Events tab */
+.td-event-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.td-event-item {
+  padding: 10px 12px;
+  border-radius: 7px;
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+}
+.td-event-name {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: "JetBrains Mono", monospace;
+  color: var(--accent);
+  margin-bottom: 3px;
+}
+.td-event-desc {
+  font-size: 11px;
+  color: var(--t2);
+  margin-bottom: 4px;
+}
+.td-event-time {
+  font-size: 9.5px;
+  color: var(--t3);
+  font-family: "JetBrains Mono", monospace;
+}
+.td-empty {
+  text-align: center;
+  color: var(--t3);
+  font-size: 12px;
+  padding: 24px 0;
+}
+
+/*
  * Tooltip enter animation. Used by the collapsed-mode workflow dots
  * (`SidebarWorkflowTree.CollapsedInstanceDot`) which render their
  * tooltip via a portal, so the keyframe lives in global CSS rather

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { ChevronsLeftRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -15,6 +15,7 @@ import type {
 } from "@/lib/workflows/types";
 
 import { TaskCard } from "./task-card";
+import { TaskDrawer } from "./task-drawer";
 
 /**
  * Read-only Process Matrix.
@@ -50,6 +51,13 @@ interface Props {
 
 export function ProcessMatrix({ instance, template }: Props) {
   const [collapsed, setCollapsed] = useState(false);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  // Local optimistic task list so approve/reject update the bar immediately.
+  const [localTasks, setLocalTasks] = useState<WorkflowTask[]>(instance.tasks);
+
+  const handleTaskUpdate = useCallback((updated: WorkflowTask) => {
+    setLocalTasks((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
+  }, []);
 
   // Derive stages, roles, and the (role, stage) -> task index up
   // front. The matrix re-renders on every collapse toggle, so we
@@ -62,21 +70,25 @@ export function ProcessMatrix({ instance, template }: Props) {
 
   const tasksByCell = useMemo(() => {
     const map = new Map<string, WorkflowTask>();
-    for (const task of instance.tasks) {
+    for (const task of localTasks) {
       map.set(`${task.roleId}::${task.stageId}`, task);
     }
     return map;
-  }, [instance.tasks]);
+  }, [localTasks]);
 
   const tasksByStage = useMemo(() => {
     const map = new Map<string, WorkflowTask[]>();
-    for (const task of instance.tasks) {
+    for (const task of localTasks) {
       const bucket = map.get(task.stageId) ?? [];
       bucket.push(task);
       map.set(task.stageId, bucket);
     }
     return map;
-  }, [instance.tasks]);
+  }, [localTasks]);
+
+  const selectedTask = selectedTaskId
+    ? (localTasks.find((t) => t.id === selectedTaskId) ?? null)
+    : null;
 
   // Empty state: a template with no stages OR no roles can't paint a
   // grid. Render the matrix shell + a friendly placeholder so QA can
@@ -84,13 +96,14 @@ export function ProcessMatrix({ instance, template }: Props) {
   const isEmpty = stages.length === 0 || roles.length === 0;
 
   return (
-    <div
-      data-testid="process-matrix"
-      data-collapsed={collapsed ? "true" : "false"}
-      className={cn(
-        "matrix-wrap",
-        collapsed && "roles-collapsed",
-      )}
+    <>
+      <div
+        data-testid="process-matrix"
+        data-collapsed={collapsed ? "true" : "false"}
+        className={cn(
+          "matrix-wrap",
+          collapsed && "roles-collapsed",
+        )}
     >
       <div
         className="matrix"
@@ -209,7 +222,8 @@ export function ProcessMatrix({ instance, template }: Props) {
                         <TaskCard
                           task={task}
                           roleColor={roleColor}
-                          barState={barClass(task, canStart(task, instance.tasks))}
+                          barState={barClass(task, canStart(task, localTasks))}
+                          onClick={() => setSelectedTaskId(task.id)}
                         />
                       ) : null}
                     </div>
@@ -221,5 +235,18 @@ export function ProcessMatrix({ instance, template }: Props) {
         )}
       </div>
     </div>
+
+    {selectedTask && (
+      <TaskDrawer
+        task={selectedTask}
+        instance={instance}
+        roles={roles}
+        template={template}
+        onClose={() => setSelectedTaskId(null)}
+        onTaskUpdate={handleTaskUpdate}
+      />
+    )}
+  </>
   );
 }
+

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -236,16 +236,14 @@ export function ProcessMatrix({ instance, template }: Props) {
       </div>
     </div>
 
-    {selectedTask && (
-      <TaskDrawer
-        task={selectedTask}
-        instance={instance}
-        roles={roles}
-        template={template}
-        onClose={() => setSelectedTaskId(null)}
-        onTaskUpdate={handleTaskUpdate}
-      />
-    )}
+    <TaskDrawer
+      task={selectedTask}
+      instance={instance}
+      roles={roles}
+      template={template}
+      onClose={() => setSelectedTaskId(null)}
+      onTaskUpdate={handleTaskUpdate}
+    />
   </>
   );
 }

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronsLeftRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -53,7 +53,9 @@ export function ProcessMatrix({ instance, template }: Props) {
   const [collapsed, setCollapsed] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   // Local optimistic task list so approve/reject update the bar immediately.
+  // Sync from server when instance.tasks changes (e.g. after revalidatePath).
   const [localTasks, setLocalTasks] = useState<WorkflowTask[]>(instance.tasks);
+  useEffect(() => { setLocalTasks(instance.tasks); }, [instance.tasks]);
 
   const handleTaskUpdate = useCallback((updated: WorkflowTask) => {
     setLocalTasks((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -50,9 +50,11 @@ export interface TaskCardProps {
   roleColor: string;
   /** Bar-state class chosen by `barClass()`. */
   barState: TaskBarState;
+  /** Opens the Task Drawer for this card. */
+  onClick?: () => void;
 }
 
-export function TaskCard({ task, roleColor, barState }: TaskCardProps) {
+export function TaskCard({ task, roleColor, barState, onClick }: TaskCardProps) {
   const statusClass = STATUS_PILL_CLASS[task.status];
   const statusLabel = STATUS_LABEL[task.status];
 
@@ -61,8 +63,13 @@ export function TaskCard({ task, roleColor, barState }: TaskCardProps) {
       data-testid={`task-card-${task.id}`}
       data-bar={barState}
       data-status={task.status}
-      className={cn("task-card", statusClass, barState)}
+      className={cn("task-card", statusClass, barState, onClick && "cursor-pointer")}
       style={{ "--role-color": roleColor } as React.CSSProperties}
+      onClick={onClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={onClick ? (e) => { if (e.key === "Enter" || e.key === " ") onClick(); } : undefined}
+      aria-label={onClick ? `Open task: ${task.title}` : undefined}
     >
       <div className="tc-top">
         <div className="tc-title">{task.title}</div>

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -68,7 +68,16 @@ export function TaskCard({ task, roleColor, barState, onClick }: TaskCardProps) 
       onClick={onClick}
       role={onClick ? "button" : undefined}
       tabIndex={onClick ? 0 : undefined}
-      onKeyDown={onClick ? (e) => { if (e.key === "Enter" || e.key === " ") onClick(); } : undefined}
+      onKeyDown={
+        onClick
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
       aria-label={onClick ? `Open task: ${task.title}` : undefined}
     >
       <div className="tc-top">

--- a/products/dashboard/components/workflows/task-drawer.tsx
+++ b/products/dashboard/components/workflows/task-drawer.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useEffect, useState, useTransition } from "react";
-import { AlertTriangle, BookOpen, Bot, X, Zap } from "lucide-react";
+import { BookOpen, X } from "lucide-react";
 
 import { captureError } from "@/lib/monitoring";
 import { emitEvent } from "@/lib/events";
 import { cn } from "@/lib/utils";
+import { getRoleColor } from "@/lib/workflows/role-colors";
 import type {
   WorkflowEvent,
   WorkflowGate,
@@ -21,6 +22,23 @@ import {
   updateTaskTriggerGatesAction,
 } from "@/app/(dashboard)/workflows/actions";
 
+// Emoji icons keyed by skill name — mirrors SKILL_ICONS in pc-components.jsx.
+const SKILL_ICONS: Record<string, string> = {
+  pm: "📋",
+  builder: "⚡",
+  devops: "🔧",
+  "finance-ops": "💰",
+  "sales-ops": "🤝",
+  designer: "🎨",
+  researcher: "🔍",
+  strategist: "🧭",
+  growth: "📈",
+  qa: "✅",
+  project: "🗂️",
+  support: "🎧",
+  "spec.review": "📋",
+};
+
 // ── TriggerGateEditor ─────────────────────────────────────────────────────────
 
 const TRIGGER_TYPES = ["manual", "event", "task_complete", "schedule", "webhook"];
@@ -35,33 +53,25 @@ interface TriggerGateEditorProps {
 
 function TriggerGateEditor({ items, kind, disabled, onChange }: TriggerGateEditorProps) {
   const [isAdding, setIsAdding] = useState(false);
-  const [pendingType, setPendingType] = useState(kind === "trigger" ? TRIGGER_TYPES[0]! : GATE_TYPES[0]!);
-  const [pendingLabel, setPendingLabel] = useState("");
-
   const types = kind === "trigger" ? TRIGGER_TYPES : GATE_TYPES;
+  const [pendingType, setPendingType] = useState(types[0]!);
+  const [pendingLabel, setPendingLabel] = useState("");
 
   function handleAdd() {
     if (!pendingLabel.trim()) return;
-    const next = [
-      ...items,
-      { type: pendingType, label: pendingLabel.trim() },
-    ];
-    onChange(next);
+    onChange([...items, { type: pendingType, label: pendingLabel.trim() }]);
     setPendingLabel("");
     setPendingType(types[0]!);
     setIsAdding(false);
   }
 
   function handleRemove(index: number) {
-    const next = items.filter((_, i) => i !== index);
-    onChange(next);
+    onChange(items.filter((_, i) => i !== index));
   }
 
   return (
-    <div className="td-section" data-testid={`tg-editor-${kind}`}>
-      <span className="td-section-label">
-        {kind === "trigger" ? "Triggers" : "Gates"}
-      </span>
+    <div className="td-sec" data-testid={`tg-editor-${kind}`}>
+      <div className="td-sec-lbl">{kind === "trigger" ? "Triggers" : "Gates"}</div>
       <div className="tg-list">
         {items.map((item, i) => (
           <div key={i} className="tg-item" data-testid={`tg-item-${kind}-${i}`}>
@@ -89,9 +99,7 @@ function TriggerGateEditor({ items, kind, disabled, onChange }: TriggerGateEdito
               onChange={(e) => setPendingType(e.target.value)}
             >
               {types.map((t) => (
-                <option key={t} value={t}>
-                  {t}
-                </option>
+                <option key={t} value={t}>{t}</option>
               ))}
             </select>
             <input
@@ -110,10 +118,7 @@ function TriggerGateEditor({ items, kind, disabled, onChange }: TriggerGateEdito
             <button
               type="button"
               className="tg-form-cancel"
-              onClick={() => {
-                setIsAdding(false);
-                setPendingLabel("");
-              }}
+              onClick={() => { setIsAdding(false); setPendingLabel(""); }}
             >
               Cancel
             </button>
@@ -142,91 +147,9 @@ function TriggerGateEditor({ items, kind, disabled, onChange }: TriggerGateEdito
   );
 }
 
-// ── Primary action card ───────────────────────────────────────────────────────
-
-interface PrimaryActionProps {
-  task: WorkflowTask;
-  isPending: boolean;
-  onApprove: () => void;
-  onReject: () => void;
-}
-
-function PrimaryActionCard({ task, isPending, onApprove, onReject }: PrimaryActionProps) {
-  if (task.status === "pending_approval") {
-    return (
-      <div className="td-action-card" data-testid="td-action-card">
-        <div className="td-action-btns">
-          <button
-            type="button"
-            className="td-btn td-btn-approve"
-            disabled={isPending}
-            onClick={onApprove}
-            data-testid="td-approve-btn"
-          >
-            ✓ Approve &amp; continue
-          </button>
-          <button
-            type="button"
-            className="td-btn td-btn-reject"
-            disabled={isPending}
-            onClick={onReject}
-            data-testid="td-reject-btn"
-          >
-            Reject
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  if (task.status === "not_started") {
-    return (
-      <div className="td-action-card" data-testid="td-action-card">
-        <div className="td-action-btns">
-          <button
-            type="button"
-            className="td-btn td-btn-primary"
-            disabled={isPending}
-            data-testid="td-start-btn"
-          >
-            ▶ Start agent
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  if (task.status === "active") {
-    return (
-      <div className="td-action-card" data-testid="td-action-card">
-        <div className="td-action-btns">
-          <button
-            type="button"
-            className="td-btn td-btn-outline"
-            disabled={isPending}
-            data-testid="td-view-run-btn"
-          >
-            View live run
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  return null;
-}
-
 // ── Details tab ───────────────────────────────────────────────────────────────
 
-const STATUS_BORDER: Record<WorkflowTask["status"], string> = {
-  complete: "#10b981",
-  active: "#6366f1",
-  pending_approval: "#f59e0b",
-  blocked: "#ef4444",
-  not_started: "var(--border)",
-};
-
-const STATUS_LABEL: Record<WorkflowTask["status"], string> = {
+const STATUS_LABELS: Record<WorkflowTask["status"], string> = {
   complete: "Complete",
   active: "Active",
   pending_approval: "Pending approval",
@@ -234,8 +157,17 @@ const STATUS_LABEL: Record<WorkflowTask["status"], string> = {
   not_started: "Not started",
 };
 
+const STATUS_PILL_CLASS: Record<WorkflowTask["status"], string> = {
+  complete: "s-complete",
+  active: "s-active",
+  pending_approval: "s-pending",
+  blocked: "s-blocked",
+  not_started: "s-not_started",
+};
+
 interface DetailsTabProps {
   task: WorkflowTask;
+  roles: WorkflowRole[];
   isPending: boolean;
   onApprove: () => void;
   onReject: () => void;
@@ -245,73 +177,133 @@ interface DetailsTabProps {
 
 function DetailsTab({
   task,
+  roles,
   isPending,
   onApprove,
   onReject,
   onTriggersChange,
   onGatesChange,
 }: DetailsTabProps) {
-  const statusColor = STATUS_BORDER[task.status];
+  const isPendingApproval = task.status === "pending_approval";
+  const isActive = task.status === "active";
+  const isNotStarted = task.status === "not_started";
+  const roleColor = getRoleColor(task.roleId, roles);
+  const skillIcon = task.skill ? (SKILL_ICONS[task.skill] ?? "🤖") : "🤖";
 
   return (
     <>
-      {/* Primary action */}
-      <PrimaryActionCard
-        task={task}
-        isPending={isPending}
-        onApprove={onApprove}
-        onReject={onReject}
-      />
+      {/* PRIMARY ACTION at top — mirrors prototype `.dr-action-top` */}
+      {(isPendingApproval || isActive || isNotStarted) && (
+        <div className="td-action-top" data-testid="td-action-card">
+          {isPendingApproval && (
+            <>
+              <button
+                type="button"
+                className="td-btn td-btn-approve"
+                disabled={isPending}
+                onClick={onApprove}
+                data-testid="td-approve-btn"
+              >
+                ✓ Approve &amp; continue
+              </button>
+              <button
+                type="button"
+                className="td-btn td-btn-ghost"
+                disabled={isPending}
+                onClick={onReject}
+                data-testid="td-reject-btn"
+              >
+                Reject
+              </button>
+            </>
+          )}
+          {isActive && (
+            <button
+              type="button"
+              className="td-btn td-btn-run"
+              disabled={isPending}
+              data-testid="td-view-run-btn"
+            >
+              View live run
+            </button>
+          )}
+          {isNotStarted && (
+            <button
+              type="button"
+              className="td-btn td-btn-primary"
+              disabled={isPending}
+              data-testid="td-start-btn"
+            >
+              ▶ Start agent
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Status */}
-      <div className="td-section">
-        <span className="td-section-label">Status</span>
+      <div className="td-sec">
+        <div className="td-sec-lbl">Status</div>
         <div
-          className="td-status-card"
-          style={{ borderLeftColor: statusColor }}
+          style={{
+            padding: "9px 12px",
+            borderRadius: 7,
+            background: "var(--bg-3)",
+            border: "1px solid var(--border)",
+            borderLeft: `2px solid ${roleColor}`,
+            fontSize: "11.5px",
+            color: "var(--t2)",
+          }}
           data-testid="td-status-card"
         >
-          <div className={cn("s-pill", `s-${task.status}`)} style={{ alignSelf: "flex-start" }}>
+          <div
+            className={cn("s-pill", STATUS_PILL_CLASS[task.status])}
+            style={{ marginBottom: 4 }}
+          >
             <div className="s-dot" aria-hidden />
-            <div className="s-text">{STATUS_LABEL[task.status]}</div>
+            <div className="s-text">{STATUS_LABELS[task.status]}</div>
           </div>
-          {task.substatus && (
-            <div style={{ fontSize: 11, color: "var(--t3)" }}>{task.substatus}</div>
-          )}
+          {task.substatus && <div>{task.substatus}</div>}
         </div>
       </div>
 
-      {/* Checkpoint */}
-      {task.checkpoint && task.status === "pending_approval" && (
-        <div className="td-checkpoint-card" data-testid="td-checkpoint-card">
-          <AlertTriangle size={13} aria-hidden />
-          Requesting approval to proceed.
+      {/* Checkpoint notice */}
+      {task.checkpoint && isPendingApproval && (
+        <div className="td-sec">
+          <div className="td-sec-lbl">Checkpoint</div>
+          <div className="td-checkpoint-notice" data-testid="td-checkpoint-card">
+            Requesting approval to proceed.
+          </div>
         </div>
       )}
 
       {/* Skills */}
-      {(task.agent || task.skill) && (
-        <div className="td-section">
-          <span className="td-section-label">Skills</span>
-          <div className="td-row">
-            <div className="td-row-icon">
-              <Bot size={12} aria-hidden />
-            </div>
-            {task.agent && (
-              <span className="td-row-name">{task.agent}</span>
-            )}
-            {task.skill && (
-              <span className="td-row-mono">{task.skill}</span>
-            )}
-            <div
-              className={cn(
-                "td-pulse-dot",
-                task.status === "active"
-                  ? "td-pulse-active"
-                  : task.status === "pending_approval"
-                    ? "td-pulse-pending"
-                    : "td-pulse-idle",
+      {(task.agent ?? task.skill) && (
+        <div className="td-sec">
+          <div className="td-sec-lbl">Skills</div>
+          <div className="td-agent">
+            <div className="td-agent-icon">{skillIcon}</div>
+            <div className="td-agent-info">
+              <div className="td-agent-name">
+                {task.agent ? `${task.agent} Agent` : "Agent"}
+              </div>
+              {task.skill && (
+                <div className="td-agent-skill">{task.skill}</div>
               )}
+            </div>
+            <div
+              className="td-agent-pulse"
+              style={{
+                background: isActive
+                  ? "#10b981"
+                  : isPendingApproval
+                    ? "#f59e0b"
+                    : "var(--border)",
+                boxShadow: isActive
+                  ? "0 0 6px rgba(16,185,129,0.5)"
+                  : isPendingApproval
+                    ? "0 0 6px rgba(245,158,11,0.4)"
+                    : "none",
+              }}
               aria-hidden
             />
           </div>
@@ -320,15 +312,13 @@ function DetailsTab({
 
       {/* Playbook */}
       {task.playbook && (
-        <div className="td-section">
-          <span className="td-section-label">Playbook</span>
-          <div className="td-row">
-            <div className="td-row-icon">
-              <BookOpen size={12} aria-hidden />
+        <div className="td-sec">
+          <div className="td-sec-lbl">Playbook</div>
+          <div className="td-playbook">
+            <div className="td-pb-icon">
+              <BookOpen size={15} aria-hidden />
             </div>
-            <span className="td-row-mono" style={{ color: "var(--accent)" }}>
-              {task.playbook}
-            </span>
+            <div className="td-pb-name">{task.playbook}</div>
           </div>
         </div>
       )}
@@ -354,32 +344,34 @@ function DetailsTab({
 
 // ── Events tab ────────────────────────────────────────────────────────────────
 
-interface EventsTabProps {
-  events: WorkflowEvent[];
-}
-
-function EventsTab({ events }: EventsTabProps) {
+function EventsTab({ events }: { events: WorkflowEvent[] }) {
   if (events.length === 0) {
     return (
       <div className="td-empty" data-testid="td-events-empty">
-        No events recorded for this task yet.
+        No events yet.
       </div>
     );
   }
 
   return (
-    <div className="td-event-list" data-testid="td-event-list">
-      {events.map((ev) => (
-        <div key={ev.id} className="td-event-item" data-testid={`td-event-${ev.id}`}>
-          <div className="td-event-name">{ev.name}</div>
-          {ev.description && (
-            <div className="td-event-desc">{ev.description}</div>
-          )}
-          <div className="td-event-time">
-            {new Date(ev.createdAt).toLocaleString()}
+    <div className="td-sec" style={{ marginTop: 4 }}>
+      <div className="td-sec-lbl">Event log</div>
+      <div className="td-event-list" data-testid="td-event-list">
+        {events.map((ev) => (
+          <div key={ev.id} className="td-event-item" data-testid={`td-event-${ev.id}`}>
+            <div className="td-event-dot" aria-hidden />
+            <div>
+              <div className="td-event-name">{ev.name}</div>
+              {ev.description && (
+                <div className="td-event-desc">{ev.description}</div>
+              )}
+              <div className="td-event-time">
+                {new Date(ev.createdAt).toLocaleString()}
+              </div>
+            </div>
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 }
@@ -388,18 +380,22 @@ function EventsTab({ events }: EventsTabProps) {
 
 function DependenciesTab() {
   return (
-    <div className="td-empty" data-testid="td-dependencies-placeholder">
-      DepTree coming in PR 10
+    <div className="td-sec" style={{ marginTop: 4 }}>
+      <div className="td-sec-lbl">Flow</div>
+      <div className="td-empty" data-testid="td-dependencies-placeholder">
+        DepTree coming in PR 10
+      </div>
     </div>
   );
 }
 
 // ── Main TaskDrawer ───────────────────────────────────────────────────────────
 
-type DrawerTab = "details" | "events" | "dependencies";
+type DrawerTab = "details" | "deps" | "events";
 
 export interface TaskDrawerProps {
-  task: WorkflowTask;
+  /** null → closed (drawer stays in DOM for CSS slide-out animation). */
+  task: WorkflowTask | null;
   instance: WorkflowInstanceDetail;
   roles: WorkflowRole[];
   template: WorkflowTemplate | null;
@@ -417,27 +413,30 @@ export function TaskDrawer({
 }: TaskDrawerProps) {
   const [activeTab, setActiveTab] = useState<DrawerTab>("details");
   const [isPending, startTransition] = useTransition();
+  const open = !!task;
 
-  const roleLabel = roles.find((r) => r.id === task.roleId)?.label ?? task.roleId;
-  const stageLabel =
-    template?.stages.find((s) => s.id === task.stageId)?.label ?? task.stageId;
-  const taskEvents = instance.events.filter((e) => e.taskId === task.id);
+  // Reset to details tab whenever a different task is selected.
+  useEffect(() => { setActiveTab("details"); }, [task?.id]);
 
-  // Analytics event on open
+  // Analytics event on open.
   useEffect(() => {
-    emitEvent("dashboard.task_drawer_opened", { task_id: task.id });
-  }, [task.id]);
+    if (task) {
+      emitEvent("dashboard.task_drawer_opened", { task_id: task.id });
+    }
+  }, [task?.id]);
 
-  // Close on Escape
+  // Close on Escape.
   useEffect(() => {
+    if (!open) return;
     function handleKey(e: KeyboardEvent) {
       if (e.key === "Escape") onClose();
     }
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [onClose]);
+  }, [open, onClose]);
 
   function handleApprove() {
+    if (!task) return;
     startTransition(async () => {
       try {
         const { task: updated } = await approveDrawerCheckpointAction(task.id);
@@ -447,15 +446,13 @@ export function TaskDrawer({
           instance_id: task.instanceId,
         });
       } catch (err) {
-        captureError(err, {
-          feature: "workflows.drawer_approve",
-          extra: { task_id: task.id },
-        });
+        captureError(err, { feature: "workflows.drawer_approve", extra: { task_id: task.id } });
       }
     });
   }
 
   function handleReject() {
+    if (!task) return;
     startTransition(async () => {
       try {
         await rejectDrawerCheckpointAction(task.id);
@@ -464,53 +461,54 @@ export function TaskDrawer({
           instance_id: task.instanceId,
         });
       } catch (err) {
-        captureError(err, {
-          feature: "workflows.drawer_reject",
-          extra: { task_id: task.id },
-        });
+        captureError(err, { feature: "workflows.drawer_reject", extra: { task_id: task.id } });
       }
     });
   }
 
   function handleTriggersChange(triggers: WorkflowTrigger[]) {
+    if (!task) return;
     startTransition(async () => {
       try {
-        const { task: updated } = await updateTaskTriggerGatesAction(
-          task.id,
-          triggers,
-          task.gates,
-        );
+        const { task: updated } = await updateTaskTriggerGatesAction(task.id, triggers, task.gates);
         onTaskUpdate(updated);
       } catch (err) {
-        captureError(err, {
-          feature: "workflows.trigger_gate_update",
-          extra: { task_id: task.id },
-        });
+        captureError(err, { feature: "workflows.trigger_gate_update", extra: { task_id: task.id } });
       }
     });
   }
 
   function handleGatesChange(gates: WorkflowGate[]) {
+    if (!task) return;
     startTransition(async () => {
       try {
-        const { task: updated } = await updateTaskTriggerGatesAction(
-          task.id,
-          task.triggers,
-          gates,
-        );
+        const { task: updated } = await updateTaskTriggerGatesAction(task.id, task.triggers, gates);
         onTaskUpdate(updated);
       } catch (err) {
-        captureError(err, {
-          feature: "workflows.trigger_gate_update",
-          extra: { task_id: task.id },
-        });
+        captureError(err, { feature: "workflows.trigger_gate_update", extra: { task_id: task.id } });
       }
     });
   }
 
+  const roleLabel = task ? (roles.find((r) => r.id === task.roleId)?.label ?? task.roleId) : "";
+  const stageLabel = task
+    ? (template?.stages.find((s) => s.id === task.stageId)?.label ?? task.stageId)
+    : "";
+  const taskEvents = task ? instance.events.filter((e) => e.taskId === task.id) : [];
+
+  // Closed state: render empty shell so the slide-out CSS transition works.
+  if (!task) {
+    return (
+      <>
+        <div className="task-drawer-overlay" aria-hidden style={{ display: "none" }} />
+        <div className="task-drawer" data-testid="task-drawer" aria-hidden />
+      </>
+    );
+  }
+
   return (
     <>
-      {/* Overlay — closes drawer on click */}
+      {/* Overlay — closes drawer on click outside */}
       <div
         className="task-drawer-overlay"
         aria-hidden
@@ -518,23 +516,16 @@ export function TaskDrawer({
         onClick={onClose}
       />
 
-      {/* Drawer panel */}
+      {/* Drawer panel — `open` class triggers CSS slide-in */}
       <div
         role="dialog"
         aria-modal="true"
         aria-label={`Task: ${task.title}`}
-        className="task-drawer"
+        className={cn("task-drawer", open && "open")}
         data-testid="task-drawer"
       >
-        {/* Header */}
+        {/* Header: title row → breadcrumb → tabs (prototype order) */}
         <header className="td-header">
-          <div className="td-breadcrumb">
-            <span>{instance.label}</span>
-            <span aria-hidden>›</span>
-            <span>{stageLabel}</span>
-            <span aria-hidden>›</span>
-            <span>{roleLabel}</span>
-          </div>
           <div className="td-header-top">
             <h2 className="td-title">{task.title}</h2>
             <button
@@ -548,21 +539,29 @@ export function TaskDrawer({
             </button>
           </div>
 
-          {/* Tab bar */}
+          <div className="td-breadcrumb">
+            <span className="td-crumb">{instance.label}</span>
+            <span className="td-crumb-sep" aria-hidden>›</span>
+            <span className="td-crumb">{stageLabel}</span>
+            <span className="td-crumb-sep" aria-hidden>›</span>
+            <span className="td-crumb">{roleLabel}</span>
+          </div>
+
           <div className="td-tabs" role="tablist" aria-label="Task sections">
-            {(["details", "dependencies", "events"] as const).map((tab) => (
+            {(["details", "deps", "events"] as const).map((tab) => (
               <button
                 key={tab}
                 role="tab"
                 aria-selected={activeTab === tab}
                 className={cn("td-tab", activeTab === tab && "td-tab-active")}
                 onClick={() => setActiveTab(tab)}
-                data-testid={`td-tab-${tab}`}
+                data-testid={`td-tab-${tab === "deps" ? "dependencies" : tab}`}
               >
-                {tab.charAt(0).toUpperCase() + tab.slice(1)}
-                {tab === "events" && taskEvents.length > 0
-                  ? ` (${taskEvents.length})`
-                  : ""}
+                {tab === "details"
+                  ? "Details"
+                  : tab === "deps"
+                    ? "Dependencies"
+                    : `Events${taskEvents.length > 0 ? ` (${taskEvents.length})` : ""}`}
               </button>
             ))}
           </div>
@@ -573,6 +572,7 @@ export function TaskDrawer({
           {activeTab === "details" && (
             <DetailsTab
               task={task}
+              roles={roles}
               isPending={isPending}
               onApprove={handleApprove}
               onReject={handleReject}
@@ -581,7 +581,7 @@ export function TaskDrawer({
             />
           )}
           {activeTab === "events" && <EventsTab events={taskEvents} />}
-          {activeTab === "dependencies" && <DependenciesTab />}
+          {activeTab === "deps" && <DependenciesTab />}
         </div>
       </div>
     </>

--- a/products/dashboard/components/workflows/task-drawer.tsx
+++ b/products/dashboard/components/workflows/task-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { BookOpen, X } from "lucide-react";
 
 import { captureError } from "@/lib/monitoring";
@@ -221,7 +221,8 @@ function DetailsTab({
             <button
               type="button"
               className="td-btn td-btn-run"
-              disabled={isPending}
+              disabled
+              title="Live run view coming in PR 10"
               data-testid="td-view-run-btn"
             >
               View live run
@@ -231,7 +232,8 @@ function DetailsTab({
             <button
               type="button"
               className="td-btn td-btn-primary"
-              disabled={isPending}
+              disabled
+              title="Manual start coming in PR 10"
               data-testid="td-start-btn"
             >
               ▶ Start agent
@@ -413,10 +415,19 @@ export function TaskDrawer({
 }: TaskDrawerProps) {
   const [activeTab, setActiveTab] = useState<DrawerTab>("details");
   const [isPending, startTransition] = useTransition();
+  const closeRef = useRef<HTMLButtonElement>(null);
   const open = !!task;
 
   // Reset to details tab whenever a different task is selected.
   useEffect(() => { setActiveTab("details"); }, [task?.id]);
+
+  // Move focus into the drawer when it opens so the dialog is usable by
+  // keyboard and screen-reader users without tabbing behind the overlay.
+  useEffect(() => {
+    if (open) {
+      closeRef.current?.focus();
+    }
+  }, [open]);
 
   // Analytics event on open.
   useEffect(() => {
@@ -529,6 +540,7 @@ export function TaskDrawer({
           <div className="td-header-top">
             <h2 className="td-title">{task.title}</h2>
             <button
+              ref={closeRef}
               type="button"
               className="td-close"
               aria-label="Close task drawer"

--- a/products/dashboard/components/workflows/task-drawer.tsx
+++ b/products/dashboard/components/workflows/task-drawer.tsx
@@ -1,0 +1,589 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { AlertTriangle, BookOpen, Bot, X, Zap } from "lucide-react";
+
+import { captureError } from "@/lib/monitoring";
+import { emitEvent } from "@/lib/events";
+import { cn } from "@/lib/utils";
+import type {
+  WorkflowEvent,
+  WorkflowGate,
+  WorkflowInstanceDetail,
+  WorkflowRole,
+  WorkflowTask,
+  WorkflowTemplate,
+  WorkflowTrigger,
+} from "@/lib/workflows/types";
+import {
+  approveDrawerCheckpointAction,
+  rejectDrawerCheckpointAction,
+  updateTaskTriggerGatesAction,
+} from "@/app/(dashboard)/workflows/actions";
+
+// ── TriggerGateEditor ─────────────────────────────────────────────────────────
+
+const TRIGGER_TYPES = ["manual", "event", "task_complete", "schedule", "webhook"];
+const GATE_TYPES = ["approval", "condition", "external", "timer"];
+
+interface TriggerGateEditorProps {
+  items: WorkflowTrigger[] | WorkflowGate[];
+  kind: "trigger" | "gate";
+  disabled?: boolean;
+  onChange: (items: WorkflowTrigger[] | WorkflowGate[]) => void;
+}
+
+function TriggerGateEditor({ items, kind, disabled, onChange }: TriggerGateEditorProps) {
+  const [isAdding, setIsAdding] = useState(false);
+  const [pendingType, setPendingType] = useState(kind === "trigger" ? TRIGGER_TYPES[0]! : GATE_TYPES[0]!);
+  const [pendingLabel, setPendingLabel] = useState("");
+
+  const types = kind === "trigger" ? TRIGGER_TYPES : GATE_TYPES;
+
+  function handleAdd() {
+    if (!pendingLabel.trim()) return;
+    const next = [
+      ...items,
+      { type: pendingType, label: pendingLabel.trim() },
+    ];
+    onChange(next);
+    setPendingLabel("");
+    setPendingType(types[0]!);
+    setIsAdding(false);
+  }
+
+  function handleRemove(index: number) {
+    const next = items.filter((_, i) => i !== index);
+    onChange(next);
+  }
+
+  return (
+    <div className="td-section" data-testid={`tg-editor-${kind}`}>
+      <span className="td-section-label">
+        {kind === "trigger" ? "Triggers" : "Gates"}
+      </span>
+      <div className="tg-list">
+        {items.map((item, i) => (
+          <div key={i} className="tg-item" data-testid={`tg-item-${kind}-${i}`}>
+            <span className="tg-item-type">{item.type}</span>
+            <span className="tg-item-label">{item.label ?? item.type}</span>
+            <button
+              type="button"
+              className="tg-item-remove"
+              aria-label={`Remove ${kind}`}
+              disabled={disabled}
+              onClick={() => handleRemove(i)}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {isAdding ? (
+        <div className="tg-inline-form" data-testid={`tg-inline-form-${kind}`}>
+          <div className="tg-inline-row">
+            <select
+              className="tg-select"
+              value={pendingType}
+              onChange={(e) => setPendingType(e.target.value)}
+            >
+              {types.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+            <input
+              className="tg-input"
+              placeholder="Label"
+              value={pendingLabel}
+              autoFocus
+              onChange={(e) => setPendingLabel(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleAdd();
+                if (e.key === "Escape") setIsAdding(false);
+              }}
+            />
+          </div>
+          <div className="tg-form-btns">
+            <button
+              type="button"
+              className="tg-form-cancel"
+              onClick={() => {
+                setIsAdding(false);
+                setPendingLabel("");
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="tg-form-save"
+              disabled={!pendingLabel.trim()}
+              onClick={handleAdd}
+            >
+              Add
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="tg-add-btn"
+          disabled={disabled}
+          onClick={() => setIsAdding(true)}
+          data-testid={`tg-add-${kind}`}
+        >
+          + Add {kind}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Primary action card ───────────────────────────────────────────────────────
+
+interface PrimaryActionProps {
+  task: WorkflowTask;
+  isPending: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+}
+
+function PrimaryActionCard({ task, isPending, onApprove, onReject }: PrimaryActionProps) {
+  if (task.status === "pending_approval") {
+    return (
+      <div className="td-action-card" data-testid="td-action-card">
+        <div className="td-action-btns">
+          <button
+            type="button"
+            className="td-btn td-btn-approve"
+            disabled={isPending}
+            onClick={onApprove}
+            data-testid="td-approve-btn"
+          >
+            ✓ Approve &amp; continue
+          </button>
+          <button
+            type="button"
+            className="td-btn td-btn-reject"
+            disabled={isPending}
+            onClick={onReject}
+            data-testid="td-reject-btn"
+          >
+            Reject
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (task.status === "not_started") {
+    return (
+      <div className="td-action-card" data-testid="td-action-card">
+        <div className="td-action-btns">
+          <button
+            type="button"
+            className="td-btn td-btn-primary"
+            disabled={isPending}
+            data-testid="td-start-btn"
+          >
+            ▶ Start agent
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (task.status === "active") {
+    return (
+      <div className="td-action-card" data-testid="td-action-card">
+        <div className="td-action-btns">
+          <button
+            type="button"
+            className="td-btn td-btn-outline"
+            disabled={isPending}
+            data-testid="td-view-run-btn"
+          >
+            View live run
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+// ── Details tab ───────────────────────────────────────────────────────────────
+
+const STATUS_BORDER: Record<WorkflowTask["status"], string> = {
+  complete: "#10b981",
+  active: "#6366f1",
+  pending_approval: "#f59e0b",
+  blocked: "#ef4444",
+  not_started: "var(--border)",
+};
+
+const STATUS_LABEL: Record<WorkflowTask["status"], string> = {
+  complete: "Complete",
+  active: "Active",
+  pending_approval: "Pending approval",
+  blocked: "Blocked",
+  not_started: "Not started",
+};
+
+interface DetailsTabProps {
+  task: WorkflowTask;
+  isPending: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+  onTriggersChange: (triggers: WorkflowTrigger[]) => void;
+  onGatesChange: (gates: WorkflowGate[]) => void;
+}
+
+function DetailsTab({
+  task,
+  isPending,
+  onApprove,
+  onReject,
+  onTriggersChange,
+  onGatesChange,
+}: DetailsTabProps) {
+  const statusColor = STATUS_BORDER[task.status];
+
+  return (
+    <>
+      {/* Primary action */}
+      <PrimaryActionCard
+        task={task}
+        isPending={isPending}
+        onApprove={onApprove}
+        onReject={onReject}
+      />
+
+      {/* Status */}
+      <div className="td-section">
+        <span className="td-section-label">Status</span>
+        <div
+          className="td-status-card"
+          style={{ borderLeftColor: statusColor }}
+          data-testid="td-status-card"
+        >
+          <div className={cn("s-pill", `s-${task.status}`)} style={{ alignSelf: "flex-start" }}>
+            <div className="s-dot" aria-hidden />
+            <div className="s-text">{STATUS_LABEL[task.status]}</div>
+          </div>
+          {task.substatus && (
+            <div style={{ fontSize: 11, color: "var(--t3)" }}>{task.substatus}</div>
+          )}
+        </div>
+      </div>
+
+      {/* Checkpoint */}
+      {task.checkpoint && task.status === "pending_approval" && (
+        <div className="td-checkpoint-card" data-testid="td-checkpoint-card">
+          <AlertTriangle size={13} aria-hidden />
+          Requesting approval to proceed.
+        </div>
+      )}
+
+      {/* Skills */}
+      {(task.agent || task.skill) && (
+        <div className="td-section">
+          <span className="td-section-label">Skills</span>
+          <div className="td-row">
+            <div className="td-row-icon">
+              <Bot size={12} aria-hidden />
+            </div>
+            {task.agent && (
+              <span className="td-row-name">{task.agent}</span>
+            )}
+            {task.skill && (
+              <span className="td-row-mono">{task.skill}</span>
+            )}
+            <div
+              className={cn(
+                "td-pulse-dot",
+                task.status === "active"
+                  ? "td-pulse-active"
+                  : task.status === "pending_approval"
+                    ? "td-pulse-pending"
+                    : "td-pulse-idle",
+              )}
+              aria-hidden
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Playbook */}
+      {task.playbook && (
+        <div className="td-section">
+          <span className="td-section-label">Playbook</span>
+          <div className="td-row">
+            <div className="td-row-icon">
+              <BookOpen size={12} aria-hidden />
+            </div>
+            <span className="td-row-mono" style={{ color: "var(--accent)" }}>
+              {task.playbook}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Triggers */}
+      <TriggerGateEditor
+        items={task.triggers}
+        kind="trigger"
+        disabled={isPending}
+        onChange={(items) => onTriggersChange(items as WorkflowTrigger[])}
+      />
+
+      {/* Gates */}
+      <TriggerGateEditor
+        items={task.gates}
+        kind="gate"
+        disabled={isPending}
+        onChange={(items) => onGatesChange(items as WorkflowGate[])}
+      />
+    </>
+  );
+}
+
+// ── Events tab ────────────────────────────────────────────────────────────────
+
+interface EventsTabProps {
+  events: WorkflowEvent[];
+}
+
+function EventsTab({ events }: EventsTabProps) {
+  if (events.length === 0) {
+    return (
+      <div className="td-empty" data-testid="td-events-empty">
+        No events recorded for this task yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="td-event-list" data-testid="td-event-list">
+      {events.map((ev) => (
+        <div key={ev.id} className="td-event-item" data-testid={`td-event-${ev.id}`}>
+          <div className="td-event-name">{ev.name}</div>
+          {ev.description && (
+            <div className="td-event-desc">{ev.description}</div>
+          )}
+          <div className="td-event-time">
+            {new Date(ev.createdAt).toLocaleString()}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Dependencies tab ──────────────────────────────────────────────────────────
+
+function DependenciesTab() {
+  return (
+    <div className="td-empty" data-testid="td-dependencies-placeholder">
+      DepTree coming in PR 10
+    </div>
+  );
+}
+
+// ── Main TaskDrawer ───────────────────────────────────────────────────────────
+
+type DrawerTab = "details" | "events" | "dependencies";
+
+export interface TaskDrawerProps {
+  task: WorkflowTask;
+  instance: WorkflowInstanceDetail;
+  roles: WorkflowRole[];
+  template: WorkflowTemplate | null;
+  onClose: () => void;
+  onTaskUpdate: (task: WorkflowTask) => void;
+}
+
+export function TaskDrawer({
+  task,
+  instance,
+  roles,
+  template,
+  onClose,
+  onTaskUpdate,
+}: TaskDrawerProps) {
+  const [activeTab, setActiveTab] = useState<DrawerTab>("details");
+  const [isPending, startTransition] = useTransition();
+
+  const roleLabel = roles.find((r) => r.id === task.roleId)?.label ?? task.roleId;
+  const stageLabel =
+    template?.stages.find((s) => s.id === task.stageId)?.label ?? task.stageId;
+  const taskEvents = instance.events.filter((e) => e.taskId === task.id);
+
+  // Analytics event on open
+  useEffect(() => {
+    emitEvent("dashboard.task_drawer_opened", { task_id: task.id });
+  }, [task.id]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  function handleApprove() {
+    startTransition(async () => {
+      try {
+        const { task: updated } = await approveDrawerCheckpointAction(task.id);
+        onTaskUpdate(updated);
+        emitEvent("workflow.checkpoint_approved", {
+          task_id: task.id,
+          instance_id: task.instanceId,
+        });
+      } catch (err) {
+        captureError(err, {
+          feature: "workflows.drawer_approve",
+          extra: { task_id: task.id },
+        });
+      }
+    });
+  }
+
+  function handleReject() {
+    startTransition(async () => {
+      try {
+        await rejectDrawerCheckpointAction(task.id);
+        emitEvent("workflow.checkpoint_rejected", {
+          task_id: task.id,
+          instance_id: task.instanceId,
+        });
+      } catch (err) {
+        captureError(err, {
+          feature: "workflows.drawer_reject",
+          extra: { task_id: task.id },
+        });
+      }
+    });
+  }
+
+  function handleTriggersChange(triggers: WorkflowTrigger[]) {
+    startTransition(async () => {
+      try {
+        const { task: updated } = await updateTaskTriggerGatesAction(
+          task.id,
+          triggers,
+          task.gates,
+        );
+        onTaskUpdate(updated);
+      } catch (err) {
+        captureError(err, {
+          feature: "workflows.trigger_gate_update",
+          extra: { task_id: task.id },
+        });
+      }
+    });
+  }
+
+  function handleGatesChange(gates: WorkflowGate[]) {
+    startTransition(async () => {
+      try {
+        const { task: updated } = await updateTaskTriggerGatesAction(
+          task.id,
+          task.triggers,
+          gates,
+        );
+        onTaskUpdate(updated);
+      } catch (err) {
+        captureError(err, {
+          feature: "workflows.trigger_gate_update",
+          extra: { task_id: task.id },
+        });
+      }
+    });
+  }
+
+  return (
+    <>
+      {/* Overlay — closes drawer on click */}
+      <div
+        className="task-drawer-overlay"
+        aria-hidden
+        data-testid="task-drawer-overlay"
+        onClick={onClose}
+      />
+
+      {/* Drawer panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Task: ${task.title}`}
+        className="task-drawer"
+        data-testid="task-drawer"
+      >
+        {/* Header */}
+        <header className="td-header">
+          <div className="td-breadcrumb">
+            <span>{instance.label}</span>
+            <span aria-hidden>›</span>
+            <span>{stageLabel}</span>
+            <span aria-hidden>›</span>
+            <span>{roleLabel}</span>
+          </div>
+          <div className="td-header-top">
+            <h2 className="td-title">{task.title}</h2>
+            <button
+              type="button"
+              className="td-close"
+              aria-label="Close task drawer"
+              onClick={onClose}
+              data-testid="task-drawer-close"
+            >
+              <X size={13} aria-hidden />
+            </button>
+          </div>
+
+          {/* Tab bar */}
+          <div className="td-tabs" role="tablist" aria-label="Task sections">
+            {(["details", "dependencies", "events"] as const).map((tab) => (
+              <button
+                key={tab}
+                role="tab"
+                aria-selected={activeTab === tab}
+                className={cn("td-tab", activeTab === tab && "td-tab-active")}
+                onClick={() => setActiveTab(tab)}
+                data-testid={`td-tab-${tab}`}
+              >
+                {tab.charAt(0).toUpperCase() + tab.slice(1)}
+                {tab === "events" && taskEvents.length > 0
+                  ? ` (${taskEvents.length})`
+                  : ""}
+              </button>
+            ))}
+          </div>
+        </header>
+
+        {/* Body */}
+        <div className="td-body" role="tabpanel" data-testid="td-body">
+          {activeTab === "details" && (
+            <DetailsTab
+              task={task}
+              isPending={isPending}
+              onApprove={handleApprove}
+              onReject={handleReject}
+              onTriggersChange={handleTriggersChange}
+              onGatesChange={handleGatesChange}
+            />
+          )}
+          {activeTab === "events" && <EventsTab events={taskEvents} />}
+          {activeTab === "dependencies" && <DependenciesTab />}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/products/dashboard/e2e/workflows.spec.ts
+++ b/products/dashboard/e2e/workflows.spec.ts
@@ -137,3 +137,75 @@ test.describe("workflows — process matrix (read-only)", () => {
     await expect(matrix).toHaveAttribute("data-collapsed", "true");
   });
 });
+
+test.describe("workflows — task drawer (AEL-51)", () => {
+  test("clicking a task card opens the drawer and Escape closes it", async ({
+    page,
+  }) => {
+    test.skip(
+      !hasSupabaseRuntime,
+      "Supabase runtime credentials required for the drawer happy path",
+    );
+
+    await authenticateWithBypass(page);
+
+    // Create a fresh instance so the matrix has tasks.
+    const dialog = await openFirstTemplateNewInstanceDialog(page);
+    await dialog
+      .getByRole("textbox", { name: /instance name/i })
+      .fill(`E2E Drawer ${Date.now()}`);
+    await dialog.getByRole("button", { name: /^create\s*→?$/i }).click();
+    await expect(page).toHaveURL(/\/workflows\/[0-9a-f-]+$/);
+
+    // Click the first task card.
+    const firstCard = page.locator('[data-testid^="task-card-"]').first();
+    await expect(firstCard).toBeVisible();
+    await firstCard.click();
+
+    // Drawer should appear.
+    const drawer = page.getByTestId("task-drawer");
+    await expect(drawer).toBeVisible();
+    await expect(drawer).toHaveAttribute("role", "dialog");
+
+    // Breadcrumb and tabs visible.
+    await expect(page.getByTestId("td-tab-details")).toBeVisible();
+    await expect(page.getByTestId("td-tab-events")).toBeVisible();
+    await expect(page.getByTestId("td-tab-dependencies")).toBeVisible();
+
+    // Escape closes the drawer.
+    await page.keyboard.press("Escape");
+    await expect(drawer).toBeHidden();
+  });
+
+  test("events tab shows seed events scoped to the selected task", async ({
+    page,
+  }) => {
+    test.skip(
+      !hasSupabaseRuntime,
+      "Supabase runtime credentials required for the events tab happy path",
+    );
+
+    await authenticateWithBypass(page);
+
+    const dialog = await openFirstTemplateNewInstanceDialog(page);
+    await dialog
+      .getByRole("textbox", { name: /instance name/i })
+      .fill(`E2E Events Tab ${Date.now()}`);
+    await dialog.getByRole("button", { name: /^create\s*→?$/i }).click();
+    await expect(page).toHaveURL(/\/workflows\/[0-9a-f-]+$/);
+
+    const firstCard = page.locator('[data-testid^="task-card-"]').first();
+    await firstCard.click();
+
+    const drawer = page.getByTestId("task-drawer");
+    await expect(drawer).toBeVisible();
+
+    await page.getByTestId("td-tab-events").click();
+
+    // Either empty state or event list is shown — both are valid depending on
+    // whether the seed script wrote events for this task.
+    const eventList = page.getByTestId("td-event-list");
+    const emptyState = page.getByTestId("td-events-empty");
+    await expect(eventList.or(emptyState)).toBeVisible();
+  });
+});

--- a/products/dashboard/lib/events.ts
+++ b/products/dashboard/lib/events.ts
@@ -37,6 +37,9 @@ type EventMap = {
   "auth.requested_magic_link": { provider: "magic_link" };
   "user.signed_in": AuthProviderPayload;
   "user.signed_out": AuthProviderPayload;
+  "dashboard.task_drawer_opened": { task_id: string };
+  "workflow.checkpoint_approved": { task_id: string; instance_id: string };
+  "workflow.checkpoint_rejected": { task_id: string; instance_id: string };
 };
 
 type EventName = keyof EventMap;

--- a/spec/examples/dashboard-product.yaml
+++ b/spec/examples/dashboard-product.yaml
@@ -377,6 +377,27 @@ events:
             type: string
           instance_id:
             type: string
+    - name: "workflow.task_updated"
+      description: "Task triggers or gates were updated via the Task Drawer editor."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: recommended
+        ordering: at_least_once
+      emitted_by:
+        - "actions.updateTaskTriggerGatesAction"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - task_id
+          - instance_id
+        properties:
+          task_id:
+            type: string
+          instance_id:
+            type: string
 
 observability:
   logs:

--- a/spec/examples/dashboard-product.yaml
+++ b/spec/examples/dashboard-product.yaml
@@ -317,6 +317,66 @@ events:
             enum:
               - magic_link
               - google
+    - name: "dashboard.task_drawer_opened"
+      description: "User opened the Task Drawer by clicking a task card in the Process Matrix."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: none
+        ordering: at_least_once
+      emitted_by:
+        - "components.task-drawer"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - task_id
+        properties:
+          task_id:
+            type: string
+    - name: "workflow.checkpoint_approved"
+      description: "User approved a pending checkpoint task from the Task Drawer, allowing the agent to continue."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: recommended
+        ordering: at_least_once
+      emitted_by:
+        - "components.task-drawer"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - task_id
+          - instance_id
+        properties:
+          task_id:
+            type: string
+          instance_id:
+            type: string
+    - name: "workflow.checkpoint_rejected"
+      description: "User rejected a pending checkpoint task from the Task Drawer."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: recommended
+        ordering: at_least_once
+      emitted_by:
+        - "components.task-drawer"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - task_id
+          - instance_id
+        properties:
+          task_id:
+            type: string
+          instance_id:
+            type: string
 
 observability:
   logs:


### PR DESCRIPTION
## Summary

- **`task-drawer.tsx`** — 420px fixed-right slide-in panel: header with breadcrumb + tab bar (Details / Events / Dependencies), overlay + Escape to close
- **Details tab** — primary action card (Approve & continue → `active`, Reject → event only, Start agent, View live run) driven by task status; status card with left-border accent; checkpoint amber banner; skills/playbook sections; inline `TriggerGateEditor` for triggers and gates
- **`process-matrix.tsx`** — wires `onClick` on every `TaskCard` to open the drawer; maintains `localTasks` state for optimistic bar-state updates post-approve
- **`task-card.tsx`** — optional `onClick` + keyboard handler (Enter/Space)
- **`actions.ts`** — `approveDrawerCheckpointAction` (→ `active`), `rejectDrawerCheckpointAction`, `updateTaskTriggerGatesAction`
- **`lib/events.ts`** — adds `dashboard.task_drawer_opened`, `workflow.checkpoint_approved`, `workflow.checkpoint_rejected` to `EventMap`
- **Spec** — 3 new events added to `dashboard-product.yaml` catalog; `npm run validate` passes
- **Tests** — 17 new unit tests for all drawer behaviours; 2 new E2E scenarios in `workflows.spec.ts`

## Test plan

- [x] `npm run validate` — green (3 spec files validated)
- [x] `npm test` — 205/205 tests pass (25 test files)
- [x] Existing process-matrix and task-card tests unaffected (21 tests)
- [ ] E2E (requires Supabase runtime): click task card → drawer opens; Escape closes; events tab renders

Closes AEL-51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slide-in task detail drawer with tabs (Details, Events, Dependencies), keyboard/overlay close, and inline trigger/gate management.
  * In-drawer checkpoint controls (Approve/Reject) with immediate UI updates reflected in the workflow matrix.
  * Drawer emits analytics events for open and checkpoint outcomes.

* **Tests**
  * New unit and end-to-end tests covering drawer UI, checkpoint flows, trigger edits, events tab, and close interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->