### PR TITLE
docs(playbook): require standardized commit override on promotion PRs

### DIFF
--- a/ai/playbooks/publish-to-production.md
+++ b/ai/playbooks/publish-to-production.md
@@ -64,8 +64,36 @@ Create a ready-for-review PR with:
 - `head=staging`
 - non-draft state
 - summary focused on the production publish scope and notable operational risk
+- a `BEGIN_COMMIT_OVERRIDE` / `END_COMMIT_OVERRIDE` block in the PR body with standardized conventional-commit lines for every releasable change in this promotion scope
 
 This PR is not a feature review surface. The substantive review already happened on the feature PRs that landed in `staging`.
+
+**Required release-please override block (mandatory):**
+
+Before merging any `staging` -> `main` promotion PR, include this section in the PR body:
+
+```md
+BEGIN_COMMIT_OVERRIDE
+<one standardized conventional commit per releasable item>
+END_COMMIT_OVERRIDE
+```
+
+Standardization rules:
+
+- Use one line per releasable change.
+- Use only conventional commit prefixes: `feat`, `fix`, `perf`, `revert`, and optionally `chore` when release metadata is intentionally desired.
+- Keep each line in the form: `<type>(<scope>): <short summary>`.
+- Keep summaries concise and user-facing; avoid tooling noise, PR numbers, merge boilerplate, and co-author trailers.
+- Do not include `docs`, `test`, `ci`, or other non-releasable-only entries unless you intentionally want them reflected in release notes.
+
+Example:
+
+```md
+BEGIN_COMMIT_OVERRIDE
+feat(dashboard): workflow run controls and task retry/cancel UX
+fix(policy): require trusted bot identity for reviewer-skip paths
+END_COMMIT_OVERRIDE
+```
 
 Canonical CLI sequence:
 
@@ -130,6 +158,7 @@ After the PR merges:
 4. Confirm the second PR receives `residual:low`, passes `validate` and `decide`, and auto-merges through the `release-please` Mergify queue in `.mergify.yml`.
 5. Confirm the merge of the second PR created the tag and GitHub Release expected by `release-please`.
 6. If no release PR appears, or it opens but does not auto-merge, inspect the failure modes in `ai/playbooks/release-management.md` before treating production publication as complete.
+7. If release-please logs report `commit could not be parsed` on the promotion merge commit, update the merged promotion PR body with a corrected `BEGIN_COMMIT_OVERRIDE` block and rerun the release-please workflow.
 
 Canonical verification sequence:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Require every `staging` -> `main` promotion PR to include a `BEGIN_COMMIT_OVERRIDE` / `END_COMMIT_OVERRIDE` block before merge.
- Add standardized formatting rules for override lines so release-please can reliably parse releasable changes.
- Document post-merge recovery step: if release-please reports `commit could not be parsed`, update the merged promotion PR override block and rerun release-please.

## Validation

- [x] `npm run validate`

## Checklist

- [x] PR targets `staging` (playbook/documentation change)
- [x] Guidance is explicit and operational for recurring promotion runs
- [x] Recovery path for parse failures is documented
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9bef2d3e-1011-44b4-aba1-b0d40354efa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bef2d3e-1011-44b4-aba1-b0d40354efa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the production promotion playbook with new formatting requirements for pull request submissions
  * Enhanced post-merge verification procedures with improved error detection and correction instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->