### PR TITLE
fix(policy): skip CodeRabbit on promotion/back-merge PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -24,5 +24,7 @@ reviews:
       - staging
     ignore_title_keywords:
       - "chore: release"
+      - "Promote staging to main"
+      - "chore: back-merge main into staging after release"
 chat:
   auto_reply: true

--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -125,7 +125,12 @@ jobs:
               return;
             }
 
-            const isReleasePleaseAutomation = (pr.headRefName ?? '').startsWith('release-please');
+            const headRefName = pr.headRefName ?? '';
+            const baseRefName = context.payload.pull_request?.base?.ref ?? '';
+            const isReleasePleaseAutomation = headRefName.startsWith('release-please');
+            const isStagingPromotion = headRefName === 'staging' && baseRefName === 'main';
+            const isBackMergeAutomation =
+              /^chore\/back-merge-main-after-/.test(headRefName) && baseRefName === 'staging';
 
             const marker = '<!-- p1-policy-decision -->';
 
@@ -310,7 +315,7 @@ jobs:
               .split(',')
               .map((s) => s.trim())
               .filter(Boolean);
-            if (isReleasePleaseAutomation) {
+            if (isReleasePleaseAutomation || isStagingPromotion || isBackMergeAutomation) {
               reviewStatusContexts = [];
             }
 
@@ -464,6 +469,8 @@ jobs:
 
             const hasFreshAiReview =
               isReleasePleaseAutomation ||
+              isStagingPromotion ||
+              isBackMergeAutomation ||
               latestAiEvidence != null ||
               (reviewerStatusesSatisfied && reviewStatusContexts.length > 0 && !hasChangesRequestedOnHead);
 

--- a/.github/workflows/p1-policy.yml
+++ b/.github/workflows/p1-policy.yml
@@ -127,10 +127,26 @@ jobs:
 
             const headRefName = pr.headRefName ?? '';
             const baseRefName = context.payload.pull_request?.base?.ref ?? '';
-            const isReleasePleaseAutomation = headRefName.startsWith('release-please');
-            const isStagingPromotion = headRefName === 'staging' && baseRefName === 'main';
+            const prActorLogin = (context.payload.pull_request?.user?.login ?? '').toLowerCase();
+            const prActorType = context.payload.pull_request?.user?.type ?? '';
+            const triggerActorLogin = (context.actor ?? '').toLowerCase();
+            const trustedAutomationLogins = new Set([
+              'github-actions[bot]',
+              'dependabot[bot]',
+              'release-please[bot]',
+            ]);
+            const isTrustedAutomationActor =
+              prActorType === 'Bot' ||
+              trustedAutomationLogins.has(prActorLogin) ||
+              trustedAutomationLogins.has(triggerActorLogin);
+            const isReleasePleaseAutomation =
+              headRefName.startsWith('release-please') && isTrustedAutomationActor;
+            const isStagingPromotion =
+              headRefName === 'staging' && baseRefName === 'main' && isTrustedAutomationActor;
             const isBackMergeAutomation =
-              /^chore\/back-merge-main-after-/.test(headRefName) && baseRefName === 'staging';
+              /^chore\/back-merge-main-after-/.test(headRefName) &&
+              baseRefName === 'staging' &&
+              isTrustedAutomationActor;
 
             const marker = '<!-- p1-policy-decision -->';
 


### PR DESCRIPTION
## Summary
- add promotion/back-merge title ignores to `.coderabbit.yaml` so those governed PRs do not trigger auto review
- update `p1-policy` to skip required AI-review status checks for `staging -> main` and `chore/back-merge-main-after-* -> staging` paths
- keep existing release-please skip behavior intact while preserving normal reviewer requirements on feature PRs

## Test plan
- [x] Confirm diff only touches `.coderabbit.yaml` and `.github/workflows/p1-policy.yml`
- [ ] Verify this PR passes normal `staging` feature-PR checks
- [ ] On next `staging -> main` promotion PR, confirm CodeRabbit remains skipped and `decide` does not wait on reviewer status
- [ ] On next `chore/back-merge-main-after-* -> staging` PR, confirm the same skip behavior

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced review automation to ignore PRs with new promote/back-merge titles and to treat staging-promotion and back-merge workflows as trusted automation.
  * These trusted automations now bypass reviewer-status requirements and are recognized as providing fresh AI review evidence, reducing unnecessary review gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->