### PR TITLE
feat(dashboard): workflow run controls, sidebar collapse, Failed label

### DIFF
--- a/products/dashboard/__tests__/api/events.test.ts
+++ b/products/dashboard/__tests__/api/events.test.ts
@@ -61,6 +61,19 @@ describe("POST /api/events — happy path", () => {
     expect(res.status).toBe(202);
   });
 
+  it("accepts workflow.task_started with task_id and instance_id and returns 202", async () => {
+    const res = await POST(
+      makeReq({
+        event_name: "workflow.task_started",
+        occurred_at: new Date().toISOString(),
+        emitted_by: "client",
+        schema_version: "1.0.0",
+        payload: { task_id: "t-1", instance_id: "i-1" },
+      }),
+    );
+    expect(res.status).toBe(202);
+  });
+
   it("rejects user.signed_in with an unsupported provider", async () => {
     const res = await POST(
       makeReq(validUserSignedIn({ payload: { provider: "twitter" } })),

--- a/products/dashboard/__tests__/app/workflows/actions.test.ts
+++ b/products/dashboard/__tests__/app/workflows/actions.test.ts
@@ -52,7 +52,12 @@ vi.mock("@/lib/workflows/repository.server", () => ({
   getServerWorkflowRepository: mockGetRepo,
 }));
 
-import { resolveCheckpointAction } from "@/app/(dashboard)/workflows/actions";
+import {
+  createTaskAction,
+  deleteTaskAction,
+  moveTaskAction,
+  resolveCheckpointAction,
+} from "@/app/(dashboard)/workflows/actions";
 
 function makeTask(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
   return {
@@ -219,5 +224,107 @@ describe("resolveCheckpointAction precondition gate", () => {
     expect(mockCaptureError).toHaveBeenCalledTimes(1);
     expect(mockRevalidatePath).toHaveBeenCalledWith("/", "layout");
     expect(result.task.status).toBe("complete");
+  });
+});
+
+describe("workflow matrix edit actions", () => {
+  beforeEach(() => {
+    mockGetRepo.mockReset();
+    mockRevalidatePath.mockReset();
+    mockCaptureError.mockReset();
+  });
+
+  it("createTaskAction creates a task and records an event", async () => {
+    const created = makeTask({ id: "task-created", status: "not_started" });
+    const createTask = vi.fn().mockResolvedValue(created);
+    const addEvent = vi.fn().mockResolvedValue({
+      id: "event-2",
+      instanceId: created.instanceId,
+      taskId: created.id,
+      name: "workflow.task_created",
+      description: "",
+      payload: {},
+      createdAt: "2026-04-19T12:00:00Z",
+    });
+
+    mockGetRepo.mockResolvedValue({
+      createTask,
+      addEvent,
+    } satisfies Partial<WorkflowRepository>);
+
+    const result = await createTaskAction({
+      instanceId: created.instanceId,
+      roleId: created.roleId,
+      stageId: created.stageId,
+      title: created.title,
+      description: created.description,
+      skill: "pm",
+      agent: "PM",
+      playbook: "slice-spec",
+    });
+
+    expect(createTask).toHaveBeenCalled();
+    expect(addEvent.mock.calls[0]?.[1].name).toBe("workflow.task_created");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/", "layout");
+    expect(result.task.id).toBe("task-created");
+  });
+
+  it("moveTaskAction updates the task position and records an event", async () => {
+    const current = makeTask({ id: "task-move", roleId: "sales", stageId: "pre-sales" });
+    const moved = makeTask({ id: "task-move", roleId: "product", stageId: "stage-2" });
+    const getTask = vi.fn().mockResolvedValue(current);
+    const updateTask = vi.fn().mockResolvedValue(moved);
+    const addEvent = vi.fn().mockResolvedValue({
+      id: "event-3",
+      instanceId: moved.instanceId,
+      taskId: moved.id,
+      name: "workflow.task_moved",
+      description: "",
+      payload: {},
+      createdAt: "2026-04-19T12:00:00Z",
+    });
+
+    mockGetRepo.mockResolvedValue({
+      getTask,
+      updateTask,
+      addEvent,
+    } satisfies Partial<WorkflowRepository>);
+
+    const result = await moveTaskAction("task-move", "product", "stage-2");
+
+    expect(updateTask).toHaveBeenCalledWith("task-move", {
+      roleId: "product",
+      stageId: "stage-2",
+    });
+    expect(addEvent.mock.calls[0]?.[1].name).toBe("workflow.task_moved");
+    expect(result.task.roleId).toBe("product");
+  });
+
+  it("deleteTaskAction deletes the task and records an instance event", async () => {
+    const existing = makeTask({ id: "task-delete" });
+    const getTask = vi.fn().mockResolvedValue(existing);
+    const deleteTask = vi.fn().mockResolvedValue(undefined);
+    const addInstanceEvent = vi.fn().mockResolvedValue({
+      id: "event-4",
+      instanceId: existing.instanceId,
+      taskId: null,
+      name: "workflow.task_deleted",
+      description: "",
+      payload: {},
+      createdAt: "2026-04-19T12:00:00Z",
+    });
+
+    mockGetRepo.mockResolvedValue({
+      getTask,
+      deleteTask,
+      addInstanceEvent,
+    } satisfies Partial<WorkflowRepository>);
+
+    await deleteTaskAction("task-delete");
+
+    expect(deleteTask).toHaveBeenCalledWith("task-delete");
+    expect(addInstanceEvent.mock.calls[0]?.[0]).toBe(existing.instanceId);
+    expect(addInstanceEvent.mock.calls[0]?.[1].name).toBe("workflow.task_deleted");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/", "layout");
   });
 });

--- a/products/dashboard/__tests__/app/workflows/actions.test.ts
+++ b/products/dashboard/__tests__/app/workflows/actions.test.ts
@@ -53,10 +53,13 @@ vi.mock("@/lib/workflows/repository.server", () => ({
 }));
 
 import {
+  cancelRunningTaskAction,
   createTaskAction,
   deleteTaskAction,
   moveTaskAction,
   resolveCheckpointAction,
+  retryBlockedTaskAction,
+  startTaskAction,
 } from "@/app/(dashboard)/workflows/actions";
 
 function makeTask(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
@@ -326,5 +329,73 @@ describe("workflow matrix edit actions", () => {
     expect(addInstanceEvent.mock.calls[0]?.[0]).toBe(existing.instanceId);
     expect(addInstanceEvent.mock.calls[0]?.[1].name).toBe("workflow.task_deleted");
     expect(mockRevalidatePath).toHaveBeenCalledWith("/", "layout");
+  });
+
+  it("startTaskAction uses the atomic status transition and records an event", async () => {
+    const started = makeTask({ id: "task-start", status: "active", checkpoint: false });
+    const updateTaskIfStatus = vi.fn().mockResolvedValue(started);
+    const addEvent = vi.fn().mockResolvedValue({
+      id: "event-5",
+      instanceId: started.instanceId,
+      taskId: started.id,
+      name: "workflow.task_started",
+      description: "",
+      payload: {},
+      createdAt: "2026-04-19T12:00:00Z",
+    });
+
+    mockGetRepo.mockResolvedValue({
+      updateTaskIfStatus,
+      addEvent,
+      getTask: vi.fn(),
+    } satisfies Partial<WorkflowRepository>);
+
+    const result = await startTaskAction("task-start");
+
+    expect(updateTaskIfStatus).toHaveBeenCalledWith("task-start", "not_started", {
+      status: "active",
+    });
+    expect(addEvent.mock.calls[0]?.[1].name).toBe("workflow.task_started");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/", "layout");
+    expect(result.task.status).toBe("active");
+  });
+
+  it("cancelRunningTaskAction rejects with the same error when the task is no longer active", async () => {
+    const current = makeTask({ id: "task-cancel", status: "complete", checkpoint: false });
+    const updateTaskIfStatus = vi.fn().mockResolvedValue(null);
+    const getTask = vi.fn().mockResolvedValue(current);
+
+    mockGetRepo.mockResolvedValue({
+      updateTaskIfStatus,
+      getTask,
+      addEvent: vi.fn(),
+    } satisfies Partial<WorkflowRepository>);
+
+    await expect(cancelRunningTaskAction("task-cancel")).rejects.toThrow(
+      /task is not active/,
+    );
+
+    expect(updateTaskIfStatus).toHaveBeenCalledWith("task-cancel", "active", {
+      status: "blocked",
+    });
+  });
+
+  it("retryBlockedTaskAction rejects with task not found when the row no longer exists", async () => {
+    const updateTaskIfStatus = vi.fn().mockResolvedValue(null);
+    const getTask = vi.fn().mockResolvedValue(null);
+
+    mockGetRepo.mockResolvedValue({
+      updateTaskIfStatus,
+      getTask,
+      addEvent: vi.fn(),
+    } satisfies Partial<WorkflowRepository>);
+
+    await expect(retryBlockedTaskAction("task-retry")).rejects.toThrow(
+      /task not found/,
+    );
+
+    expect(updateTaskIfStatus).toHaveBeenCalledWith("task-retry", "blocked", {
+      status: "active",
+    });
   });
 });

--- a/products/dashboard/__tests__/components/top-bar.test.tsx
+++ b/products/dashboard/__tests__/components/top-bar.test.tsx
@@ -12,7 +12,8 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { usePathname } from "next/navigation";
+import userEvent from "@testing-library/user-event";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { TopBar } from "@/components/top-bar";
 
@@ -66,5 +67,26 @@ describe("TopBar", () => {
     render(<TopBar />);
     const pill = screen.getByRole("button", { name: /my tasks/i });
     expect(pill).toBeDisabled();
+  });
+
+  it("renders the workflow edit pill and toggles the edit query param", async () => {
+    vi.mocked(usePathname).mockReturnValue("/workflows/123");
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams());
+    const replace = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({
+      push: vi.fn(),
+      replace,
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+    });
+
+    render(<TopBar />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(replace).toHaveBeenCalledWith("/workflows/123?edit=1", { scroll: false });
   });
 });

--- a/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { ProcessMatrix } from "@/components/workflows/process-matrix";
@@ -241,7 +241,7 @@ describe("ProcessMatrix", () => {
         title: "New task",
       }),
     );
-    expect(screen.getByTestId("task-card-created-1")).toBeInTheDocument();
+    expect(await screen.findByTestId("task-card-created-1")).toBeInTheDocument();
   });
 
   it("removes a task after confirm", async () => {
@@ -257,6 +257,8 @@ describe("ProcessMatrix", () => {
     await user.click(screen.getByRole("button", { name: "Delete" }));
 
     expect(mockDeleteTaskAction).toHaveBeenCalledWith("k-1");
-    expect(screen.queryByTestId("task-card-k-1")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByTestId("task-card-k-1")).not.toBeInTheDocument();
+    });
   });
 });

--- a/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
@@ -11,7 +11,7 @@
  *     row instead of crashing the route.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -21,6 +21,31 @@ import type {
   WorkflowTask,
   WorkflowTemplate,
 } from "@/lib/workflows/types";
+
+const {
+  mockCreateTaskAction,
+  mockDeleteTaskAction,
+  mockMoveTaskAction,
+  mockCaptureError,
+} = vi.hoisted(() => ({
+  mockCreateTaskAction: vi.fn(),
+  mockDeleteTaskAction: vi.fn(),
+  mockMoveTaskAction: vi.fn(),
+  mockCaptureError: vi.fn(),
+}));
+
+vi.mock("@/app/(dashboard)/workflows/actions", () => ({
+  createTaskAction: mockCreateTaskAction,
+  deleteTaskAction: mockDeleteTaskAction,
+  moveTaskAction: mockMoveTaskAction,
+  approveDrawerCheckpointAction: vi.fn(),
+  rejectDrawerCheckpointAction: vi.fn(),
+  updateTaskTriggerGatesAction: vi.fn(),
+}));
+
+vi.mock("@/lib/monitoring", () => ({
+  captureError: mockCaptureError,
+}));
 
 const TEMPLATE: WorkflowTemplate = {
   id: "client-delivery",
@@ -77,6 +102,13 @@ function instance(tasks: WorkflowTask[]): WorkflowInstanceDetail {
 }
 
 describe("ProcessMatrix", () => {
+  beforeEach(() => {
+    mockCreateTaskAction.mockReset();
+    mockDeleteTaskAction.mockReset();
+    mockMoveTaskAction.mockReset();
+    mockCaptureError.mockReset();
+  });
+
   it("renders stage headers, role rows, and task cells", () => {
     const inst = instance([
       task({
@@ -179,5 +211,52 @@ describe("ProcessMatrix", () => {
     expect(screen.getByTestId("matrix-empty")).toHaveTextContent(
       /no stages or roles/i,
     );
+  });
+
+  it("shows edit affordances and creates a task in an empty cell", async () => {
+    const inst = instance([task({ id: "k-1", status: "active" })]);
+    const user = userEvent.setup();
+    const created = task({
+      id: "created-1",
+      roleId: "product",
+      stageId: "validation",
+      title: "New task",
+      agent: "PM",
+    });
+    mockCreateTaskAction.mockResolvedValue({ task: created });
+
+    render(<ProcessMatrix instance={inst} template={TEMPLATE} editMode />);
+
+    await user.click(screen.getByTestId("matrix-add-task-product-validation"));
+    expect(screen.getByRole("dialog", { name: "New task" })).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Task title"), "New task");
+    await user.click(screen.getByRole("button", { name: /create task/i }));
+
+    expect(mockCreateTaskAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: "inst-1",
+        roleId: "product",
+        stageId: "validation",
+        title: "New task",
+      }),
+    );
+    expect(screen.getByTestId("task-card-created-1")).toBeInTheDocument();
+  });
+
+  it("removes a task after confirm", async () => {
+    const inst = instance([task({ id: "k-1", status: "active" })]);
+    const user = userEvent.setup();
+    mockDeleteTaskAction.mockResolvedValue(undefined);
+
+    render(<ProcessMatrix instance={inst} template={TEMPLATE} editMode />);
+
+    await user.click(screen.getByLabelText("Remove task: Project Description"));
+    expect(screen.getByRole("dialog", { name: 'Delete "Project Description"?' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(mockDeleteTaskAction).toHaveBeenCalledWith("k-1");
+    expect(screen.queryByTestId("task-card-k-1")).not.toBeInTheDocument();
   });
 });

--- a/products/dashboard/__tests__/components/workflows/task-card.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/task-card.test.tsx
@@ -51,13 +51,13 @@ describe("TaskCard", () => {
     expect(
       within(card).getByText("Define objective, identify PDR need"),
     ).toBeInTheDocument();
-    expect(within(card).getByText("Active")).toBeInTheDocument();
+    expect(within(card).getByText("In progress")).toBeInTheDocument();
     expect(within(card).getByText("Sales Ops")).toBeInTheDocument();
   });
 
   it.each<[WorkflowTask["status"], TaskBarState, string]>([
     ["complete", "bar-complete", "Complete"],
-    ["active", "bar-active", "Active"],
+    ["active", "bar-active", "In progress"],
     ["pending_approval", "bar-pending", "Pending approval"],
     ["blocked", "bar-blocked", "Blocked"],
     ["not_started", "bar-ready", "Not started"],

--- a/products/dashboard/__tests__/components/workflows/task-card.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/task-card.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Component tests for components/workflows/task-card.tsx.
  * Spec anchor: AEL-50 — PR 7 (Process Matrix). Covers:
- *   - Each bar state (locked/ready/active/pending/complete/blocked)
+ *   - Each bar state (locked/ready/active/pending/complete/failed)
  *     toggles the `bar-*` class on the card root and the
  *     `data-bar` attribute (used by Playwright for asserting state).
  *   - The role accent colour is wired through the `--role-color`
@@ -59,7 +59,7 @@ describe("TaskCard", () => {
     ["complete", "bar-complete", "Complete"],
     ["active", "bar-active", "In progress"],
     ["pending_approval", "bar-pending", "Pending approval"],
-    ["blocked", "bar-blocked", "Blocked"],
+    ["blocked", "bar-cancelled", "Failed"],
     ["not_started", "bar-ready", "Not started"],
     ["not_started", "bar-locked", "Not started"],
   ])(

--- a/products/dashboard/__tests__/components/workflows/task-drawer.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/task-drawer.test.tsx
@@ -298,7 +298,7 @@ describe("TaskDrawer", () => {
       await user.click(screen.getByTestId("td-tab-dependencies"));
 
       expect(screen.getByTestId("td-dependencies-placeholder")).toHaveTextContent(
-        /DepTree coming in PR 10/i,
+        /DepTree coming in PR 14/i,
       );
     });
   });

--- a/products/dashboard/__tests__/components/workflows/task-drawer.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/task-drawer.test.tsx
@@ -35,18 +35,32 @@ import { TaskDrawer } from "@/components/workflows/task-drawer";
 
 // ── Module mocks ─────────────────────────────────────────────────────────────
 
-const { mockApprove, mockReject, mockUpdateTG, mockEmitEvent, mockCaptureError } =
-  vi.hoisted(() => ({
-    mockApprove: vi.fn(),
-    mockReject: vi.fn(),
-    mockUpdateTG: vi.fn(),
-    mockEmitEvent: vi.fn(),
-    mockCaptureError: vi.fn(),
-  }));
+const {
+  mockApprove,
+  mockReject,
+  mockStart,
+  mockCancelRun,
+  mockRetryBlocked,
+  mockUpdateTG,
+  mockEmitEvent,
+  mockCaptureError,
+} = vi.hoisted(() => ({
+  mockApprove: vi.fn(),
+  mockReject: vi.fn(),
+  mockStart: vi.fn(),
+  mockCancelRun: vi.fn(),
+  mockRetryBlocked: vi.fn(),
+  mockUpdateTG: vi.fn(),
+  mockEmitEvent: vi.fn(),
+  mockCaptureError: vi.fn(),
+}));
 
 vi.mock("@/app/(dashboard)/workflows/actions", () => ({
   approveDrawerCheckpointAction: mockApprove,
   rejectDrawerCheckpointAction: mockReject,
+  startTaskAction: mockStart,
+  cancelRunningTaskAction: mockCancelRun,
+  retryBlockedTaskAction: mockRetryBlocked,
   updateTaskTriggerGatesAction: mockUpdateTG,
 }));
 
@@ -137,6 +151,7 @@ function renderDrawer(
   events: WorkflowEvent[] = [],
   onClose = vi.fn(),
   onTaskUpdate = vi.fn(),
+  onOpenPlaybookPrompt?: () => void,
 ) {
   const task = makeTask(taskOverrides);
   const instance = makeInstance([task], events);
@@ -149,6 +164,7 @@ function renderDrawer(
       template={TEMPLATE}
       onClose={onClose}
       onTaskUpdate={onTaskUpdate}
+      onOpenPlaybookPrompt={onOpenPlaybookPrompt}
     />,
   );
 
@@ -161,6 +177,9 @@ describe("TaskDrawer", () => {
   beforeEach(() => {
     mockApprove.mockReset();
     mockReject.mockReset();
+    mockStart.mockReset();
+    mockCancelRun.mockReset();
+    mockRetryBlocked.mockReset();
     mockUpdateTG.mockReset();
     mockEmitEvent.mockReset();
     mockCaptureError.mockReset();
@@ -202,19 +221,98 @@ describe("TaskDrawer", () => {
       expect(screen.getByTestId("td-reject-btn")).toBeInTheDocument();
     });
 
-    it("shows Start agent button for not_started task", () => {
-      renderDrawer({ status: "not_started", checkpoint: false });
+    it("shows Start agent button for not_started task with playbook", () => {
+      renderDrawer({ status: "not_started", checkpoint: false, playbook: "demo-pb" });
       expect(screen.getByTestId("td-start-btn")).toBeInTheDocument();
+      const playbookCard = screen.getByTestId("td-playbook-card");
+      expect(playbookCard).not.toHaveAttribute("role", "button");
     });
 
-    it("shows View live run button for active task", () => {
-      renderDrawer({ status: "active", checkpoint: false });
-      expect(screen.getByTestId("td-view-run-btn")).toBeInTheDocument();
+    it("shows active playbook row with stop control for running task", () => {
+      renderDrawer({ status: "active", checkpoint: false, playbook: "demo-pb" });
+      const playbookCard = screen.getByTestId("td-playbook-card");
+      expect(playbookCard).toHaveAttribute("role", "button");
+      expect(screen.getByTestId("td-pb-stop-run-btn")).toBeInTheDocument();
     });
 
     it("shows no action card for complete task", () => {
       renderDrawer({ status: "complete", checkpoint: false });
       expect(screen.queryByTestId("td-action-card")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Cancel run", () => {
+    it("calls cancelRunningTaskAction and onTaskUpdate when stop is clicked", async () => {
+      const updatedTask = makeTask({
+        status: "blocked",
+        checkpoint: false,
+        playbook: "demo-pb",
+      });
+      mockCancelRun.mockResolvedValue({ task: updatedTask });
+      const onTaskUpdate = vi.fn();
+      const { task } = renderDrawer(
+        { status: "active", checkpoint: false, playbook: "demo-pb" },
+        [],
+        vi.fn(),
+        onTaskUpdate,
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("td-pb-stop-run-btn"));
+      });
+
+      expect(mockCancelRun).toHaveBeenCalledWith(task.id);
+      expect(onTaskUpdate).toHaveBeenCalledWith(updatedTask);
+      expect(mockEmitEvent).toHaveBeenCalledWith("workflow.run_cancelled", {
+        task_id: task.id,
+        instance_id: task.instanceId,
+      });
+    });
+  });
+
+  describe("Retry run", () => {
+    it("calls retryBlockedTaskAction and onTaskUpdate when retry is clicked", async () => {
+      const updatedTask = makeTask({
+        status: "active",
+        checkpoint: false,
+        playbook: "demo-pb",
+      });
+      mockRetryBlocked.mockResolvedValue({ task: updatedTask });
+      const onTaskUpdate = vi.fn();
+      const { task } = renderDrawer(
+        { status: "blocked", checkpoint: false, playbook: "demo-pb" },
+        [],
+        vi.fn(),
+        onTaskUpdate,
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("td-pb-retry-run-btn"));
+      });
+
+      expect(mockRetryBlocked).toHaveBeenCalledWith(task.id);
+      expect(onTaskUpdate).toHaveBeenCalledWith(updatedTask);
+      expect(mockEmitEvent).toHaveBeenCalledWith("workflow.run_retried", {
+        task_id: task.id,
+        instance_id: task.instanceId,
+      });
+    });
+  });
+
+  describe("Playbook chat affordance", () => {
+    it("invokes onOpenPlaybookPrompt when the playbook card is clicked", async () => {
+      const onOpenPlaybookPrompt = vi.fn();
+      const user = userEvent.setup();
+      renderDrawer(
+        { status: "complete", checkpoint: false, playbook: "demo-pb" },
+        [],
+        vi.fn(),
+        vi.fn(),
+        onOpenPlaybookPrompt,
+      );
+
+      await user.click(screen.getByTestId("td-playbook-card"));
+      expect(onOpenPlaybookPrompt).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/products/dashboard/__tests__/components/workflows/task-drawer.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/task-drawer.test.tsx
@@ -231,7 +231,7 @@ describe("TaskDrawer", () => {
     it("shows active playbook row with stop control for running task", () => {
       renderDrawer({ status: "active", checkpoint: false, playbook: "demo-pb" });
       const playbookCard = screen.getByTestId("td-playbook-card");
-      expect(playbookCard).toHaveAttribute("role", "button");
+      expect(playbookCard).not.toHaveAttribute("role", "button");
       expect(screen.getByTestId("td-pb-stop-run-btn")).toBeInTheDocument();
     });
 
@@ -300,6 +300,12 @@ describe("TaskDrawer", () => {
   });
 
   describe("Playbook chat affordance", () => {
+    it("only exposes button semantics when a playbook handler is provided", () => {
+      renderDrawer({ status: "complete", checkpoint: false, playbook: "demo-pb" });
+
+      expect(screen.getByTestId("td-playbook-card")).not.toHaveAttribute("role", "button");
+    });
+
     it("invokes onOpenPlaybookPrompt when the playbook card is clicked", async () => {
       const onOpenPlaybookPrompt = vi.fn();
       const user = userEvent.setup();
@@ -311,7 +317,9 @@ describe("TaskDrawer", () => {
         onOpenPlaybookPrompt,
       );
 
-      await user.click(screen.getByTestId("td-playbook-card"));
+      const playbookCard = screen.getByTestId("td-playbook-card");
+      expect(playbookCard).toHaveAttribute("role", "button");
+      await user.click(playbookCard);
       expect(onOpenPlaybookPrompt).toHaveBeenCalledTimes(1);
     });
   });

--- a/products/dashboard/__tests__/lib/workflows/matrix.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/matrix.test.ts
@@ -91,7 +91,7 @@ describe("barClass", () => {
     expect(barClass(task("c", { status: "complete" }), false)).toBe("bar-complete");
     expect(barClass(task("a", { status: "active" }), false)).toBe("bar-active");
     expect(barClass(task("p", { status: "pending_approval" }), true)).toBe("bar-pending");
-    expect(barClass(task("b", { status: "blocked" }), true)).toBe("bar-blocked");
+    expect(barClass(task("b", { status: "blocked" }), true)).toBe("bar-cancelled");
   });
 
   it("splits not_started tasks into ready/locked based on canStart", () => {

--- a/products/dashboard/__tests__/lib/workflows/repository.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/repository.test.ts
@@ -465,6 +465,51 @@ describe("workflow repository", () => {
     });
   });
 
+  describe("createTask + updateTaskIfStatus", () => {
+    it("creates instance tasks with an explicit not_started state", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+      const instance = await repo.createInstance("client-delivery", "Acme Corp");
+
+      const created = await repo.createTask({
+        instanceId: instance.id,
+        roleId: "sales",
+        stageId: "pre-sales",
+        title: "Follow up",
+        description: "",
+      });
+
+      expect(created.status).toBe("not_started");
+      expect(created.substatus).toBe("");
+    });
+
+    it("updates a task only when the expected status still matches", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+      const instance = await repo.createInstance("client-delivery", "Acme Corp");
+      const target = instance.tasks[0]!;
+
+      const transitioned = await repo.updateTaskIfStatus(target.id, "not_started", {
+        status: "active",
+      });
+
+      expect(transitioned).not.toBeNull();
+      expect(transitioned!.status).toBe("active");
+      expect((await repo.getTask(target.id))!.status).toBe("active");
+    });
+
+    it("returns null when updateTaskIfStatus sees a stale current status", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+      const instance = await repo.createInstance("client-delivery", "Acme Corp");
+      const target = instance.tasks[0]!;
+
+      const transitioned = await repo.updateTaskIfStatus(target.id, "active", {
+        status: "blocked",
+      });
+
+      expect(transitioned).toBeNull();
+      expect((await repo.getTask(target.id))!.status).toBe("not_started");
+    });
+  });
+
   describe("addEvent + getInstance", () => {
     it("appends an event and surfaces it via getInstance", async () => {
       const repo = createWorkflowRepository(makeFakeClient(store));

--- a/products/dashboard/app/(dashboard)/api/events/route.ts
+++ b/products/dashboard/app/(dashboard)/api/events/route.ts
@@ -29,6 +29,14 @@ const ALLOWED_EVENTS = new Set([
   "workflow.run_retried",
 ]);
 
+const WORKFLOW_TASK_INSTANCE_EVENTS = new Set([
+  "workflow.checkpoint_approved",
+  "workflow.checkpoint_rejected",
+  "workflow.task_started",
+  "workflow.run_cancelled",
+  "workflow.run_retried",
+]);
+
 type EventBody = {
   event_name: string;
   occurred_at?: string;
@@ -79,13 +87,7 @@ function sanitizePayload(
     return { task_id };
   }
 
-  if (
-    eventName === "workflow.checkpoint_approved" ||
-    eventName === "workflow.checkpoint_rejected" ||
-    eventName === "workflow.task_started" ||
-    eventName === "workflow.run_cancelled" ||
-    eventName === "workflow.run_retried"
-  ) {
+  if (WORKFLOW_TASK_INSTANCE_EVENTS.has(eventName)) {
     const task_id = clampString(payload.task_id, 80);
     const instance_id = clampString(payload.instance_id, 80);
     if (!task_id || !instance_id) return null;

--- a/products/dashboard/app/(dashboard)/api/events/route.ts
+++ b/products/dashboard/app/(dashboard)/api/events/route.ts
@@ -21,6 +21,12 @@ const ALLOWED_EVENTS = new Set([
   "auth.requested_magic_link",
   "user.signed_in",
   "user.signed_out",
+  "dashboard.task_drawer_opened",
+  "workflow.checkpoint_approved",
+  "workflow.checkpoint_rejected",
+  "workflow.task_started",
+  "workflow.run_cancelled",
+  "workflow.run_retried",
 ]);
 
 type EventBody = {
@@ -65,6 +71,25 @@ function sanitizePayload(
     }
 
     return { provider: payload.provider };
+  }
+
+  if (eventName === "dashboard.task_drawer_opened") {
+    const task_id = clampString(payload.task_id, 80);
+    if (!task_id) return null;
+    return { task_id };
+  }
+
+  if (
+    eventName === "workflow.checkpoint_approved" ||
+    eventName === "workflow.checkpoint_rejected" ||
+    eventName === "workflow.task_started" ||
+    eventName === "workflow.run_cancelled" ||
+    eventName === "workflow.run_retried"
+  ) {
+    const task_id = clampString(payload.task_id, 80);
+    const instance_id = clampString(payload.instance_id, 80);
+    if (!task_id || !instance_id) return null;
+    return { task_id, instance_id };
   }
 
   return null;

--- a/products/dashboard/app/(dashboard)/framework/playbooks/page.tsx
+++ b/products/dashboard/app/(dashboard)/framework/playbooks/page.tsx
@@ -3,7 +3,7 @@ import { ShellEvents } from "@/components/shell-events";
 /**
  * Playbooks — placeholder.
  *
- * Real Playbooks library lands in PR 14 (AEL-57). This page exists so
+ * Real Playbooks library lands in PR 13 (AEL-57). This page exists so
  * the sidebar's Framework → Playbooks link doesn't 404 and so shell
  * events fire on the route during PR 3.
  */

--- a/products/dashboard/app/(dashboard)/framework/skills/page.tsx
+++ b/products/dashboard/app/(dashboard)/framework/skills/page.tsx
@@ -3,7 +3,7 @@ import { ShellEvents } from "@/components/shell-events";
 /**
  * Skills — placeholder.
  *
- * Real Skills library lands in PR 13 (AEL-56). This page exists so the
+ * Real Skills library lands in PR 12 (AEL-56). This page exists so the
  * sidebar's Framework → Skills link doesn't 404 and so shell events
  * fire on the route during PR 3.
  */

--- a/products/dashboard/app/(dashboard)/workflows/[instanceId]/page.tsx
+++ b/products/dashboard/app/(dashboard)/workflows/[instanceId]/page.tsx
@@ -30,13 +30,21 @@ interface Params {
 
 export default async function WorkflowInstancePage({
   params,
+  searchParams,
 }: {
   params: Promise<Params>;
+  searchParams: Promise<{ edit?: string }>;
 }) {
   const { instanceId } = await params;
+  const { edit } = await searchParams;
+  const editMode = edit === "1";
 
   const repo = await getServerWorkflowRepository();
-  const instance = await repo.getInstance(instanceId);
+  const [instance, skills, playbooks] = await Promise.all([
+    repo.getInstance(instanceId),
+    repo.getFrameworkItems("skill"),
+    repo.getFrameworkItems("playbook"),
+  ]);
 
   if (!instance) {
     notFound();
@@ -65,7 +73,13 @@ export default async function WorkflowInstancePage({
           </p>
         </header>
 
-        <ProcessMatrix instance={instance} template={template} />
+        <ProcessMatrix
+          instance={instance}
+          template={template}
+          editMode={editMode}
+          skillOptions={skills}
+          playbookOptions={playbooks}
+        />
       </div>
     </>
   );

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -436,13 +436,14 @@ export async function startTaskAction(
   if (!trimmedId) throw new Error("startTaskAction: taskId is required");
 
   const repo = await getServerWorkflowRepository();
-  const current = await repo.getTask(trimmedId);
-  if (!current) throw new Error("startTaskAction: task not found");
-  if (current.status !== "not_started") {
+  const task = await repo.updateTaskIfStatus(trimmedId, "not_started", {
+    status: "active",
+  });
+  if (!task) {
+    const current = await repo.getTask(trimmedId);
+    if (!current) throw new Error("startTaskAction: task not found");
     throw new Error("startTaskAction: task is not in not_started state");
   }
-
-  const task = await repo.updateTask(trimmedId, { status: "active" });
 
   try {
     await repo.addEvent(trimmedId, {
@@ -475,15 +476,16 @@ export async function cancelRunningTaskAction(
   }
 
   const repo = await getServerWorkflowRepository();
-  const current = await repo.getTask(trimmedId);
-  if (!current) {
-    throw new Error("cancelRunningTaskAction: task not found");
-  }
-  if (current.status !== "active") {
+  const task = await repo.updateTaskIfStatus(trimmedId, "active", {
+    status: "blocked",
+  });
+  if (!task) {
+    const current = await repo.getTask(trimmedId);
+    if (!current) {
+      throw new Error("cancelRunningTaskAction: task not found");
+    }
     throw new Error("cancelRunningTaskAction: task is not active");
   }
-
-  const task = await repo.updateTask(trimmedId, { status: "blocked" });
 
   try {
     await repo.addEvent(trimmedId, {
@@ -516,15 +518,16 @@ export async function retryBlockedTaskAction(
   }
 
   const repo = await getServerWorkflowRepository();
-  const current = await repo.getTask(trimmedId);
-  if (!current) {
-    throw new Error("retryBlockedTaskAction: task not found");
-  }
-  if (current.status !== "blocked") {
+  const task = await repo.updateTaskIfStatus(trimmedId, "blocked", {
+    status: "active",
+  });
+  if (!task) {
+    const current = await repo.getTask(trimmedId);
+    if (!current) {
+      throw new Error("retryBlockedTaskAction: task not found");
+    }
     throw new Error("retryBlockedTaskAction: task is not blocked");
   }
-
-  const task = await repo.updateTask(trimmedId, { status: "active" });
 
   try {
     await repo.addEvent(trimmedId, {

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -8,6 +8,7 @@ import type {
   WorkflowGate,
   WorkflowInstance,
   WorkflowTask,
+  WorkflowTaskCreateInput,
   WorkflowTrigger,
 } from "@/lib/workflows/types";
 
@@ -295,4 +296,205 @@ export async function updateTaskTriggerGatesAction(
 
   revalidatePath("/", "layout");
   return { task };
+}
+
+const MAX_TASK_TITLE_LENGTH = 120;
+const MAX_TASK_DESCRIPTION_LENGTH = 240;
+const MAX_PLAYBOOK_LENGTH = 120;
+
+function normalizeTaskField(value: string, label: string, maxLength: number): string {
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string`);
+  }
+  return value.trim().slice(0, maxLength);
+}
+
+export interface CreateTaskResult {
+  task: WorkflowTask;
+}
+
+export async function createTaskAction(
+  input: WorkflowTaskCreateInput,
+): Promise<CreateTaskResult> {
+  const instanceId = normalizeTaskField(input.instanceId, "instanceId", 80);
+  const roleId = normalizeTaskField(input.roleId, "roleId", 80);
+  const stageId = normalizeTaskField(input.stageId, "stageId", 80);
+  const title = normalizeTaskField(input.title, "title", MAX_TASK_TITLE_LENGTH);
+  const description = normalizeTaskField(
+    input.description ?? "",
+    "description",
+    MAX_TASK_DESCRIPTION_LENGTH,
+  );
+  const playbook = normalizeTaskField(
+    input.playbook ?? "",
+    "playbook",
+    MAX_PLAYBOOK_LENGTH,
+  );
+
+  if (!instanceId || !roleId || !stageId || !title) {
+    throw new Error(
+      "createTaskAction: instanceId, roleId, stageId, and title are required",
+    );
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const task = await repo.createTask({
+    ...input,
+    instanceId,
+    roleId,
+    stageId,
+    title,
+    description,
+    playbook: playbook || null,
+  });
+
+  try {
+    await repo.addEvent(task.id, {
+      name: "workflow.task_created",
+      description: `Created task: ${task.title}`,
+      payload: {
+        task_id: task.id,
+        instance_id: task.instanceId,
+        role_id: task.roleId,
+        stage_id: task.stageId,
+      },
+    });
+  } catch (eventError) {
+    captureError(eventError, {
+      feature: "workflows.create_task",
+      action: "addEvent",
+      extra: { task_id: task.id, instance_id: task.instanceId },
+    });
+  }
+
+  revalidatePath("/", "layout");
+  return { task };
+}
+
+export interface MoveTaskResult {
+  task: WorkflowTask;
+}
+
+export async function moveTaskAction(
+  taskId: string,
+  roleId: string,
+  stageId: string,
+): Promise<MoveTaskResult> {
+  const trimmedTaskId = normalizeTaskField(taskId, "taskId", 80);
+  const trimmedRoleId = normalizeTaskField(roleId, "roleId", 80);
+  const trimmedStageId = normalizeTaskField(stageId, "stageId", 80);
+
+  if (!trimmedTaskId || !trimmedRoleId || !trimmedStageId) {
+    throw new Error("moveTaskAction: taskId, roleId, and stageId are required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const current = await repo.getTask(trimmedTaskId);
+  if (!current) {
+    throw new Error("moveTaskAction: task not found");
+  }
+
+  const task =
+    current.roleId === trimmedRoleId && current.stageId === trimmedStageId
+      ? current
+      : await repo.updateTask(trimmedTaskId, {
+          roleId: trimmedRoleId,
+          stageId: trimmedStageId,
+        });
+
+  if (task !== current) {
+    try {
+      await repo.addEvent(task.id, {
+        name: "workflow.task_moved",
+        description: `Moved task: ${task.title}`,
+        payload: {
+          task_id: task.id,
+          instance_id: task.instanceId,
+          from_role_id: current.roleId,
+          from_stage_id: current.stageId,
+          to_role_id: task.roleId,
+          to_stage_id: task.stageId,
+        },
+      });
+    } catch (eventError) {
+      captureError(eventError, {
+        feature: "workflows.move_task",
+        action: "addEvent",
+        extra: { task_id: task.id, instance_id: task.instanceId },
+      });
+    }
+  }
+
+  revalidatePath("/", "layout");
+  return { task };
+}
+
+export async function startTaskAction(
+  taskId: string,
+): Promise<{ task: WorkflowTask }> {
+  const trimmedId = normalizeTaskField(taskId, "taskId", 80);
+  if (!trimmedId) throw new Error("startTaskAction: taskId is required");
+
+  const repo = await getServerWorkflowRepository();
+  const current = await repo.getTask(trimmedId);
+  if (!current) throw new Error("startTaskAction: task not found");
+  if (current.status !== "not_started") {
+    throw new Error("startTaskAction: task is not in not_started state");
+  }
+
+  const task = await repo.updateTask(trimmedId, { status: "active" });
+
+  try {
+    await repo.addEvent(trimmedId, {
+      name: "workflow.task_started",
+      description: `Started task: ${task.title}`,
+      payload: { task_id: task.id, instance_id: task.instanceId },
+    });
+  } catch (eventError) {
+    captureError(eventError, {
+      feature: "workflows.start_task",
+      action: "addEvent",
+      extra: { task_id: task.id, instance_id: task.instanceId },
+    });
+  }
+
+  revalidatePath("/", "layout");
+  return { task };
+}
+
+export async function deleteTaskAction(taskId: string): Promise<void> {
+  const trimmedTaskId = normalizeTaskField(taskId, "taskId", 80);
+  if (!trimmedTaskId) {
+    throw new Error("deleteTaskAction: taskId is required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const task = await repo.getTask(trimmedTaskId);
+  if (!task) {
+    throw new Error("deleteTaskAction: task not found");
+  }
+
+  await repo.deleteTask(trimmedTaskId);
+
+  try {
+    await repo.addInstanceEvent(task.instanceId, {
+      taskId: null,
+      name: "workflow.task_deleted",
+      description: `Deleted task: ${task.title}`,
+      payload: {
+        task_id: task.id,
+        instance_id: task.instanceId,
+        role_id: task.roleId,
+        stage_id: task.stageId,
+      },
+    });
+  } catch (eventError) {
+    captureError(eventError, {
+      feature: "workflows.delete_task",
+      action: "addInstanceEvent",
+      extra: { task_id: task.id, instance_id: task.instanceId },
+    });
+  }
+
+  revalidatePath("/", "layout");
 }

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -462,6 +462,88 @@ export async function startTaskAction(
   return { task };
 }
 
+/**
+ * Stop an in-flight task run: persists `status: "blocked"` (failed in UI)
+ * and records `workflow.run_cancelled`. Only `active` tasks accept this path.
+ */
+export async function cancelRunningTaskAction(
+  taskId: string,
+): Promise<{ task: WorkflowTask }> {
+  const trimmedId = normalizeTaskField(taskId, "taskId", 80);
+  if (!trimmedId) {
+    throw new Error("cancelRunningTaskAction: taskId is required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const current = await repo.getTask(trimmedId);
+  if (!current) {
+    throw new Error("cancelRunningTaskAction: task not found");
+  }
+  if (current.status !== "active") {
+    throw new Error("cancelRunningTaskAction: task is not active");
+  }
+
+  const task = await repo.updateTask(trimmedId, { status: "blocked" });
+
+  try {
+    await repo.addEvent(trimmedId, {
+      name: "workflow.run_cancelled",
+      description: `Failed run: ${task.title}`,
+      payload: { task_id: task.id, instance_id: task.instanceId },
+    });
+  } catch (eventError) {
+    captureError(eventError, {
+      feature: "workflows.cancel_run",
+      action: "addEvent",
+      extra: { task_id: task.id, instance_id: task.instanceId },
+    });
+  }
+
+  revalidatePath("/", "layout");
+  return { task };
+}
+
+/**
+ * Resume a failed playbook run: `blocked` → `active`.
+ * Used when the user chooses Retry from the Task Drawer playbook control.
+ */
+export async function retryBlockedTaskAction(
+  taskId: string,
+): Promise<{ task: WorkflowTask }> {
+  const trimmedId = normalizeTaskField(taskId, "taskId", 80);
+  if (!trimmedId) {
+    throw new Error("retryBlockedTaskAction: taskId is required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const current = await repo.getTask(trimmedId);
+  if (!current) {
+    throw new Error("retryBlockedTaskAction: task not found");
+  }
+  if (current.status !== "blocked") {
+    throw new Error("retryBlockedTaskAction: task is not blocked");
+  }
+
+  const task = await repo.updateTask(trimmedId, { status: "active" });
+
+  try {
+    await repo.addEvent(trimmedId, {
+      name: "workflow.run_retried",
+      description: `Retried run: ${task.title}`,
+      payload: { task_id: task.id, instance_id: task.instanceId },
+    });
+  } catch (eventError) {
+    captureError(eventError, {
+      feature: "workflows.retry_run",
+      action: "addEvent",
+      extra: { task_id: task.id, instance_id: task.instanceId },
+    });
+  }
+
+  revalidatePath("/", "layout");
+  return { task };
+}
+
 export async function deleteTaskAction(taskId: string): Promise<void> {
   const trimmedTaskId = normalizeTaskField(taskId, "taskId", 80);
   if (!trimmedTaskId) {

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -518,9 +518,9 @@ body {
 .task-card.bar-complete::before {
   opacity: 0.35;
 }
-.task-card.bar-blocked::before {
-  background: #ef4444;
-  opacity: 1;
+/* DB `blocked` / UI "failed" — keep role accent, not error red */
+.task-card.bar-cancelled::before {
+  opacity: 0.4;
 }
 @keyframes ainative-bar-pulse {
   0%,
@@ -952,6 +952,39 @@ body {
   background: var(--bg-3);
   border: 1px solid var(--border);
   min-height: 54px;
+  transition:
+    background 0.14s ease,
+    border-color 0.14s ease;
+}
+/* Subtle surface tint by task status (matches pill token families) */
+.td-playbook--not_started {
+  background: color-mix(in srgb, var(--pill-ns-bg) 58%, var(--bg-3));
+}
+.td-playbook--active {
+  background: color-mix(in srgb, var(--pill-active-bg) 50%, var(--bg-3));
+  border-color: color-mix(in srgb, var(--pill-active-d) 22%, var(--border));
+}
+.td-playbook--pending_approval {
+  background: color-mix(in srgb, var(--pill-pending-bg) 52%, var(--bg-3));
+  border-color: color-mix(in srgb, var(--pill-pending-d) 24%, var(--border));
+}
+.td-playbook--complete {
+  background: color-mix(in srgb, var(--pill-complete-bg) 52%, var(--bg-3));
+  border-color: color-mix(in srgb, var(--pill-complete-d) 22%, var(--border));
+}
+.td-playbook--blocked {
+  background: color-mix(in srgb, var(--pill-blocked-bg) 52%, var(--bg-3));
+  border-color: color-mix(in srgb, var(--pill-blocked-d) 24%, var(--border));
+}
+.td-playbook-clickable {
+  cursor: pointer;
+}
+.td-playbook-clickable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.td-playbook-clickable:hover {
+  border-color: var(--border-hi);
 }
 .td-agent-profile-icon,
 .td-pb-icon {
@@ -1300,9 +1333,9 @@ body {
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  border: 1px solid var(--border-hi);
-  background: var(--bg-4);
-  color: var(--t3);
+  border: 1px solid color-mix(in srgb, var(--pill-complete-d) 38%, var(--border-hi));
+  background: color-mix(in srgb, var(--pill-complete-bg) 70%, var(--bg-4));
+  color: var(--pill-complete-t);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -1311,17 +1344,16 @@ body {
   padding: 0;
 }
 .td-pb-run-btn:hover:not(:disabled) {
-  background: var(--primary-bg);
-  border-color: var(--primary);
-  color: var(--accent);
+  background: color-mix(in srgb, var(--pill-complete-bg) 95%, var(--bg-4));
+  border-color: color-mix(in srgb, var(--pill-complete-d) 55%, var(--border-hi));
+  color: var(--pill-complete-d);
 }
 .td-pb-run-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
 .td-pb-state-busy,
-.td-pb-state-done,
-.td-pb-state-failed {
+.td-pb-state-done {
   width: 18px;
   height: 18px;
   border-radius: 50%;
@@ -1329,6 +1361,73 @@ body {
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+}
+/* Running spinner + hover/focus stop (cancels run → `blocked` in DB) */
+.td-pb-busy-wrap {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.td-pb-busy-wrap .td-pb-state-busy {
+  position: absolute;
+  inset: 3px;
+}
+.td-pb-stop-btn {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  padding: 0;
+  cursor: pointer;
+  background: var(--bg-4);
+  color: var(--t2);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.12s ease,
+    background 0.12s ease,
+    color 0.12s ease;
+}
+.td-pb-stop-btn:hover:not(:disabled),
+.td-pb-stop-btn:focus-visible:not(:disabled) {
+  background: rgba(239, 68, 68, 0.12);
+  color: #f87171;
+}
+.td-pb-stop-btn:disabled {
+  opacity: 0;
+  cursor: not-allowed;
+}
+@media (hover: hover) {
+  .td-pb-busy-wrap:hover .td-pb-state-busy {
+    opacity: 0;
+  }
+  .td-pb-busy-wrap:hover .td-pb-stop-btn:not(:disabled) {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+.td-pb-busy-wrap:focus-within .td-pb-state-busy {
+  opacity: 0;
+}
+.td-pb-busy-wrap:focus-within .td-pb-stop-btn:not(:disabled) {
+  opacity: 1;
+  pointer-events: auto;
+}
+@media (hover: none) {
+  .td-pb-busy-wrap .td-pb-stop-btn:not(:disabled) {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .td-pb-busy-wrap .td-pb-state-busy {
+    opacity: 0.25;
+  }
 }
 .td-pb-state-busy {
   background: transparent;
@@ -1340,9 +1439,75 @@ body {
   background: rgba(16, 185, 129, 0.15);
   color: #34d399;
 }
-.td-pb-state-failed {
-  background: rgba(239, 68, 68, 0.12);
-  color: #f87171;
+/* Failed playbook — hover/focus shows retry (blocked → active) */
+.td-pb-failed-wrap {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.td-pb-failed-wrap .td-pb-failed-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--pill-blocked-t);
+  transition: opacity 0.12s ease;
+}
+.td-pb-retry-btn {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  padding: 0;
+  cursor: pointer;
+  background: var(--bg-4);
+  color: var(--t2);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.12s ease,
+    background 0.12s ease,
+    color 0.12s ease;
+}
+.td-pb-retry-btn:hover:not(:disabled),
+.td-pb-retry-btn:focus-visible:not(:disabled) {
+  background: rgba(16, 185, 129, 0.14);
+  color: #34d399;
+}
+.td-pb-retry-btn:disabled {
+  opacity: 0;
+  cursor: not-allowed;
+}
+@media (hover: hover) {
+  .td-pb-failed-wrap:hover .td-pb-failed-icon {
+    opacity: 0;
+  }
+  .td-pb-failed-wrap:hover .td-pb-retry-btn:not(:disabled) {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+.td-pb-failed-wrap:focus-within .td-pb-failed-icon {
+  opacity: 0;
+}
+.td-pb-failed-wrap:focus-within .td-pb-retry-btn:not(:disabled) {
+  opacity: 1;
+  pointer-events: auto;
+}
+@media (hover: none) {
+  .td-pb-failed-wrap .td-pb-retry-btn:not(:disabled) {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .td-pb-failed-wrap .td-pb-failed-icon {
+    opacity: 0.22;
+  }
 }
 @keyframes ainative-spin {
   from { transform: rotate(0deg); }
@@ -1372,7 +1537,7 @@ body {
   pointer-events: none;
 }
 .td-playbook-active:hover {
-  background: var(--bg-4);
+  background: color-mix(in srgb, var(--pill-active-bg) 38%, var(--bg-4));
 }
 @keyframes ainative-wave {
   0%   { left: -60%; }

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -63,9 +63,10 @@
   --pill-complete-t: #34d399;
   --pill-complete-d: #10b981;
 
-  --pill-active-bg: rgba(99, 102, 241, 0.12);
-  --pill-active-t: #818cf8;
-  --pill-active-d: #6366f1;
+  /* In-progress task — sky (complete stays emerald / “done”). */
+  --pill-active-bg: rgba(14, 165, 233, 0.14);
+  --pill-active-t: #7dd3fc;
+  --pill-active-d: #0ea5e9;
 
   --pill-pending-bg: rgba(245, 158, 11, 0.12);
   --pill-pending-t: #fbbf24;
@@ -108,9 +109,9 @@
   --pill-complete-t: #059669;
   --pill-complete-d: #10b981;
 
-  --pill-active-bg: #eef2ff;
-  --pill-active-t: #4f46e5;
-  --pill-active-d: #6366f1;
+  --pill-active-bg: #f0f9ff;
+  --pill-active-t: #0369a1;
+  --pill-active-d: #0ea5e9;
 
   --pill-pending-bg: #fffbeb;
   --pill-pending-t: #d97706;
@@ -931,7 +932,7 @@ body {
   color: #34d399;
   margin-bottom: 16px;
 }
-/* Skill card — name only, no min-height needed */
+/* Skill card — name only (paired row with status sets min-height via `.td-status-skill-row`) */
 .td-agent-profile {
   display: flex;
   align-items: center;
@@ -970,7 +971,8 @@ body {
   min-width: 0;
 }
 .td-agent-profile-name,
-.td-pb-name {
+.td-pb-name,
+.td-status-label {
   font-size: 13px;
   font-weight: 600;
   font-family: "JetBrains Mono", monospace;
@@ -1171,29 +1173,120 @@ body {
   color: var(--t3);
   padding-top: 4px;
 }
-/* Status + Skill two-column row */
+/* Status + Skill two-column row — columns stretch; cards share one height */
 .td-status-skill-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 12px;
+  align-items: stretch;
 }
-.td-status-pill-xl {
-  height: 32px;
-  padding: 0 14px;
-  gap: 8px;
+.td-status-skill-row .td-status-col,
+.td-status-skill-row .td-skill-col {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  min-height: 0;
 }
-.td-status-pill-xl .s-dot {
+.td-status-skill-row .td-status-col .td-status-card,
+.td-status-skill-row .td-skill-col .td-agent-profile {
+  flex: 1 1 auto;
+  min-height: 54px;
+}
+/* Task drawer — status (one surface; dot + left copy, vertically centered in card) */
+.td-status-card {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 11px 13px;
+  border-radius: 9px;
+  border: 1px solid var(--border);
+  background: var(--bg-3);
+}
+.td-status-copy {
+  flex: 1;
+  min-width: 0;
+}
+.td-status-indicator {
   width: 9px;
   height: 9px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
-.td-status-pill-xl .s-text {
-  font-size: 14px;
-  font-weight: 700;
-  letter-spacing: -0.01em;
+.td-status-card--complete {
+  background: color-mix(in srgb, var(--pill-complete-bg) 55%, var(--bg-3));
+  border-color: color-mix(in srgb, var(--pill-complete-d) 32%, var(--border));
+}
+.td-status-card--complete .td-status-indicator {
+  background: var(--pill-complete-d);
+  box-shadow: 0 0 0 3px var(--pill-complete-bg);
+}
+.td-status-card--complete .td-status-label {
+  color: var(--pill-complete-t);
+}
+.td-status-card--active {
+  background: color-mix(in srgb, var(--pill-active-bg) 55%, var(--bg-3));
+  border-color: color-mix(in srgb, var(--pill-active-d) 30%, var(--border));
+}
+.td-status-card--active .td-status-indicator {
+  background: var(--pill-active-d);
+  box-shadow: 0 0 0 3px var(--pill-active-bg);
+}
+.td-status-card--active .td-status-label {
+  color: var(--pill-active-t);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .td-status-card--active .td-status-indicator {
+    animation: td-status-pulse 2.5s ease-in-out infinite;
+  }
+}
+@keyframes td-status-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 3px var(--pill-active-bg);
+  }
+  50% {
+    box-shadow:
+      0 0 0 3px var(--pill-active-bg),
+      0 0 0 6px color-mix(in srgb, var(--pill-active-d) 18%, transparent);
+  }
+}
+.td-status-card--pending_approval {
+  background: color-mix(in srgb, var(--pill-pending-bg) 55%, var(--bg-3));
+  border-color: color-mix(in srgb, var(--pill-pending-d) 32%, var(--border));
+}
+.td-status-card--pending_approval .td-status-indicator {
+  background: var(--pill-pending-d);
+  box-shadow: 0 0 0 3px var(--pill-pending-bg);
+}
+.td-status-card--pending_approval .td-status-label {
+  color: var(--pill-pending-t);
+}
+.td-status-card--blocked {
+  background: color-mix(in srgb, var(--pill-blocked-bg) 55%, var(--bg-3));
+  border-color: color-mix(in srgb, var(--pill-blocked-d) 30%, var(--border));
+}
+.td-status-card--blocked .td-status-indicator {
+  background: var(--pill-blocked-d);
+  box-shadow: 0 0 0 3px var(--pill-blocked-bg);
+}
+.td-status-card--blocked .td-status-label {
+  color: var(--pill-blocked-t);
+}
+.td-status-card--not_started {
+  background: color-mix(in srgb, var(--pill-ns-bg) 70%, var(--bg-3));
+  border-color: var(--border);
+}
+.td-status-card--not_started .td-status-indicator {
+  background: var(--pill-ns-d);
+  box-shadow: 0 0 0 3px var(--pill-ns-bg);
+}
+.td-status-card--not_started .td-status-label {
+  color: var(--t2);
 }
 .td-substatus {
   margin-top: 5px;
-  font-size: 10.5px;
+  font-size: 12px;
+  line-height: 1.4;
   color: var(--t3);
 }
 /* Playbook inline run state */

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -326,6 +326,9 @@ body {
   margin-top: 1px;
   font-style: italic;
 }
+.mx-stage-sub-plain {
+  font-style: normal;
+}
 .mx-stage-pips {
   display: flex;
   gap: 3px;
@@ -379,6 +382,10 @@ body {
   color: var(--t3);
   margin-top: 2px;
   line-height: 1.3;
+  font-style: italic;
+}
+.mx-role-owner-plain {
+  font-style: normal;
 }
 .mx-task-cell {
   width: 192px;
@@ -394,6 +401,73 @@ body {
 }
 .mx-task-cell.has-task:hover {
   background: var(--bg-2);
+}
+.mx-empty-cell {
+  position: relative;
+  height: 100%;
+  min-height: 92px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 7px;
+  border: 1px dashed transparent;
+  transition:
+    background 0.14s,
+    border-color 0.14s,
+    box-shadow 0.14s;
+}
+.mx-task-cell:hover .mx-empty-cell {
+  background: var(--bg-2);
+  border-color: var(--border-hi);
+}
+.mx-add-btn {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 92px;
+  font-size: 0;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--t3);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.14s,
+    color 0.14s,
+    transform 0.14s;
+}
+.mx-add-btn::after {
+  content: "+";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 20px;
+  height: 20px;
+  margin-left: -10px;
+  margin-top: -10px;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  font-weight: 300;
+  line-height: 1;
+}
+.mx-task-cell:hover .mx-add-btn {
+  opacity: 1;
+}
+.mx-add-btn:hover {
+  color: var(--accent);
+  transform: translateY(-1px);
+}
+.mx-add-btn:hover::after {
+  color: var(--accent);
+}
+.mx-add-btn:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* ── Task card ── */
@@ -477,6 +551,7 @@ body {
   display: flex;
   align-items: flex-start;
   gap: 5px;
+  padding-right: 24px;
 }
 .tc-title {
   font-size: 11.5px;
@@ -582,6 +657,43 @@ body {
   justify-content: center;
   flex-shrink: 0;
   box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.15);
+}
+.tc-remove {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(7, 13, 26, 0.72);
+  backdrop-filter: blur(6px);
+  color: var(--t3);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  opacity: 0.92;
+  padding: 0;
+  transition:
+    opacity 0.14s,
+    background 0.14s,
+    border-color 0.14s,
+    color 0.14s;
+}
+.tc-remove:hover {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: #f87171;
+  opacity: 1;
+}
+.tc-remove:focus-visible {
+  outline: 2px solid #f87171;
+  outline-offset: 1px;
 }
 
 /*
@@ -819,8 +931,17 @@ body {
   color: #34d399;
   margin-bottom: 16px;
 }
-/* Agent and playbook rows */
-.td-agent,
+/* Skill card — name only, no min-height needed */
+.td-agent-profile {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+}
+/* Playbook card — keeps min-height to accommodate description */
 .td-playbook {
   display: flex;
   align-items: center;
@@ -831,7 +952,7 @@ body {
   border: 1px solid var(--border);
   min-height: 54px;
 }
-.td-agent-icon,
+.td-agent-profile-icon,
 .td-pb-icon {
   width: 32px;
   height: 32px;
@@ -843,32 +964,26 @@ body {
   flex-shrink: 0;
   font-size: 16px;
 }
-.td-agent-info {
+.td-agent-profile-info,
+.td-pb-info {
   flex: 1;
+  min-width: 0;
 }
-.td-agent-name {
-  font-size: 12.5px;
+.td-agent-profile-name,
+.td-pb-name {
+  font-size: 13px;
   font-weight: 600;
+  font-family: "JetBrains Mono", monospace;
   color: var(--t1);
 }
-.td-agent-skill {
+.td-item-desc {
+  margin-top: 2px;
   font-size: 10.5px;
   color: var(--t3);
-  font-family: "JetBrains Mono", monospace;
-  margin-top: 2px;
+  font-style: italic;
 }
-.td-pb-name {
-  font-size: 12.5px;
-  font-weight: 600;
-  font-family: "JetBrains Mono", monospace;
-  color: var(--accent);
-  flex: 1;
-}
-.td-agent-pulse {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  flex-shrink: 0;
+.td-item-desc-plain {
+  font-style: normal;
 }
 /* Checkpoint notice */
 .td-checkpoint-notice {
@@ -1055,6 +1170,124 @@ body {
   font-size: 11.5px;
   color: var(--t3);
   padding-top: 4px;
+}
+/* Status + Skill two-column row */
+.td-status-skill-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.td-status-pill-xl {
+  height: 32px;
+  padding: 0 14px;
+  gap: 8px;
+}
+.td-status-pill-xl .s-dot {
+  width: 9px;
+  height: 9px;
+}
+.td-status-pill-xl .s-text {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.td-substatus {
+  margin-top: 5px;
+  font-size: 10.5px;
+  color: var(--t3);
+}
+/* Playbook inline run state */
+.td-pb-action {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.td-pb-run-btn {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid var(--border-hi);
+  background: var(--bg-4);
+  color: var(--t3);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.14s;
+  padding: 0;
+}
+.td-pb-run-btn:hover:not(:disabled) {
+  background: var(--primary-bg);
+  border-color: var(--primary);
+  color: var(--accent);
+}
+.td-pb-run-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.td-pb-state-busy,
+.td-pb-state-done,
+.td-pb-state-failed {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.td-pb-state-busy {
+  background: transparent;
+  border: 2.5px solid rgba(16, 185, 129, 0.25);
+  border-top-color: #10b981;
+  animation: ainative-spin 0.85s linear infinite;
+}
+.td-pb-state-done {
+  background: rgba(16, 185, 129, 0.15);
+  color: #34d399;
+}
+.td-pb-state-failed {
+  background: rgba(239, 68, 68, 0.12);
+  color: #f87171;
+}
+@keyframes ainative-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+/* Active playbook card — wave shimmer to signal work in progress */
+.td-playbook-active {
+  cursor: pointer;
+  border-color: var(--border-hi);
+  position: relative;
+  overflow: hidden;
+}
+.td-playbook-active::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 60%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.05) 50%,
+    transparent 100%
+  );
+  animation: ainative-wave 2.4s ease-in-out infinite;
+  pointer-events: none;
+}
+.td-playbook-active:hover {
+  background: var(--bg-4);
+}
+@keyframes ainative-wave {
+  0%   { left: -60%; }
+  100% { left: 140%; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .td-pb-state-busy,
+  .td-playbook-active::after { animation: none; }
 }
 
 /*

--- a/products/dashboard/components/sidebar.tsx
+++ b/products/dashboard/components/sidebar.tsx
@@ -291,7 +291,7 @@ export function Sidebar({
             Workflows
           </span>
           {/*
-           * "+ New workflow" — opens the template editor. PR 12 wires the
+           * "+ New workflow" — opens the template editor. PR 11 wires the
            * actual editor route, but the link is in place so the affordance
            * is keyboard- and screen-reader-reachable today.
            */}

--- a/products/dashboard/components/sidebar.tsx
+++ b/products/dashboard/components/sidebar.tsx
@@ -258,14 +258,21 @@ export function Sidebar({
         >
           <span className="text-[10px] font-bold">AI</span>
         </button>
-        <div data-sidebar-collapsible className="flex flex-1 items-center gap-2 overflow-hidden">
-          <span className="truncate text-[13px] font-bold tracking-tight text-t1">AI-Native</span>
-          <span className="rounded bg-bg-3 px-1.5 py-[2px] font-mono text-[9.5px] text-t3">v0.1</span>
+        <div
+          data-sidebar-collapsible
+          className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden"
+        >
+          <span className="min-w-0 flex-1 truncate text-[13px] font-bold tracking-tight text-t1">
+            AI-Native
+          </span>
+          <span className="shrink-0 rounded bg-bg-3 px-1.5 py-[2px] font-mono text-[9.5px] text-t3">
+            v0.1
+          </span>
           <button
             type="button"
             onClick={toggleCollapsed}
             aria-label="Collapse sidebar"
-            className="ml-auto flex h-[22px] w-[22px] items-center justify-center rounded-[5px] border border-border text-t3 hover:bg-bg-3 hover:text-t1 transition-colors"
+            className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-[5px] border border-border text-t3 hover:bg-bg-3 hover:text-t1 transition-colors"
             title="Collapse"
           >
             <ChevronLeft className="h-3.5 w-3.5" />

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -16,6 +16,8 @@ import { Bell, Pencil } from "lucide-react";
  * Visual contract: prototype `TopBar` (`Process Canvas.html`).
  */
 
+const WORKFLOW_INSTANCE_ROUTE_REGEX = /^\/workflows\/(?!templates(?:\/|$))[^/]+\/?$/;
+
 const ROUTE_LABELS: ReadonlyArray<{ test: (path: string) => boolean; crumbs: string[] }> = [
   { test: (p) => p === "/", crumbs: ["Overview"] },
   { test: (p) => p === "/framework/skills" || p.startsWith("/framework/skills/"), crumbs: ["Skills"] },
@@ -31,8 +33,7 @@ const ROUTE_LABELS: ReadonlyArray<{ test: (path: string) => boolean; crumbs: str
   // they get their own ROUTE_LABELS entry — don't get mis-labelled as
   // an instance crumb.
   {
-    test: (p) =>
-      /^\/workflows\/(?!templates(?:\/|$))[^/]+\/?$/.test(p),
+    test: (p) => WORKFLOW_INSTANCE_ROUTE_REGEX.test(p),
     crumbs: ["Workflows", "Instance"],
   },
 ];
@@ -54,7 +55,7 @@ export function TopBar() {
   const searchParams = useSearchParams();
   const crumbs = deriveCrumbs(pathname);
   const isWorkflowInstanceRoute =
-    !!pathname && /^\/workflows\/(?!templates(?:\/|$))[^/]+\/?$/.test(pathname);
+    !!pathname && WORKFLOW_INSTANCE_ROUTE_REGEX.test(pathname);
   const editMode = searchParams.get("edit") === "1";
 
   function toggleEditMode() {

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { usePathname } from "next/navigation";
-import { Bell } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Bell, Pencil } from "lucide-react";
 
 /**
  * Dashboard top bar.
@@ -25,7 +25,7 @@ const ROUTE_LABELS: ReadonlyArray<{ test: (path: string) => boolean; crumbs: str
   // Workflow instance routes carry the instance label in the page itself,
   // so the breadcrumb stays generic until per-instance metadata is wired.
   // Match exactly one segment after `/workflows/` so sub-routes like
-  // `/workflows/templates/new` (PR12 stub) don't pick up the instance crumb.
+  // `/workflows/templates/new` (PR11 stub) don't pick up the instance crumb.
   // The negative lookahead excludes known reserved roots (currently just
   // `templates`) so future top-level workflow sections — added before
   // they get their own ROUTE_LABELS entry — don't get mis-labelled as
@@ -50,7 +50,24 @@ function deriveCrumbs(pathname: string | null): string[] {
 
 export function TopBar() {
   const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const crumbs = deriveCrumbs(pathname);
+  const isWorkflowInstanceRoute =
+    !!pathname && /^\/workflows\/(?!templates(?:\/|$))[^/]+\/?$/.test(pathname);
+  const editMode = searchParams.get("edit") === "1";
+
+  function toggleEditMode() {
+    if (!pathname) return;
+    const next = new URLSearchParams(searchParams.toString());
+    if (editMode) {
+      next.delete("edit");
+    } else {
+      next.set("edit", "1");
+    }
+    const query = next.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }
 
   return (
     <header className="flex h-[52px] shrink-0 items-center gap-2.5 border-b border-border bg-bg px-5">
@@ -76,6 +93,22 @@ export function TopBar() {
       </nav>
 
       <div className="flex shrink-0 items-center gap-1.5">
+        {isWorkflowInstanceRoute ? (
+          <button
+            type="button"
+            aria-pressed={editMode}
+            onClick={toggleEditMode}
+            title={editMode ? "Finish editing tasks" : "Edit workflow tasks"}
+            className={
+              editMode
+                ? "flex cursor-pointer items-center gap-1.5 rounded-md border border-primary bg-primary-bg px-2.5 py-1.5 text-[11.5px] font-medium text-accent shadow-[inset_0_0_0_1px_rgba(99,102,241,0.08)] transition hover:bg-[rgba(99,102,241,0.16)] hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                : "flex cursor-pointer items-center gap-1.5 rounded-md border border-border bg-bg-2 px-2.5 py-1.5 text-[11.5px] font-medium text-t2 transition hover:border-border-hi hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+            }
+          >
+            <Pencil className="h-3.5 w-3.5" />
+            {editMode ? "Done" : "Edit"}
+          </button>
+        ) : null}
         <button
           type="button"
           disabled

--- a/products/dashboard/components/ui/confirm-modal.tsx
+++ b/products/dashboard/components/ui/confirm-modal.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+interface ConfirmModalProps {
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmModal({
+  title,
+  description,
+  confirmLabel = "Delete",
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-(--overlay) p-4 backdrop-blur-[3px]"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onCancel();
+        }
+      }}
+    >
+      <div
+        className="w-full max-w-[380px] rounded-[14px] border border-border-hi bg-bg-2 p-7 shadow-[var(--shadow-canvas)]"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-modal-title"
+      >
+        <div
+          id="confirm-modal-title"
+          className="text-[16px] font-bold tracking-tight text-[#ef4444]"
+        >
+          {title}
+        </div>
+        <div className="mb-6 mt-1 text-[12.5px] leading-[1.6] text-t3">
+          {description}
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            className="rounded-lg border border-border bg-bg-3 px-4 py-2 text-[13px] font-medium text-t2 transition hover:bg-bg-4 hover:text-t1"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded-lg bg-[#ef4444] px-5 py-2 text-[13px] font-semibold text-white transition hover:opacity-90"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/products/dashboard/components/ui/confirm-modal.tsx
+++ b/products/dashboard/components/ui/confirm-modal.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useId, useRef } from "react";
+
 interface ConfirmModalProps {
   title: string;
   description: string;
@@ -15,6 +17,29 @@ export function ConfirmModal({
   onConfirm,
   onCancel,
 }: ConfirmModalProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    cancelButtonRef.current?.focus();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onCancel();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      previousFocusRef.current?.focus();
+    };
+  }, [onCancel]);
+
   return (
     <div
       className="fixed inset-0 z-[70] flex items-center justify-center bg-(--overlay) p-4 backdrop-blur-[3px]"
@@ -29,20 +54,22 @@ export function ConfirmModal({
         className="w-full max-w-[380px] rounded-[14px] border border-border-hi bg-bg-2 p-7 shadow-[var(--shadow-canvas)]"
         role="dialog"
         aria-modal="true"
-        aria-labelledby="confirm-modal-title"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
       >
         <div
-          id="confirm-modal-title"
+          id={titleId}
           className="text-[16px] font-bold tracking-tight text-[#ef4444]"
         >
           {title}
         </div>
-        <div className="mb-6 mt-1 text-[12.5px] leading-[1.6] text-t3">
+        <div id={descriptionId} className="mb-6 mt-1 text-[12.5px] leading-[1.6] text-t3">
           {description}
         </div>
         <div className="flex justify-end gap-2">
           <button
             type="button"
+            ref={cancelButtonRef}
             className="rounded-lg border border-border bg-bg-3 px-4 py-2 text-[13px] font-medium text-t2 transition hover:bg-bg-4 hover:text-t1"
             onClick={onCancel}
           >

--- a/products/dashboard/components/workflows/add-task-modal.tsx
+++ b/products/dashboard/components/workflows/add-task-modal.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { Search } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { FrameworkItem, WorkflowTaskCreateInput } from "@/lib/workflows/types";
+
+const AGENTS = [
+  ["PM", "pm"],
+  ["Builder", "builder"],
+  ["DevOps", "devops"],
+  ["Designer", "designer"],
+  ["Researcher", "researcher"],
+  ["Project", "project"],
+  ["Sales Ops", "sales-ops"],
+  ["Finance Ops", "finance-ops"],
+  ["Support", "support"],
+  ["QA Engineer", "qa"],
+] as const;
+
+interface AddTaskModalProps {
+  instanceId: string;
+  roleId: string;
+  stageId: string;
+  roleName: string;
+  stageName: string;
+  skillOptions?: FrameworkItem[];
+  playbookOptions?: FrameworkItem[];
+  onClose: () => void;
+  onCreate: (input: WorkflowTaskCreateInput) => void;
+}
+
+interface PickerProps {
+  label: string;
+  emptyLabel: string;
+  searchPlaceholder: string;
+  value: string;
+  options: Array<{ id: string; name: string; description?: string; icon?: string | null }>;
+  onSelect: (value: string) => void;
+}
+
+function SearchablePicker({
+  label,
+  emptyLabel,
+  searchPlaceholder,
+  value,
+  options,
+  onSelect,
+}: PickerProps) {
+  const [query, setQuery] = useState("");
+
+  const filteredOptions = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return options;
+    return options.filter((option) =>
+      [option.name, option.description ?? ""].some((field) =>
+        field.toLowerCase().includes(normalized),
+      ),
+    );
+  }, [options, query]);
+
+  return (
+    <div className="mb-3">
+      <label className="mb-1.5 block text-[11px] font-medium text-t2">{label}</label>
+      <div className="rounded-lg border border-border bg-bg-3">
+        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+          <Search className="h-3.5 w-3.5 text-t3" />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={searchPlaceholder}
+            className="w-full bg-transparent text-[13px] text-t1 placeholder:text-t3 focus:outline-none"
+          />
+        </div>
+
+        <div className="max-h-40 overflow-y-auto p-1.5">
+          <button
+            type="button"
+            onClick={() => onSelect("")}
+            className={cn(
+              "flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12.5px] transition",
+              !value
+                ? "bg-primary-bg text-accent"
+                : "text-t2 hover:bg-bg-4 hover:text-t1",
+            )}
+          >
+            <span className="text-[14px] text-t3">∅</span>
+            <span>{emptyLabel}</span>
+          </button>
+
+          {filteredOptions.map((option) => {
+            const selected = value === option.id;
+            return (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => onSelect(option.id)}
+                className={cn(
+                  "flex w-full items-start gap-2 rounded-md px-2.5 py-2 text-left transition",
+                  selected
+                    ? "bg-primary-bg text-accent"
+                    : "text-t2 hover:bg-bg-4 hover:text-t1",
+                )}
+              >
+                <span className="mt-0.5 text-[14px] text-t3">
+                  {option.icon || "•"}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-[12.5px] font-medium">
+                    {option.name}
+                  </span>
+                  {option.description ? (
+                    <span className="mt-0.5 block truncate text-[10.5px] text-t3">
+                      {option.description}
+                    </span>
+                  ) : null}
+                </span>
+              </button>
+            );
+          })}
+
+          {filteredOptions.length === 0 ? (
+            <div className="px-2.5 py-3 text-[11.5px] text-t3">No matches found.</div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AddTaskModal({
+  instanceId,
+  roleId,
+  stageId,
+  roleName,
+  stageName,
+  skillOptions = [],
+  playbookOptions = [],
+  onClose,
+  onCreate,
+}: AddTaskModalProps) {
+  const [form, setForm] = useState({
+    title: "",
+    description: "",
+    agent: "PM",
+    skill: "pm",
+    playbook: "",
+  });
+
+  const normalizedSkillOptions = useMemo(
+    () =>
+      (skillOptions.length > 0
+        ? skillOptions
+        : AGENTS.map(([name, id]) => ({
+            id,
+            name,
+            description: "Built-in workflow skill",
+            icon: null,
+          }))) as Array<{
+        id: string;
+        name: string;
+        description?: string;
+        icon?: string | null;
+      }>,
+    [skillOptions],
+  );
+
+  const normalizedPlaybookOptions = useMemo(
+    () =>
+      playbookOptions.map((item) => ({
+        id: item.name,
+        name: item.name,
+        description: item.description,
+        icon: item.icon,
+      })),
+    [playbookOptions],
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-(--overlay) p-4 backdrop-blur-[3px]"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        className="w-full max-w-[680px] rounded-[14px] border border-border-hi bg-bg-2 p-7 shadow-[var(--shadow-canvas)]"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-task-modal-title"
+      >
+        <div
+          id="add-task-modal-title"
+          className="text-[16px] font-bold tracking-tight text-t1"
+        >
+          New task
+        </div>
+        <div className="mb-[18px] mt-1 text-[12.5px] text-t3">
+          {roleName} · {stageName}
+        </div>
+
+        <label className="mb-1.5 block text-[11px] font-medium text-t2">Title</label>
+        <input
+          autoFocus
+          className="mb-3 block w-full rounded-lg border border-border bg-bg-3 px-3 py-2.5 text-[13px] text-t1 placeholder:text-t3 focus:border-primary focus:outline-none"
+          placeholder="Task title"
+          value={form.title}
+          onChange={(event) =>
+            setForm((current) => ({ ...current, title: event.target.value }))
+          }
+        />
+
+        <label className="mb-1.5 block text-[11px] font-medium text-t2">
+          Description
+        </label>
+        <input
+          className="mb-3 block w-full rounded-lg border border-border bg-bg-3 px-3 py-2.5 text-[13px] text-t1 placeholder:text-t3 focus:border-primary focus:outline-none"
+          placeholder="Brief description"
+          value={form.description}
+          onChange={(event) =>
+            setForm((current) => ({
+              ...current,
+              description: event.target.value,
+            }))
+          }
+        />
+
+        <div className="mb-3 grid gap-3 md:grid-cols-2">
+          <SearchablePicker
+            label="Agent skill"
+            emptyLabel="No skill"
+            searchPlaceholder="Search skills"
+            value={form.skill}
+            options={normalizedSkillOptions}
+            onSelect={(value) => {
+              const selected = AGENTS.find((agent) => agent[1] === value);
+              const selectedFrameworkSkill = normalizedSkillOptions.find(
+                (option) => option.id === value,
+              );
+              setForm((current) => ({
+                ...current,
+                skill: value,
+                agent: selected?.[0] ?? selectedFrameworkSkill?.name ?? current.agent,
+              }));
+            }}
+          />
+
+          <SearchablePicker
+            label="Playbook"
+            emptyLabel="No playbook"
+            searchPlaceholder="Search playbooks"
+            value={form.playbook}
+            options={normalizedPlaybookOptions}
+            onSelect={(value) =>
+              setForm((current) => ({ ...current, playbook: value }))
+            }
+          />
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            className="rounded-lg border border-border bg-bg-3 px-4 py-2 text-[13px] font-medium text-t2 transition hover:bg-bg-4 hover:text-t1"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="rounded-lg bg-primary px-5 py-2 text-[13px] font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!form.title.trim()}
+            onClick={() => {
+              if (!form.title.trim()) return;
+              onCreate({
+                instanceId,
+                roleId,
+                stageId,
+                title: form.title,
+                description: form.description,
+                agent: form.agent,
+                skill: form.skill,
+                playbook: form.playbook,
+              });
+            }}
+          >
+            Create task →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/products/dashboard/components/workflows/add-task-modal.tsx
+++ b/products/dashboard/components/workflows/add-task-modal.tsx
@@ -141,7 +141,13 @@ export function AddTaskModal({
   onClose,
   onCreate,
 }: AddTaskModalProps) {
-  const [form, setForm] = useState({
+  const [form, setForm] = useState<{
+    title: string;
+    description: string;
+    agent: string | null;
+    skill: string | null;
+    playbook: string;
+  }>({
     title: "",
     description: "",
     agent: "PM",
@@ -235,7 +241,7 @@ export function AddTaskModal({
             label="Agent skill"
             emptyLabel="No skill"
             searchPlaceholder="Search skills"
-            value={form.skill}
+            value={form.skill ?? ""}
             options={normalizedSkillOptions}
             onSelect={(value) => {
               const selected = AGENTS.find((agent) => agent[1] === value);
@@ -244,8 +250,10 @@ export function AddTaskModal({
               );
               setForm((current) => ({
                 ...current,
-                skill: value,
-                agent: selected?.[0] ?? selectedFrameworkSkill?.name ?? current.agent,
+                skill: value || null,
+                agent: value
+                  ? selected?.[0] ?? selectedFrameworkSkill?.name ?? current.agent
+                  : null,
               }));
             }}
           />

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -100,8 +100,24 @@ export function ProcessMatrix({
       apply: (tasks: WorkflowTask[]) => WorkflowTask[],
       commit: () => Promise<WorkflowTask | void>,
     ) => {
-      const previous = localTasks;
-      setLocalTasks(apply(previous));
+      const snapshot = localTasks;
+      const optimistic = apply(snapshot);
+      const snapshotById = new Map(snapshot.map((task) => [task.id, task]));
+      const optimisticById = new Map(optimistic.map((task) => [task.id, task]));
+      const changedTaskIds = new Set<string>();
+
+      for (const task of snapshot) {
+        if (optimisticById.get(task.id) !== task) {
+          changedTaskIds.add(task.id);
+        }
+      }
+      for (const task of optimistic) {
+        if (snapshotById.get(task.id) !== task) {
+          changedTaskIds.add(task.id);
+        }
+      }
+
+      setLocalTasks((current) => apply(current));
 
       startTransition(async () => {
         try {
@@ -114,7 +130,31 @@ export function ProcessMatrix({
             );
           }
         } catch (error) {
-          setLocalTasks(previous);
+          setLocalTasks((current) => {
+            const reverted: WorkflowTask[] = [];
+            const restoredIds = new Set<string>();
+
+            for (const task of current) {
+              if (!changedTaskIds.has(task.id)) {
+                reverted.push(task);
+                continue;
+              }
+
+              const snapshotTask = snapshotById.get(task.id);
+              if (snapshotTask) {
+                reverted.push(snapshotTask);
+                restoredIds.add(task.id);
+              }
+            }
+
+            for (const task of snapshot) {
+              if (changedTaskIds.has(task.id) && !restoredIds.has(task.id)) {
+                reverted.push(task);
+              }
+            }
+
+            return reverted;
+          });
           captureError(error, { feature: "workflows.process_matrix_edit" });
         }
       });

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import { ChevronsLeftRight } from "lucide-react";
 
+import {
+  createTaskAction,
+  deleteTaskAction,
+  moveTaskAction,
+} from "@/app/(dashboard)/workflows/actions";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { captureError } from "@/lib/monitoring";
 import { cn } from "@/lib/utils";
 import { barClass, canStart } from "@/lib/workflows/matrix";
 import { getRoleColor } from "@/lib/workflows/role-colors";
 import type {
+  FrameworkItem,
   WorkflowInstanceDetail,
   WorkflowRole,
   WorkflowStage,
@@ -14,56 +22,49 @@ import type {
   WorkflowTemplate,
 } from "@/lib/workflows/types";
 
+import { AddTaskModal } from "./add-task-modal";
 import { TaskCard } from "./task-card";
 import { TaskDrawer } from "./task-drawer";
 
-/**
- * Read-only Process Matrix.
- *
- * Visual contract: prototype `ProcessMatrix` (`pc-components.jsx`
- * lines 395-541) and the matrix CSS block (`Process Canvas.html`
- * lines 141-218). The structural pieces this PR ships:
- *
- *   - sticky stage header row (top: 0, blurred backdrop)
- *   - sticky `Roles` corner cell (left: 0)
- *   - per-stage pip strip (one pip per task in that stage, tinted by
- *     the task's role colour and dimmed by status)
- *   - sticky role column with a collapse toggle that narrows the
- *     column to a 44px swatch-only rail (label hidden)
- *   - 192px task cells with per-cell border separators
- *
- * Editing affordances (insert role, drag-reorder, add stage, etc.)
- * are intentionally absent for PR 7 — they ship in PR 11. A read-only
- * matrix unblocks the rest of the canvas (drawer, checkpoint panel)
- * without spinning matrix-editor logic into this slice.
- *
- * Roles preference: instance-level role list takes precedence so
- * `WorkflowRepository.createInstance` (which copies template roles
- * into the instance row) is the single source of truth for what the
- * user sees. Falls back to the template's role list if the instance
- * row was somehow seeded without roles.
- */
 interface Props {
   instance: WorkflowInstanceDetail;
-  /** Template the matrix renders against; null = template missing. */
   template: WorkflowTemplate | null;
+  editMode?: boolean;
+  skillOptions?: FrameworkItem[];
+  playbookOptions?: FrameworkItem[];
 }
 
-export function ProcessMatrix({ instance, template }: Props) {
+export function ProcessMatrix({
+  instance,
+  template,
+  editMode = false,
+  skillOptions = [],
+  playbookOptions = [],
+}: Props) {
   const [collapsed, setCollapsed] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
-  // Local optimistic task list so approve/reject update the bar immediately.
-  // Sync from server when instance.tasks changes (e.g. after revalidatePath).
+  const [dragTaskId, setDragTaskId] = useState<string | null>(null);
+  const [dragOverCell, setDragOverCell] = useState<string | null>(null);
+  const [addTaskFor, setAddTaskFor] = useState<{
+    roleId: string;
+    roleName: string;
+    stageId: string;
+    stageName: string;
+  } | null>(null);
+  const [confirmDeleteTask, setConfirmDeleteTask] = useState<WorkflowTask | null>(
+    null,
+  );
   const [localTasks, setLocalTasks] = useState<WorkflowTask[]>(instance.tasks);
-  useEffect(() => { setLocalTasks(instance.tasks); }, [instance.tasks]);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    setLocalTasks(instance.tasks);
+  }, [instance.tasks]);
 
   const handleTaskUpdate = useCallback((updated: WorkflowTask) => {
-    setLocalTasks((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
+    setLocalTasks((prev) => prev.map((task) => (task.id === updated.id ? updated : task)));
   }, []);
 
-  // Derive stages, roles, and the (role, stage) -> task index up
-  // front. The matrix re-renders on every collapse toggle, so we
-  // memoise the lookup map to keep the inner cell loop O(1).
   const stages: WorkflowStage[] = template?.stages ?? [];
   const roles: WorkflowRole[] =
     instance.roles && instance.roles.length > 0
@@ -89,164 +90,319 @@ export function ProcessMatrix({ instance, template }: Props) {
   }, [localTasks]);
 
   const selectedTask = selectedTaskId
-    ? (localTasks.find((t) => t.id === selectedTaskId) ?? null)
+    ? (localTasks.find((task) => task.id === selectedTaskId) ?? null)
     : null;
 
-  // Empty state: a template with no stages OR no roles can't paint a
-  // grid. Render the matrix shell + a friendly placeholder so QA can
-  // still verify the route renders.
   const isEmpty = stages.length === 0 || roles.length === 0;
+
+  const runMutation = useCallback(
+    async (
+      apply: (tasks: WorkflowTask[]) => WorkflowTask[],
+      commit: () => Promise<WorkflowTask | void>,
+    ) => {
+      const previous = localTasks;
+      setLocalTasks(apply(previous));
+
+      startTransition(async () => {
+        try {
+          const result = await commit();
+          if (result) {
+            setLocalTasks((current) =>
+              current.some((task) => task.id === result.id)
+                ? current.map((task) => (task.id === result.id ? result : task))
+                : [...current, result],
+            );
+          }
+        } catch (error) {
+          setLocalTasks(previous);
+          captureError(error, { feature: "workflows.process_matrix_edit" });
+        }
+      });
+    },
+    [localTasks],
+  );
 
   return (
     <>
       <div
         data-testid="process-matrix"
         data-collapsed={collapsed ? "true" : "false"}
-        className={cn(
-          "matrix-wrap",
-          collapsed && "roles-collapsed",
-        )}
-    >
-      <div
-        className="matrix"
-        role="table"
-        aria-label="Workflow process matrix"
+        className={cn("matrix-wrap", collapsed && "roles-collapsed")}
       >
-        <div className="matrix-head-row" role="row">
-          <div className="mx-corner" role="columnheader">
-            {!collapsed && <span className="flex-1">Roles</span>}
-            <button
-              type="button"
-              data-testid="matrix-roles-toggle"
-              aria-pressed={collapsed}
-              aria-label={collapsed ? "Expand role labels" : "Collapse role labels"}
-              title={collapsed ? "Expand role labels" : "Collapse role labels"}
-              onClick={() => setCollapsed((value) => !value)}
-              className="mx-corner-toggle"
-              style={collapsed ? { marginLeft: 0 } : undefined}
-            >
-              <ChevronsLeftRight aria-hidden size={11} />
-            </button>
-          </div>
-          {stages.map((stage) => {
-            const stageTasks = tasksByStage.get(stage.id) ?? [];
-            return (
-              <div
-                key={stage.id}
-                role="columnheader"
-                className="mx-stage-hd"
-                data-testid={`matrix-stage-${stage.id}`}
+        <div className="matrix" role="table" aria-label="Workflow process matrix">
+          <div className="matrix-head-row" role="row">
+            <div className="mx-corner" role="columnheader">
+              {!collapsed && <span className="flex-1">Roles</span>}
+              <button
+                type="button"
+                data-testid="matrix-roles-toggle"
+                aria-pressed={collapsed}
+                aria-label={collapsed ? "Expand role labels" : "Collapse role labels"}
+                title={collapsed ? "Expand role labels" : "Collapse role labels"}
+                onClick={() => setCollapsed((value) => !value)}
+                className="mx-corner-toggle"
+                style={collapsed ? { marginLeft: 0 } : undefined}
               >
-                <div className="mx-stage-name">{stage.label}</div>
-                {stage.sub ? (
-                  <div className="mx-stage-sub">{stage.sub}</div>
-                ) : null}
-                {stageTasks.length > 0 && (
-                  <div className="mx-stage-pips" aria-hidden>
-                    {stageTasks.map((task) => {
-                      const color = getRoleColor(task.roleId, roles);
-                      const opacity =
-                        task.status === "not_started"
-                          ? 0.2
-                          : task.status === "complete"
-                            ? 0.5
-                            : 1;
-                      return (
-                        <div
-                          key={task.id}
-                          data-testid={`matrix-pip-${task.id}`}
-                          className="mx-pip"
-                          style={{ background: color, opacity }}
-                        />
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-
-        {isEmpty ? (
-          <div role="row" data-testid="matrix-empty" className="border-t border-border-2">
-            <div
-              role="cell"
-              aria-colspan={Math.max(1, 1 + stages.length)}
-              className="px-4 py-6 text-center text-[12px] text-t2"
-            >
-              {template
-                ? "This workflow has no stages or roles defined yet."
-                : "The template that defines this workflow is no longer available."}
+                <ChevronsLeftRight aria-hidden size={11} />
+              </button>
             </div>
-          </div>
-        ) : (
-          roles.map((role) => {
-            const roleColor = getRoleColor(role.id, roles);
-            return (
-              <div
-                key={role.id}
-                role="row"
-                className="mx-body-row"
-                data-testid={`matrix-role-row-${role.id}`}
-              >
-                <div className="mx-role-cell" role="rowheader">
-                  <span
-                    aria-hidden
-                    data-testid={`matrix-role-dot-${role.id}`}
-                    className="block h-2 w-2 shrink-0 rounded-full"
-                    style={{ background: roleColor }}
-                  />
-                  {!collapsed && (
-                    <div
-                      className="min-w-0 flex-1"
-                      data-testid={`matrix-role-label-${role.id}`}
-                    >
-                      <div className="mx-role-name">{role.label}</div>
-                      {role.owner ? (
-                        <div className="mx-role-owner">{role.owner}</div>
-                      ) : null}
-                    </div>
-                  )}
-                </div>
-                {stages.map((stage) => {
-                  const task = tasksByCell.get(`${role.id}::${stage.id}`);
-                  return (
-                    <div
-                      key={`${role.id}-${stage.id}`}
-                      role="cell"
-                      data-testid={`matrix-cell-${role.id}-${stage.id}`}
-                      className={cn(
-                        "mx-task-cell",
-                        task ? "has-task" : undefined,
-                      )}
-                    >
-                      {task ? (
-                        <TaskCard
-                          task={task}
-                          roleColor={roleColor}
-                          barState={barClass(task, canStart(task, localTasks))}
-                          onClick={() => setSelectedTaskId(task.id)}
-                        />
-                      ) : null}
-                    </div>
-                  );
-                })}
-              </div>
-            );
-          })
-        )}
-      </div>
-    </div>
 
-    <TaskDrawer
-      task={selectedTask}
-      instance={instance}
-      roles={roles}
-      template={template}
-      onClose={() => setSelectedTaskId(null)}
-      onTaskUpdate={handleTaskUpdate}
-    />
-  </>
+            {stages.map((stage) => {
+              const stageTasks = tasksByStage.get(stage.id) ?? [];
+              return (
+                <div
+                  key={stage.id}
+                  role="columnheader"
+                  className="mx-stage-hd"
+                  data-testid={`matrix-stage-${stage.id}`}
+                >
+                  <div className="mx-stage-name">{stage.label}</div>
+                  <div className={cn("mx-stage-sub", stage.sub?.trim() && "mx-stage-sub-plain")}>
+                    {stage.sub?.trim() || "No description"}
+                  </div>
+                  {stageTasks.length > 0 ? (
+                    <div className="mx-stage-pips" aria-hidden>
+                      {stageTasks.map((task) => {
+                        const color = getRoleColor(task.roleId, roles);
+                        const opacity =
+                          task.status === "not_started"
+                            ? 0.2
+                            : task.status === "complete"
+                              ? 0.5
+                              : 1;
+                        return (
+                          <div
+                            key={task.id}
+                            data-testid={`matrix-pip-${task.id}`}
+                            className="mx-pip"
+                            style={{ background: color, opacity }}
+                          />
+                        );
+                      })}
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+
+          {isEmpty ? (
+            <div role="row" data-testid="matrix-empty" className="border-t border-border-2">
+              <div
+                role="cell"
+                aria-colspan={Math.max(1, 1 + stages.length)}
+                className="px-4 py-6 text-center text-[12px] text-t2"
+              >
+                {template
+                  ? "This workflow has no stages or roles defined yet."
+                  : "The template that defines this workflow is no longer available."}
+              </div>
+            </div>
+          ) : (
+            roles.map((role) => {
+              const roleColor = getRoleColor(role.id, roles);
+              return (
+                <div
+                  key={role.id}
+                  role="row"
+                  className="mx-body-row"
+                  data-testid={`matrix-role-row-${role.id}`}
+                >
+                  <div className="mx-role-cell" role="rowheader">
+                    <span
+                      aria-hidden
+                      data-testid={`matrix-role-dot-${role.id}`}
+                      className="block h-2 w-2 shrink-0 rounded-full"
+                      style={{ background: roleColor }}
+                    />
+                    {!collapsed ? (
+                      <div
+                        className="min-w-0 flex-1"
+                        data-testid={`matrix-role-label-${role.id}`}
+                      >
+                        <div className="mx-role-name">{role.label}</div>
+                        <div className={cn("mx-role-owner", role.owner?.trim() && "mx-role-owner-plain")}>
+                          {role.owner?.trim() || "No description"}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+
+                  {stages.map((stage) => {
+                    const cellKey = `${role.id}-${stage.id}`;
+                    const task = tasksByCell.get(`${role.id}::${stage.id}`);
+
+                    return (
+                      <div
+                        key={cellKey}
+                        role="cell"
+                        data-testid={`matrix-cell-${role.id}-${stage.id}`}
+                        className={cn(
+                          "mx-task-cell",
+                          task && "has-task",
+                          dragOverCell === cellKey && "drag-over-cell",
+                        )}
+                        onDragOver={
+                          editMode
+                            ? (event) => {
+                                if (!dragTaskId || task) return;
+                                event.preventDefault();
+                                setDragOverCell(cellKey);
+                              }
+                            : undefined
+                        }
+                        onDragLeave={
+                          editMode
+                            ? () => {
+                                setDragOverCell((current) =>
+                                  current === cellKey ? null : current,
+                                );
+                              }
+                            : undefined
+                        }
+                        onDrop={
+                          editMode
+                            ? (event) => {
+                                event.preventDefault();
+                                const droppedTaskId =
+                                  event.dataTransfer.getData("taskId") || dragTaskId;
+                                setDragTaskId(null);
+                                setDragOverCell(null);
+                                if (!droppedTaskId || task) return;
+
+                                runMutation(
+                                  (tasks) =>
+                                    tasks.map((item) =>
+                                      item.id === droppedTaskId
+                                        ? { ...item, roleId: role.id, stageId: stage.id }
+                                        : item,
+                                    ),
+                                  async () => {
+                                    const result = await moveTaskAction(
+                                      droppedTaskId,
+                                      role.id,
+                                      stage.id,
+                                    );
+                                    return result.task;
+                                  },
+                                );
+                              }
+                            : undefined
+                        }
+                      >
+                        {task ? (
+                          <TaskCard
+                            task={task}
+                            roleColor={roleColor}
+                            barState={barClass(task, canStart(task, localTasks))}
+                            editMode={editMode}
+                            draggable
+                            onClick={() => setSelectedTaskId(task.id)}
+                            onRemove={
+                              editMode ? () => setConfirmDeleteTask(task) : undefined
+                            }
+                            onDragStart={
+                              editMode
+                                ? (event) => {
+                                    event.dataTransfer.setData("taskId", task.id);
+                                    setDragTaskId(task.id);
+                                  }
+                                : undefined
+                            }
+                            onDragEnd={
+                              editMode
+                                ? () => {
+                                    setDragTaskId(null);
+                                    setDragOverCell(null);
+                                  }
+                                : undefined
+                            }
+                          />
+                        ) : editMode ? (
+                          <div
+                            className="mx-empty-cell"
+                            onClick={() =>
+                              setAddTaskFor({
+                                roleId: role.id,
+                                roleName: role.label,
+                                stageId: stage.id,
+                                stageName: stage.label,
+                              })
+                            }
+                          >
+                            <button
+                              type="button"
+                              className="mx-add-btn"
+                              data-testid={`matrix-add-task-${role.id}-${stage.id}`}
+                              aria-label={`Add task for ${role.label} in ${stage.label}`}
+                            >
+                              +
+                            </button>
+                          </div>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+
+      <TaskDrawer
+        task={selectedTask}
+        instance={instance}
+        roles={roles}
+        template={template}
+        skillOptions={skillOptions}
+        playbookOptions={playbookOptions}
+        onClose={() => setSelectedTaskId(null)}
+        onTaskUpdate={handleTaskUpdate}
+      />
+
+      {addTaskFor ? (
+        <AddTaskModal
+          instanceId={instance.id}
+          roleId={addTaskFor.roleId}
+          roleName={addTaskFor.roleName}
+          stageId={addTaskFor.stageId}
+          stageName={addTaskFor.stageName}
+          skillOptions={skillOptions}
+          playbookOptions={playbookOptions}
+          onClose={() => setAddTaskFor(null)}
+          onCreate={(input) => {
+            setAddTaskFor(null);
+            runMutation(
+              (tasks) => tasks,
+              async () => {
+                const result = await createTaskAction(input);
+                return result.task;
+              },
+            );
+          }}
+        />
+      ) : null}
+
+      {confirmDeleteTask ? (
+        <ConfirmModal
+          title={`Delete "${confirmDeleteTask.title}"?`}
+          description="This task and its configuration will be deleted from this instance."
+          onCancel={() => setConfirmDeleteTask(null)}
+          onConfirm={() => {
+            const task = confirmDeleteTask;
+            setConfirmDeleteTask(null);
+            runMutation(
+              (tasks) => tasks.filter((item) => item.id !== task.id),
+              async () => {
+                await deleteTaskAction(task.id);
+              },
+            );
+          }}
+        />
+      ) : null}
+
+      {isPending ? <span className="sr-only">Saving workflow edits</span> : null}
+    </>
   );
 }
-

--- a/products/dashboard/components/workflows/sidebar-workflow-tree.tsx
+++ b/products/dashboard/components/workflows/sidebar-workflow-tree.tsx
@@ -318,7 +318,7 @@ export function SidebarWorkflowTree({ templates, instancesByTemplate }: Props) {
                 {/* Count pill — number by default, pen icon on hover.
                     Mirrors prototype's `pt-count-pill`/`pt-count-edit`
                     pair (lines 86-90). The pen click navigates to the
-                    template-editor stub (PR 12 wires the real route). */}
+                    template-editor stub (PR 11 wires the real route). */}
                 <Link
                   href={`/workflows/templates/${template.id}/edit`}
                   onClick={(e) => e.stopPropagation()}

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -32,7 +32,7 @@ const STATUS_LABEL: Record<WorkflowTask["status"], string> = {
   complete: "Complete",
   active: "In progress",
   pending_approval: "Pending approval",
-  blocked: "Blocked",
+  blocked: "Failed",
   not_started: "Not started",
 };
 

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -30,7 +30,7 @@ import type { WorkflowTask } from "@/lib/workflows/types";
 
 const STATUS_LABEL: Record<WorkflowTask["status"], string> = {
   complete: "Complete",
-  active: "Active",
+  active: "In progress",
   pending_approval: "Pending approval",
   blocked: "Blocked",
   not_started: "Not started",

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import type { TaskBarState } from "@/lib/workflows/matrix";
@@ -52,9 +52,24 @@ export interface TaskCardProps {
   barState: TaskBarState;
   /** Opens the Task Drawer for this card. */
   onClick?: () => void;
+  editMode?: boolean;
+  onRemove?: () => void;
+  draggable?: boolean;
+  onDragStart?: React.DragEventHandler<HTMLDivElement>;
+  onDragEnd?: React.DragEventHandler<HTMLDivElement>;
 }
 
-export function TaskCard({ task, roleColor, barState, onClick }: TaskCardProps) {
+export function TaskCard({
+  task,
+  roleColor,
+  barState,
+  onClick,
+  editMode = false,
+  onRemove,
+  draggable = false,
+  onDragStart,
+  onDragEnd,
+}: TaskCardProps) {
   const statusClass = STATUS_PILL_CLASS[task.status];
   const statusLabel = STATUS_LABEL[task.status];
 
@@ -65,6 +80,9 @@ export function TaskCard({ task, roleColor, barState, onClick }: TaskCardProps) 
       data-status={task.status}
       className={cn("task-card", statusClass, barState, onClick && "cursor-pointer")}
       style={{ "--role-color": roleColor } as React.CSSProperties}
+      draggable={editMode && draggable}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
       onClick={onClick}
       role={onClick ? "button" : undefined}
       tabIndex={onClick ? 0 : undefined}
@@ -80,6 +98,19 @@ export function TaskCard({ task, roleColor, barState, onClick }: TaskCardProps) 
       }
       aria-label={onClick ? `Open task: ${task.title}` : undefined}
     >
+      {editMode ? (
+        <button
+          type="button"
+          className="tc-remove"
+          aria-label={`Remove task: ${task.title}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onRemove?.();
+          }}
+        >
+          <X aria-hidden size={11} strokeWidth={2.2} />
+        </button>
+      ) : null}
       <div className="tc-top">
         <div className="tc-title">{task.title}</div>
         {task.checkpoint && (

--- a/products/dashboard/components/workflows/task-drawer.tsx
+++ b/products/dashboard/components/workflows/task-drawer.tsx
@@ -153,18 +153,10 @@ function TriggerGateEditor({ items, kind, disabled, onChange }: TriggerGateEdito
 
 const STATUS_LABELS: Record<WorkflowTask["status"], string> = {
   complete: "Complete",
-  active: "Active",
+  active: "In progress",
   pending_approval: "Pending approval",
   blocked: "Blocked",
   not_started: "Not started",
-};
-
-const STATUS_PILL_CLASS: Record<WorkflowTask["status"], string> = {
-  complete: "s-complete",
-  active: "s-active",
-  pending_approval: "s-pending",
-  blocked: "s-blocked",
-  not_started: "s-not_started",
 };
 
 interface DetailsTabProps {
@@ -211,21 +203,24 @@ function DetailsTab({
     <>
       {/* 1. Status + Skill — two columns */}
       <div className="td-status-skill-row td-sec">
-        <div className="td-status-col" data-testid="td-status-card">
+        <div className="td-status-col">
           <div className="td-sec-lbl">Status</div>
-          <div className={STATUS_PILL_CLASS[task.status]}>
-            <div className="s-pill td-status-pill-xl">
-              <div className="s-dot" aria-hidden />
-              <div className="s-text">{STATUS_LABELS[task.status]}</div>
+          <div
+            className={cn("td-status-card", `td-status-card--${task.status}`)}
+            data-testid="td-status-card"
+          >
+            <span className="td-status-indicator" aria-hidden />
+            <div className="td-status-copy">
+              <div className="td-status-label">{STATUS_LABELS[task.status]}</div>
+              {task.substatus ? (
+                <div className="td-substatus">{task.substatus}</div>
+              ) : null}
             </div>
           </div>
-          {task.substatus && (
-            <div className="td-substatus">{task.substatus}</div>
-          )}
         </div>
 
         {(task.agent ?? task.skill) && (
-          <div>
+          <div className="td-skill-col">
             <div className="td-sec-lbl">Skill</div>
             <div className="td-agent-profile">
               <div className="td-agent-profile-icon">{skillIcon}</div>

--- a/products/dashboard/components/workflows/task-drawer.tsx
+++ b/products/dashboard/components/workflows/task-drawer.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState, useTransition } from "react";
-import { BookOpen, Check, Play, X, XCircle } from "lucide-react";
+import { BookOpen, Check, CircleAlert, Play, RotateCw, Square, X } from "lucide-react";
 
 import { captureError } from "@/lib/monitoring";
 import { emitEvent } from "@/lib/events";
 import { cn } from "@/lib/utils";
-import { getRoleColor } from "@/lib/workflows/role-colors";
 import type {
   FrameworkItem,
   WorkflowEvent,
@@ -19,7 +18,9 @@ import type {
 } from "@/lib/workflows/types";
 import {
   approveDrawerCheckpointAction,
+  cancelRunningTaskAction,
   rejectDrawerCheckpointAction,
+  retryBlockedTaskAction,
   startTaskAction,
   updateTaskTriggerGatesAction,
 } from "@/app/(dashboard)/workflows/actions";
@@ -155,7 +156,7 @@ const STATUS_LABELS: Record<WorkflowTask["status"], string> = {
   complete: "Complete",
   active: "In progress",
   pending_approval: "Pending approval",
-  blocked: "Blocked",
+  blocked: "Failed",
   not_started: "Not started",
 };
 
@@ -166,10 +167,14 @@ interface DetailsTabProps {
   playbookOptions: FrameworkItem[];
   isPending: boolean;
   onStart: () => void;
+  onCancelRun: () => void;
+  onRetryRun: () => void;
   onApprove: () => void;
   onReject: () => void;
   onTriggersChange: (triggers: WorkflowTrigger[]) => void;
   onGatesChange: (gates: WorkflowGate[]) => void;
+  /** Playbook row (post–not_started) — opens chat/prompt when wired. */
+  onOpenPlaybookPrompt?: () => void;
 }
 
 function DetailsTab({
@@ -179,15 +184,18 @@ function DetailsTab({
   playbookOptions,
   isPending,
   onStart,
+  onCancelRun,
+  onRetryRun,
   onApprove,
   onReject,
   onTriggersChange,
   onGatesChange,
+  onOpenPlaybookPrompt,
 }: DetailsTabProps) {
   const isPendingApproval = task.status === "pending_approval";
   const isActive = task.status === "active";
   const isNotStarted = task.status === "not_started";
-  const roleColor = getRoleColor(task.roleId, roles);
+  const playbookCardClickable = !isNotStarted;
   const skillIcon = task.skill ? (SKILL_ICONS[task.skill] ?? "🤖") : "🤖";
   const skillItem = task.skill
     ? skillOptions.find((item) => item.name === task.skill || item.id === task.skill)
@@ -273,12 +281,40 @@ function DetailsTab({
         <div className="td-sec">
           <div className="td-sec-lbl">Playbook</div>
           <div
-            className={cn("td-playbook", isActive && "td-playbook-active")}
-            role={isActive ? "button" : undefined}
-            tabIndex={isActive ? 0 : undefined}
-            aria-label={isActive ? "View live run" : undefined}
-            title={isActive ? "Live run view coming in PR 10" : undefined}
-            data-testid={isActive ? "td-view-run-btn" : undefined}
+            className={cn(
+              "td-playbook",
+              `td-playbook--${task.status}`,
+              isActive && "td-playbook-active",
+              playbookCardClickable && "td-playbook-clickable",
+            )}
+            data-testid="td-playbook-card"
+            role={playbookCardClickable ? "button" : undefined}
+            tabIndex={playbookCardClickable ? 0 : undefined}
+            aria-label={playbookCardClickable ? "Open playbook chat" : undefined}
+            title={
+              playbookCardClickable
+                ? isActive
+                  ? "Open playbook chat — live run surface ships in a later release"
+                  : "Open playbook chat"
+                : undefined
+            }
+            onClick={
+              playbookCardClickable
+                ? () => {
+                    onOpenPlaybookPrompt?.();
+                  }
+                : undefined
+            }
+            onKeyDown={
+              playbookCardClickable
+                ? (e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onOpenPlaybookPrompt?.();
+                    }
+                  }
+                : undefined
+            }
           >
             <div className="td-pb-icon">
               {playbookItem?.icon ? (
@@ -306,13 +342,32 @@ function DetailsTab({
                   disabled={isPending}
                   aria-label="Start playbook"
                   data-testid="td-start-btn"
-                  onClick={onStart}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onStart();
+                  }}
                 >
                   <Play size={9} aria-hidden />
                 </button>
               )}
               {isActive && (
-                <div className="td-pb-state-busy" aria-label="Running" />
+                <div className="td-pb-busy-wrap">
+                  <div className="td-pb-state-busy" aria-hidden />
+                  <button
+                    type="button"
+                    className="td-pb-stop-btn"
+                    disabled={isPending}
+                    aria-label="Stop and cancel run"
+                    title="Stop and cancel run"
+                    data-testid="td-pb-stop-run-btn"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onCancelRun();
+                    }}
+                  >
+                    <Square size={9} fill="currentColor" aria-hidden />
+                  </button>
+                </div>
               )}
               {task.status === "complete" && (
                 <div className="td-pb-state-done" aria-label="Done">
@@ -320,8 +375,24 @@ function DetailsTab({
                 </div>
               )}
               {task.status === "blocked" && (
-                <div className="td-pb-state-failed" aria-label="Failed">
-                  <XCircle size={10} aria-hidden />
+                <div className="td-pb-failed-wrap" aria-label="Failed">
+                  <div className="td-pb-failed-icon">
+                    <CircleAlert size={16} strokeWidth={2.25} aria-hidden />
+                  </div>
+                  <button
+                    type="button"
+                    className="td-pb-retry-btn"
+                    disabled={isPending}
+                    aria-label="Retry playbook run"
+                    title="Retry playbook run"
+                    data-testid="td-pb-retry-run-btn"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRetryRun();
+                    }}
+                  >
+                    <RotateCw size={11} strokeWidth={2.25} aria-hidden />
+                  </button>
                 </div>
               )}
             </div>
@@ -409,6 +480,11 @@ export interface TaskDrawerProps {
   playbookOptions?: FrameworkItem[];
   onClose: () => void;
   onTaskUpdate: (task: WorkflowTask) => void;
+  /**
+   * Invoked when the user activates the playbook row (any status except
+   * `not_started`) to open the agent chat / prompt surface (implemented later).
+   */
+  onOpenPlaybookPrompt?: () => void;
 }
 
 export function TaskDrawer({
@@ -420,6 +496,7 @@ export function TaskDrawer({
   playbookOptions = [],
   onClose,
   onTaskUpdate,
+  onOpenPlaybookPrompt,
 }: TaskDrawerProps) {
   const [activeTab, setActiveTab] = useState<DrawerTab>("details");
   const [isPending, startTransition] = useTransition();
@@ -466,6 +543,38 @@ export function TaskDrawer({
         });
       } catch (err) {
         captureError(err, { feature: "workflows.start_task", extra: { task_id: task.id } });
+      }
+    });
+  }
+
+  function handleCancelRun() {
+    if (!task) return;
+    startTransition(async () => {
+      try {
+        const { task: updated } = await cancelRunningTaskAction(task.id);
+        onTaskUpdate(updated);
+        emitEvent("workflow.run_cancelled", {
+          task_id: task.id,
+          instance_id: task.instanceId,
+        });
+      } catch (err) {
+        captureError(err, { feature: "workflows.cancel_run", extra: { task_id: task.id } });
+      }
+    });
+  }
+
+  function handleRetryRun() {
+    if (!task) return;
+    startTransition(async () => {
+      try {
+        const { task: updated } = await retryBlockedTaskAction(task.id);
+        onTaskUpdate(updated);
+        emitEvent("workflow.run_retried", {
+          task_id: task.id,
+          instance_id: task.instanceId,
+        });
+      } catch (err) {
+        captureError(err, { feature: "workflows.retry_run", extra: { task_id: task.id } });
       }
     });
   }
@@ -613,10 +722,13 @@ export function TaskDrawer({
               playbookOptions={playbookOptions}
               isPending={isPending}
               onStart={handleStart}
+              onCancelRun={handleCancelRun}
+              onRetryRun={handleRetryRun}
               onApprove={handleApprove}
               onReject={handleReject}
               onTriggersChange={handleTriggersChange}
               onGatesChange={handleGatesChange}
+              onOpenPlaybookPrompt={onOpenPlaybookPrompt}
             />
           )}
           {activeTab === "events" && <EventsTab events={taskEvents} />}

--- a/products/dashboard/components/workflows/task-drawer.tsx
+++ b/products/dashboard/components/workflows/task-drawer.tsx
@@ -195,7 +195,8 @@ function DetailsTab({
   const isPendingApproval = task.status === "pending_approval";
   const isActive = task.status === "active";
   const isNotStarted = task.status === "not_started";
-  const playbookCardClickable = !isNotStarted;
+  const playbookCardClickable =
+    !isNotStarted && typeof onOpenPlaybookPrompt === "function";
   const skillIcon = task.skill ? (SKILL_ICONS[task.skill] ?? "🤖") : "🤖";
   const skillItem = task.skill
     ? skillOptions.find((item) => item.name === task.skill || item.id === task.skill)

--- a/products/dashboard/components/workflows/task-drawer.tsx
+++ b/products/dashboard/components/workflows/task-drawer.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useEffect, useRef, useState, useTransition } from "react";
-import { BookOpen, X } from "lucide-react";
+import { BookOpen, Check, Play, X, XCircle } from "lucide-react";
 
 import { captureError } from "@/lib/monitoring";
 import { emitEvent } from "@/lib/events";
 import { cn } from "@/lib/utils";
 import { getRoleColor } from "@/lib/workflows/role-colors";
 import type {
+  FrameworkItem,
   WorkflowEvent,
   WorkflowGate,
   WorkflowInstanceDetail,
@@ -19,6 +20,7 @@ import type {
 import {
   approveDrawerCheckpointAction,
   rejectDrawerCheckpointAction,
+  startTaskAction,
   updateTaskTriggerGatesAction,
 } from "@/app/(dashboard)/workflows/actions";
 
@@ -168,7 +170,10 @@ const STATUS_PILL_CLASS: Record<WorkflowTask["status"], string> = {
 interface DetailsTabProps {
   task: WorkflowTask;
   roles: WorkflowRole[];
+  skillOptions: FrameworkItem[];
+  playbookOptions: FrameworkItem[];
   isPending: boolean;
+  onStart: () => void;
   onApprove: () => void;
   onReject: () => void;
   onTriggersChange: (triggers: WorkflowTrigger[]) => void;
@@ -178,7 +183,10 @@ interface DetailsTabProps {
 function DetailsTab({
   task,
   roles,
+  skillOptions,
+  playbookOptions,
   isPending,
+  onStart,
   onApprove,
   onReject,
   onTriggersChange,
@@ -189,84 +197,71 @@ function DetailsTab({
   const isNotStarted = task.status === "not_started";
   const roleColor = getRoleColor(task.roleId, roles);
   const skillIcon = task.skill ? (SKILL_ICONS[task.skill] ?? "🤖") : "🤖";
+  const skillItem = task.skill
+    ? skillOptions.find((item) => item.name === task.skill || item.id === task.skill)
+    : null;
+  const playbookItem = task.playbook
+    ? playbookOptions.find(
+        (item) => item.name === task.playbook || item.id === task.playbook,
+      )
+    : null;
+  const playbookDescription = playbookItem?.description?.trim();
 
   return (
     <>
-      {/* PRIMARY ACTION at top — mirrors prototype `.dr-action-top` */}
-      {(isPendingApproval || isActive || isNotStarted) && (
+      {/* 1. Status + Skill — two columns */}
+      <div className="td-status-skill-row td-sec">
+        <div className="td-status-col" data-testid="td-status-card">
+          <div className="td-sec-lbl">Status</div>
+          <div className={STATUS_PILL_CLASS[task.status]}>
+            <div className="s-pill td-status-pill-xl">
+              <div className="s-dot" aria-hidden />
+              <div className="s-text">{STATUS_LABELS[task.status]}</div>
+            </div>
+          </div>
+          {task.substatus && (
+            <div className="td-substatus">{task.substatus}</div>
+          )}
+        </div>
+
+        {(task.agent ?? task.skill) && (
+          <div>
+            <div className="td-sec-lbl">Skill</div>
+            <div className="td-agent-profile">
+              <div className="td-agent-profile-icon">{skillIcon}</div>
+              <div className="td-agent-profile-info">
+                <div className="td-agent-profile-name">
+                  {skillItem?.name ?? task.skill ?? task.agent}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Approve / reject card — only for pending_approval */}
+      {isPendingApproval && (
         <div className="td-action-top" data-testid="td-action-card">
-          {isPendingApproval && (
-            <>
-              <button
-                type="button"
-                className="td-btn td-btn-approve"
-                disabled={isPending}
-                onClick={onApprove}
-                data-testid="td-approve-btn"
-              >
-                ✓ Approve &amp; continue
-              </button>
-              <button
-                type="button"
-                className="td-btn td-btn-ghost"
-                disabled={isPending}
-                onClick={onReject}
-                data-testid="td-reject-btn"
-              >
-                Reject
-              </button>
-            </>
-          )}
-          {isActive && (
-            <button
-              type="button"
-              className="td-btn td-btn-run"
-              disabled
-              title="Live run view coming in PR 10"
-              data-testid="td-view-run-btn"
-            >
-              View live run
-            </button>
-          )}
-          {isNotStarted && (
-            <button
-              type="button"
-              className="td-btn td-btn-primary"
-              disabled
-              title="Manual start coming in PR 10"
-              data-testid="td-start-btn"
-            >
-              ▶ Start agent
-            </button>
-          )}
+          <button
+            type="button"
+            className="td-btn td-btn-approve"
+            disabled={isPending}
+            onClick={onApprove}
+            data-testid="td-approve-btn"
+          >
+            ✓ Approve &amp; continue
+          </button>
+          <button
+            type="button"
+            className="td-btn td-btn-ghost"
+            disabled={isPending}
+            onClick={onReject}
+            data-testid="td-reject-btn"
+          >
+            Reject
+          </button>
         </div>
       )}
-
-      {/* Status */}
-      <div className="td-sec">
-        <div className="td-sec-lbl">Status</div>
-        <div
-          style={{
-            padding: "9px 12px",
-            borderRadius: 7,
-            background: "var(--bg-3)",
-            border: "1px solid var(--border)",
-            borderLeft: `2px solid ${roleColor}`,
-            fontSize: "11.5px",
-            color: "var(--t2)",
-          }}
-          data-testid="td-status-card"
-        >
-          <div
-            className={cn("s-pill", STATUS_PILL_CLASS[task.status])}
-            style={{ marginBottom: 4 }}
-          >
-            <div className="s-dot" aria-hidden />
-            <div className="s-text">{STATUS_LABELS[task.status]}</div>
-          </div>
-          {task.substatus && <div>{task.substatus}</div>}
-        </div>
-      </div>
 
       {/* Checkpoint notice */}
       {task.checkpoint && isPendingApproval && (
@@ -278,49 +273,63 @@ function DetailsTab({
         </div>
       )}
 
-      {/* Skills */}
-      {(task.agent ?? task.skill) && (
-        <div className="td-sec">
-          <div className="td-sec-lbl">Skills</div>
-          <div className="td-agent">
-            <div className="td-agent-icon">{skillIcon}</div>
-            <div className="td-agent-info">
-              <div className="td-agent-name">
-                {task.agent ? `${task.agent} Agent` : "Agent"}
-              </div>
-              {task.skill && (
-                <div className="td-agent-skill">{task.skill}</div>
-              )}
-            </div>
-            <div
-              className="td-agent-pulse"
-              style={{
-                background: isActive
-                  ? "#10b981"
-                  : isPendingApproval
-                    ? "#f59e0b"
-                    : "var(--border)",
-                boxShadow: isActive
-                  ? "0 0 6px rgba(16,185,129,0.5)"
-                  : isPendingApproval
-                    ? "0 0 6px rgba(245,158,11,0.4)"
-                    : "none",
-              }}
-              aria-hidden
-            />
-          </div>
-        </div>
-      )}
-
-      {/* Playbook */}
+      {/* 3. Playbook — what is being run, with inline run state */}
       {task.playbook && (
         <div className="td-sec">
           <div className="td-sec-lbl">Playbook</div>
-          <div className="td-playbook">
+          <div
+            className={cn("td-playbook", isActive && "td-playbook-active")}
+            role={isActive ? "button" : undefined}
+            tabIndex={isActive ? 0 : undefined}
+            aria-label={isActive ? "View live run" : undefined}
+            title={isActive ? "Live run view coming in PR 10" : undefined}
+            data-testid={isActive ? "td-view-run-btn" : undefined}
+          >
             <div className="td-pb-icon">
-              <BookOpen size={15} aria-hidden />
+              {playbookItem?.icon ? (
+                <span aria-hidden>{playbookItem.icon}</span>
+              ) : (
+                <BookOpen size={15} aria-hidden />
+              )}
             </div>
-            <div className="td-pb-name">{task.playbook}</div>
+            <div className="td-pb-info">
+              <div className="td-pb-name">{playbookItem?.name ?? task.playbook}</div>
+              <div
+                className={cn(
+                  "td-item-desc",
+                  playbookDescription && "td-item-desc-plain",
+                )}
+              >
+                {playbookDescription || "No description"}
+              </div>
+            </div>
+            <div className="td-pb-action">
+              {isNotStarted && (
+                <button
+                  type="button"
+                  className="td-pb-run-btn"
+                  disabled={isPending}
+                  aria-label="Start playbook"
+                  data-testid="td-start-btn"
+                  onClick={onStart}
+                >
+                  <Play size={9} aria-hidden />
+                </button>
+              )}
+              {isActive && (
+                <div className="td-pb-state-busy" aria-label="Running" />
+              )}
+              {task.status === "complete" && (
+                <div className="td-pb-state-done" aria-label="Done">
+                  <Check size={10} aria-hidden />
+                </div>
+              )}
+              {task.status === "blocked" && (
+                <div className="td-pb-state-failed" aria-label="Failed">
+                  <XCircle size={10} aria-hidden />
+                </div>
+              )}
+            </div>
           </div>
         </div>
       )}
@@ -385,7 +394,7 @@ function DependenciesTab() {
     <div className="td-sec" style={{ marginTop: 4 }}>
       <div className="td-sec-lbl">Flow</div>
       <div className="td-empty" data-testid="td-dependencies-placeholder">
-        DepTree coming in PR 10
+        DepTree coming in PR 14
       </div>
     </div>
   );
@@ -401,6 +410,8 @@ export interface TaskDrawerProps {
   instance: WorkflowInstanceDetail;
   roles: WorkflowRole[];
   template: WorkflowTemplate | null;
+  skillOptions?: FrameworkItem[];
+  playbookOptions?: FrameworkItem[];
   onClose: () => void;
   onTaskUpdate: (task: WorkflowTask) => void;
 }
@@ -410,6 +421,8 @@ export function TaskDrawer({
   instance,
   roles,
   template,
+  skillOptions = [],
+  playbookOptions = [],
   onClose,
   onTaskUpdate,
 }: TaskDrawerProps) {
@@ -445,6 +458,22 @@ export function TaskDrawer({
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
   }, [open, onClose]);
+
+  function handleStart() {
+    if (!task) return;
+    startTransition(async () => {
+      try {
+        const { task: updated } = await startTaskAction(task.id);
+        onTaskUpdate(updated);
+        emitEvent("workflow.task_started", {
+          task_id: task.id,
+          instance_id: task.instanceId,
+        });
+      } catch (err) {
+        captureError(err, { feature: "workflows.start_task", extra: { task_id: task.id } });
+      }
+    });
+  }
 
   function handleApprove() {
     if (!task) return;
@@ -585,7 +614,10 @@ export function TaskDrawer({
             <DetailsTab
               task={task}
               roles={roles}
+              skillOptions={skillOptions}
+              playbookOptions={playbookOptions}
               isPending={isPending}
+              onStart={handleStart}
               onApprove={handleApprove}
               onReject={handleReject}
               onTriggersChange={handleTriggersChange}

--- a/products/dashboard/e2e/workflows.spec.ts
+++ b/products/dashboard/e2e/workflows.spec.ts
@@ -46,6 +46,15 @@ async function openFirstTemplateNewInstanceDialog(page: Page) {
   return dialog;
 }
 
+async function createFreshInstance(page: Page, labelPrefix: string) {
+  const dialog = await openFirstTemplateNewInstanceDialog(page);
+  await dialog
+    .getByRole("textbox", { name: /instance name/i })
+    .fill(`${labelPrefix} ${Date.now()}`);
+  await dialog.getByRole("button", { name: /^create\s*→?$/i }).click();
+  await expect(page).toHaveURL(/\/workflows\/[0-9a-f-]+$/);
+}
+
 test.describe("workflows — create-instance modal", () => {
   test("opens the modal, creates a new instance, and lands on the matrix route", async ({
     page,
@@ -96,12 +105,7 @@ test.describe("workflows — process matrix (read-only)", () => {
     // The matrix needs an existing instance to paint, so create a fresh
     // one from the first template in the sidebar (no fixture coupling)
     // and follow the redirect onto its `/workflows/{id}` route.
-    const dialog = await openFirstTemplateNewInstanceDialog(page);
-    await dialog
-      .getByRole("textbox", { name: /instance name/i })
-      .fill(`E2E Matrix ${Date.now()}`);
-    await dialog.getByRole("button", { name: /^create\s*→?$/i }).click();
-    await expect(page).toHaveURL(/\/workflows\/[0-9a-f-]+$/);
+    await createFreshInstance(page, "E2E Matrix");
 
     const matrix = page.getByTestId("process-matrix");
     await expect(matrix).toBeVisible();
@@ -150,12 +154,7 @@ test.describe("workflows — task drawer (AEL-51)", () => {
     await authenticateWithBypass(page);
 
     // Create a fresh instance so the matrix has tasks.
-    const dialog = await openFirstTemplateNewInstanceDialog(page);
-    await dialog
-      .getByRole("textbox", { name: /instance name/i })
-      .fill(`E2E Drawer ${Date.now()}`);
-    await dialog.getByRole("button", { name: /^create\s*→?$/i }).click();
-    await expect(page).toHaveURL(/\/workflows\/[0-9a-f-]+$/);
+    await createFreshInstance(page, "E2E Drawer");
 
     // Click the first task card.
     const firstCard = page.locator('[data-testid^="task-card-"]').first();
@@ -187,12 +186,7 @@ test.describe("workflows — task drawer (AEL-51)", () => {
 
     await authenticateWithBypass(page);
 
-    const dialog = await openFirstTemplateNewInstanceDialog(page);
-    await dialog
-      .getByRole("textbox", { name: /instance name/i })
-      .fill(`E2E Events Tab ${Date.now()}`);
-    await dialog.getByRole("button", { name: /^create\s*→?$/i }).click();
-    await expect(page).toHaveURL(/\/workflows\/[0-9a-f-]+$/);
+    await createFreshInstance(page, "E2E Events Tab");
 
     const firstCard = page.locator('[data-testid^="task-card-"]').first();
     await firstCard.click();
@@ -207,5 +201,36 @@ test.describe("workflows — task drawer (AEL-51)", () => {
     const eventList = page.getByTestId("td-event-list");
     const emptyState = page.getByTestId("td-events-empty");
     await expect(eventList.or(emptyState)).toBeVisible();
+  });
+});
+
+test.describe("workflows — matrix edit mode (AEL-52)", () => {
+  test("opens the add-task modal and creates a task in an empty cell", async ({
+    page,
+  }) => {
+    test.skip(
+      !hasSupabaseRuntime,
+      "Supabase runtime credentials required for the matrix edit-mode happy path",
+    );
+
+    await authenticateWithBypass(page);
+    await createFreshInstance(page, "E2E Edit Mode");
+
+    await page.getByRole("button", { name: "Edit" }).click();
+    await expect(page).toHaveURL(/edit=1/);
+
+    const addTrigger = page.locator('[data-testid^="matrix-add-task-"]').first();
+    await expect(addTrigger).toBeVisible();
+    await addTrigger.click();
+
+    const modal = page.getByRole("dialog", { name: "New task" });
+    await expect(modal).toBeVisible();
+    await expect(modal.getByText(/·/)).toBeVisible();
+
+    await modal.getByPlaceholder("Task title").fill("E2E created task");
+    await modal.getByRole("button", { name: /create task/i }).click();
+
+    await expect(modal).toBeHidden();
+    await expect(page.getByText("E2E created task")).toBeVisible();
   });
 });

--- a/products/dashboard/e2e/workflows.spec.ts
+++ b/products/dashboard/e2e/workflows.spec.ts
@@ -225,7 +225,7 @@ test.describe("workflows — matrix edit mode (AEL-52)", () => {
 
     const modal = page.getByRole("dialog", { name: "New task" });
     await expect(modal).toBeVisible();
-    await expect(modal.getByText(/·/)).toBeVisible();
+    await expect(modal.getByPlaceholder("Task title")).toBeVisible();
 
     await modal.getByPlaceholder("Task title").fill("E2E created task");
     await modal.getByRole("button", { name: /create task/i }).click();

--- a/products/dashboard/lib/events.ts
+++ b/products/dashboard/lib/events.ts
@@ -28,6 +28,12 @@ type AuthProviderPayload = {
   provider: "magic_link" | "google";
 };
 
+/** Task + instance identifiers (shared by several workflow client events). */
+type WorkflowTaskInstancePayload = {
+  task_id: string;
+  instance_id: string;
+};
+
 /**
  * Discriminated map — enforces name/payload pairing at compile time.
  * Adding a new event requires updating this map; TypeScript will catch mismatches.
@@ -38,8 +44,11 @@ type EventMap = {
   "user.signed_in": AuthProviderPayload;
   "user.signed_out": AuthProviderPayload;
   "dashboard.task_drawer_opened": { task_id: string };
-  "workflow.checkpoint_approved": { task_id: string; instance_id: string };
-  "workflow.checkpoint_rejected": { task_id: string; instance_id: string };
+  "workflow.checkpoint_approved": WorkflowTaskInstancePayload;
+  "workflow.checkpoint_rejected": WorkflowTaskInstancePayload;
+  "workflow.task_started": WorkflowTaskInstancePayload;
+  "workflow.run_cancelled": WorkflowTaskInstancePayload;
+  "workflow.run_retried": WorkflowTaskInstancePayload;
 };
 
 type EventName = keyof EventMap;

--- a/products/dashboard/lib/workflows/matrix.ts
+++ b/products/dashboard/lib/workflows/matrix.ts
@@ -20,7 +20,8 @@ import type { WorkflowTask } from "./types";
 const TASK_TRIGGER_TYPES = new Set(["task", "after_task"]);
 
 /**
- * Bar state strings rendered by `.task-card.bar-*` (see `globals.css`).
+ * Bar state strings rendered by `.task-card.bar-*` (see `globals.css`;
+ * `bar-cancelled` is DB `blocked` / UI "failed").
  * Exporting the type keeps the component / test surface honest:
  * any new state must round-trip through this union.
  */
@@ -30,7 +31,7 @@ export type TaskBarState =
   | "bar-active"
   | "bar-pending"
   | "bar-complete"
-  | "bar-blocked";
+  | "bar-cancelled";
 
 /**
  * Returns true when `task` has no remaining upstream task dependencies.
@@ -84,7 +85,7 @@ export function barClass(
     case "pending_approval":
       return "bar-pending";
     case "blocked":
-      return "bar-blocked";
+      return "bar-cancelled";
     case "not_started":
     default:
       return isReady ? "bar-ready" : "bar-locked";

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -11,6 +11,7 @@ import type {
   WorkflowRepository,
   WorkflowRole,
   WorkflowTask,
+  WorkflowTaskCreateInput,
   WorkflowTaskPatch,
   WorkflowTaskTemplate,
   WorkflowTemplate,
@@ -448,6 +449,28 @@ export function createWorkflowRepository(
       return { ...instance, tasks, events: [] };
     },
 
+    async createTask(input: WorkflowTaskCreateInput): Promise<WorkflowTask> {
+      const { data, error } = await client
+        .from("workflow_tasks")
+        .insert({
+          instance_id: input.instanceId,
+          role_id: input.roleId,
+          stage_id: input.stageId,
+          title: input.title,
+          description: input.description ?? "",
+          checkpoint: input.checkpoint ?? false,
+          triggers: input.triggers ?? [],
+          gates: input.gates ?? [],
+          agent: input.agent ?? null,
+          skill: input.skill ?? null,
+          playbook: input.playbook ?? null,
+        })
+        .select("*")
+        .single();
+
+      return mapTask(unwrap("createTask", data, error) as WorkflowTaskRow);
+    },
+
     async updateTask(taskId: string, patch: WorkflowTaskPatch): Promise<WorkflowTask> {
       const row = patchToRow(patch);
       if (Object.keys(row).length === 0) {
@@ -462,6 +485,17 @@ export function createWorkflowRepository(
         .single();
 
       return mapTask(unwrap("updateTask", data, error) as WorkflowTaskRow);
+    },
+
+    async deleteTask(taskId: string): Promise<void> {
+      const { error } = await client
+        .from("workflow_tasks")
+        .delete()
+        .eq("id", taskId);
+
+      if (error) {
+        throw new WorkflowRepositoryError("deleteTask failed", error);
+      }
     },
 
     async addEvent(taskId: string, event: WorkflowEventInput): Promise<WorkflowEvent> {
@@ -490,6 +524,25 @@ export function createWorkflowRepository(
         .single();
 
       return mapEvent(unwrap("addEvent", data, error) as WorkflowEventRow);
+    },
+
+    async addInstanceEvent(
+      instanceId: string,
+      event: WorkflowEventInput & { taskId?: string | null },
+    ): Promise<WorkflowEvent> {
+      const { data, error } = await client
+        .from("workflow_events")
+        .insert({
+          instance_id: instanceId,
+          task_id: event.taskId ?? null,
+          name: event.name,
+          description: event.description ?? "",
+          payload: event.payload ?? {},
+        })
+        .select("*")
+        .single();
+
+      return mapEvent(unwrap("addInstanceEvent", data, error) as WorkflowEventRow);
     },
 
     async getFrameworkItems(type?: FrameworkItemType): Promise<FrameworkItem[]> {

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -13,6 +13,7 @@ import type {
   WorkflowTask,
   WorkflowTaskCreateInput,
   WorkflowTaskPatch,
+  WorkflowTaskStatus,
   WorkflowTaskTemplate,
   WorkflowTemplate,
 } from "./types";
@@ -458,6 +459,8 @@ export function createWorkflowRepository(
           stage_id: input.stageId,
           title: input.title,
           description: input.description ?? "",
+          status: "not_started",
+          substatus: "",
           checkpoint: input.checkpoint ?? false,
           triggers: input.triggers ?? [],
           gates: input.gates ?? [],
@@ -469,6 +472,33 @@ export function createWorkflowRepository(
         .single();
 
       return mapTask(unwrap("createTask", data, error) as WorkflowTaskRow);
+    },
+
+    async updateTaskIfStatus(
+      taskId: string,
+      expectedStatus: WorkflowTaskStatus,
+      patch: WorkflowTaskPatch,
+    ): Promise<WorkflowTask | null> {
+      const row = patchToRow(patch);
+      if (Object.keys(row).length === 0) {
+        throw new WorkflowRepositoryError("updateTaskIfStatus called with empty patch");
+      }
+
+      const { data, error } = await client
+        .from("workflow_tasks")
+        .update(row)
+        .eq("id", taskId)
+        .eq("status", expectedStatus)
+        .select("*")
+        .maybeSingle();
+
+      if (error) {
+        throw new WorkflowRepositoryError("updateTaskIfStatus failed", error);
+      }
+      if (!data) {
+        return null;
+      }
+      return mapTask(data as WorkflowTaskRow);
     },
 
     async updateTask(taskId: string, patch: WorkflowTaskPatch): Promise<WorkflowTask> {

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -211,6 +211,17 @@ export interface WorkflowRepository {
     taskId: string,
     nextStatus: WorkflowCheckpointTransitionStatus,
   ): Promise<WorkflowTask | null>;
+  /**
+   * Atomic conditional update for ordinary task writes that depend on
+   * the current task status. Returns the updated row when the status
+   * predicate still matched at write time, or `null` when the row is
+   * missing / hidden / no longer in `expectedStatus`.
+   */
+  updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: WorkflowTaskStatus,
+    patch: WorkflowTaskPatch,
+  ): Promise<WorkflowTask | null>;
   listInstances(templateId?: string): Promise<WorkflowInstance[]>;
   /**
    * All tasks across every instance the caller can read (RLS still

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -100,6 +100,20 @@ export interface WorkflowTask {
   updatedAt: string;
 }
 
+export interface WorkflowTaskCreateInput {
+  instanceId: string;
+  roleId: string;
+  stageId: string;
+  title: string;
+  description?: string;
+  checkpoint?: boolean;
+  triggers?: WorkflowTrigger[];
+  gates?: WorkflowGate[];
+  agent?: string | null;
+  skill?: string | null;
+  playbook?: string | null;
+}
+
 export interface WorkflowEvent {
   id: string;
   instanceId: string;
@@ -210,8 +224,14 @@ export interface WorkflowRepository {
    */
   listRecentEvents(limit: number): Promise<WorkflowEvent[]>;
   createInstance(templateId: string, label: string): Promise<WorkflowInstanceDetail>;
+  createTask(input: WorkflowTaskCreateInput): Promise<WorkflowTask>;
   updateTask(taskId: string, patch: WorkflowTaskPatch): Promise<WorkflowTask>;
+  deleteTask(taskId: string): Promise<void>;
   addEvent(taskId: string, event: WorkflowEventInput): Promise<WorkflowEvent>;
+  addInstanceEvent(
+    instanceId: string,
+    event: WorkflowEventInput & { taskId?: string | null },
+  ): Promise<WorkflowEvent>;
   getFrameworkItems(type?: FrameworkItemType): Promise<FrameworkItem[]>;
   upsertFrameworkItem(item: FrameworkItem): Promise<FrameworkItem>;
 }

--- a/spec/examples/dashboard-product.yaml
+++ b/spec/examples/dashboard-product.yaml
@@ -398,6 +398,93 @@ events:
             type: string
           instance_id:
             type: string
+    - name: "workflow.task_created"
+      description: "User created a new task in workflow instance edit mode."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: none
+        ordering: at_least_once
+      emitted_by:
+        - "actions.createTaskAction"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - task_id
+          - instance_id
+          - role_id
+          - stage_id
+        properties:
+          task_id:
+            type: string
+          instance_id:
+            type: string
+          role_id:
+            type: string
+          stage_id:
+            type: string
+    - name: "workflow.task_moved"
+      description: "User moved a task to a different role-stage cell in workflow instance edit mode."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: recommended
+        ordering: at_least_once
+      emitted_by:
+        - "actions.moveTaskAction"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - task_id
+          - instance_id
+          - from_role_id
+          - from_stage_id
+          - to_role_id
+          - to_stage_id
+        properties:
+          task_id:
+            type: string
+          instance_id:
+            type: string
+          from_role_id:
+            type: string
+          from_stage_id:
+            type: string
+          to_role_id:
+            type: string
+          to_stage_id:
+            type: string
+    - name: "workflow.task_deleted"
+      description: "User deleted a task from workflow instance edit mode."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: recommended
+        ordering: at_least_once
+      emitted_by:
+        - "actions.deleteTaskAction"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - task_id
+          - instance_id
+          - role_id
+          - stage_id
+        properties:
+          task_id:
+            type: string
+          instance_id:
+            type: string
+          role_id:
+            type: string
+          stage_id:
+            type: string
 
 observability:
   logs:

--- a/spec/examples/dashboard-product.yaml
+++ b/spec/examples/dashboard-product.yaml
@@ -485,6 +485,69 @@ events:
             type: string
           stage_id:
             type: string
+    - name: "workflow.task_started"
+      description: "User started a not_started task run from the Task Drawer playbook control."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: recommended
+        ordering: at_least_once
+      emitted_by:
+        - "components.task-drawer"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - task_id
+          - instance_id
+        properties:
+          task_id:
+            type: string
+          instance_id:
+            type: string
+    - name: "workflow.run_cancelled"
+      description: "User stopped an active task run from the Task Drawer; persisted as blocked (failed in UI)."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: recommended
+        ordering: at_least_once
+      emitted_by:
+        - "components.task-drawer"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - task_id
+          - instance_id
+        properties:
+          task_id:
+            type: string
+          instance_id:
+            type: string
+    - name: "workflow.run_retried"
+      description: "User retried a blocked (failed) task run from the Task Drawer playbook control."
+      version: "1.0.0"
+      schema_version: "1.0.0"
+      classification:
+        pii: none
+        idempotency: recommended
+        ordering: at_least_once
+      emitted_by:
+        - "components.task-drawer"
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - task_id
+          - instance_id
+        properties:
+          task_id:
+            type: string
+          instance_id:
+            type: string
 
 observability:
   logs:


### PR DESCRIPTION
## Summary

This PR ships dashboard workflow UX around playbook runs, fixes the sidebar collapse hit target, and renames the blocked-task UI label from Cancelled to Failed.

## Changes

- **Task drawer / workflows:** Start, cancel in-flight runs, and retry blocked runs with matching server actions, events, and tests. Playbook row interactions, status styling, and matrix bar class for blocked tasks (`bar-cancelled` / UI Failed).
- **Sidebar:** Brand row flex layout (`min-w-0`, truncating title, `shrink-0` on controls) so the collapse chevron stays clickable.
- **Copy:** Blocked tasks show **Failed**; cancel-run audit description aligned.

## Verification

- `npm run validate` (local) — pass on head `b8d9551`.

## Risk

Medium — application logic and UI in `products/dashboard`; no schema or control-plane workflow edits in this branch.

Targets `staging` per repository branch model.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit mode with drag‑and‑drop task creation, move, delete; Add Task and confirmation modals; inline playbook start/stop/retry controls; Top Bar “Edit/Done” toggle.
* **Bug Fixes**
  * Status label updates: “In progress” and “Failed”.
* **Style**
  * Refined matrix/task/drawer visuals, updated pill colors, empty‑cell affordances, remove button and playbook UI primitives.
* **Events / Instrumentation**
  * New workflow lifecycle events emitted for create/move/delete/start/cancel/retry.
* **Tests**
  * Expanded unit, integration, and E2E coverage for edit and run flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->