### PR TITLE
feat(dashboard): checkpoint template editor and workflow polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,19 +2,36 @@
 
 ## Purpose
 
-This repository defines an AI-native operating framework for product-led companies. The canonical system lives in schema, policy, interfaces, and playbooks. **`AGENTS.md` is the only agent-centric file at the repository root**; every other agent runtime artifact lives under **`ai/`** (indices, skills, playbooks, memory). Long-form framework narrative stays in **`docs/`**.
+This repository defines an AI-native operating framework for product-led companies. The durable operating system lives in `spec/`, `interfaces/`, and `ai/playbooks/`. Root `AGENTS.md` is the bootstrap surface; every other agent artifact lives under `ai/`.
+
+## Core Idea
+
+Keep these facts loaded by default:
+
+- The framework is spec-driven, event-observable, human-governed, and provider-agnostic at the core.
+- Schema, policy, interfaces, and playbooks are the durable system; `ai/` is routing, memory, and execution support.
+- Agents execute within declared constraints; humans decide strategy, ambiguity, and high-stakes actions.
+- Framework changes are incomplete if the agent bundle under `ai/` is left stale.
+
+When you see The Framework, open `docs/AI_NATIVE_FRAMEWORK.md`.
+The Framework is the repository's long-form conceptual and normative narrative for the AI-native operating model: what the system is, its core principles, the division of labor between agents and humans, the layered architecture, the workflow library, and how the framework fits across product, operations, and governance. Use it when the conversation is about framework meaning, first principles, terminology, or cross-cutting design intent rather than a specific playbook or implementation detail.
 
 ## Read Order
 
-You are reading the first-read entry point. After this file, read the following before making non-trivial changes:
+Read these before non-trivial work:
 
 1. `README.md`
-2. `docs/AI_NATIVE_FRAMEWORK.md`
-3. `ai/PLAYBOOKS.md`
-4. The specific files under `ai/playbooks/` or `spec/` relevant to the task
-5. `ai/SKILLS.md`
-6. Only the specific `ai/skills/*.md` files selected from `ai/SKILLS.md`
-7. `ai/MEMORY.md`
+2. `ai/PLAYBOOKS.md`
+3. The specific files under `ai/playbooks/` or `spec/` relevant to the task
+4. `ai/SKILLS.md`
+5. Only the specific `ai/skills/*.md` files selected from `ai/SKILLS.md`
+6. `ai/MEMORY.md`
+
+Open `docs/AI_NATIVE_FRAMEWORK.md` only when:
+
+- the user references The Framework
+- framework prose or first-principles interpretation is needed
+- the lower-order artifacts do not answer the question
 
 ## Authority Ladder
 
@@ -25,7 +42,7 @@ Higher items override lower items:
 3. `spec/policy/*`
 4. `interfaces/interfaces.yaml`
 5. `ai/playbooks/*.md`
-6. `docs/*` (framework prose and other explanatory docs)
+6. `docs/*`
 7. `AGENTS.md`, `ai/PLAYBOOKS.md`, `ai/SKILLS.md`, `ai/skills/*.md`, `ai/MEMORY.md`
 
 If two sources conflict, follow the higher source and update the lower one if that is within scope.
@@ -39,62 +56,57 @@ If you change schema, examples, policy, templates, or playbooks, run `npm run va
 
 ## Working Rules
 
-- Keep the framework provider-agnostic. Do not encode a single model vendor or IDE as core policy.
-- Treat specs, policy, and playbooks as the durable operating system. This file and `ai/` are bootstrap and routing surfaces, not a replacement for canonical artifacts.
-- Prefer updating the framework and playbooks together when a process change affects repository behavior.
-- Keep repository-local agent instructions concise. Link outward instead of duplicating long prose.
-- Preserve the distinction between stable memory and temporary working notes.
-- Before starting any non-trivial implementation task, match the task to the closest skill in `ai/SKILLS.md` and load the corresponding `ai/skills/*.md` file. Do not begin editing files until the skill's workflow, decision rules, and completion criteria are loaded.
-- After completing any non-trivial workflow, ask whether the work introduced durable learnings that should update `ai/MEMORY.md`, `ai/SKILLS.md`, a specific `ai/skills/*.md`, `AGENTS.md`, or a playbook under `ai/playbooks/` before considering the task fully closed.
-- Treat repository settings changes as separate control-plane work. Do not use settings changes as the default fix path for an ordinary task or PR blocker.
-- Do not merge a pull request in this repository until every configured merge gate on the current head SHA is complete and green. This rule still applies if GitHub branch protection is missing or misconfigured.
-- When you are the agent executing the PR loop for a change you published, **you are responsible for finishing the loop**: after gates are green and CodeRabbit threads are accounted for per `ai/playbooks/pull-request-execution-loop.md`, **merge** (or confirm the configured merge queue has merged) unless policy requires a human decision. Prefer a single verification pass when the operator says checks finished, instead of unbounded polling.
-- Configured AI review (CodeRabbit) is a **soft-mandatory** gate for substance, not only for a green status. Before merge, **every** open review thread **MUST** be closed with a code fix or a **visible** decision using the canonical outcomes in `.coderabbit.yaml` (**fix**, **accept as follow-up**, **won't change**). Full mappings, per-thread vs consolidated comments, GitHub thread-state rules, nit handling, and waiver requirements are normative in `ai/playbooks/pull-request-execution-loop.md` (finding closure before merge + §1.5)—do not resolve threads solely to clear “conversations resolved” without that accounting.
-- When addressing CodeRabbit findings, prefer replying directly in the review thread with the resolution details so the history stays attached to the finding itself.
-- Do not use admin merge, temporary removal of required checks, or other host bypasses to skip that review accounting unless the human operator has **explicitly** instructed you to use a documented control-plane exception (for example merging a workflow change that updates `p1-policy` itself).
-- Wait for CodeRabbit's automatic review run by default. If no CodeRabbit comment or status appears after roughly 15 seconds on a new head SHA, you may post `@coderabbitai review` without asking. If CodeRabbit has already posted a "review in progress" style comment or otherwise clearly started, poll for up to 5 minutes in 1-minute intervals and then ask the user before posting a manual `@coderabbitai review` recovery comment. A green reviewer check does not prove a new **submitted** review replaced an older **`CHANGES_REQUESTED`**.
-- When every thread has a visible outcome on the **current** head but **`CHANGES_REQUESTED`** persists, or threads still need CodeRabbit to acknowledge closure, post **one** PR comment with the **canonical approval prompt** from `ai/playbooks/pull-request-execution-loop.md` section 3 item 6. **Do not** use `@coderabbitai review` for that—it forces a long full re-review. See `ai/skills/developer.md` step 9.
-- **Stale reviews / merge queue:** When thread closure on the **current** head is complete but GitHub still shows **`CHANGES_REQUESTED`** only from **older** bot submissions, a **maintainer** may **dismiss** those stale reviews with a **visible message** (normative rules: `ai/playbooks/pull-request-execution-loop.md`, finding closure)—not a bypass for open findings. If **Mergify** dropped the PR, re-queue with `@mergifyio queue` and the queue name from `.mergify.yml` (e.g. `low-risk`); remove a stray **`dequeued`** label if it blocks a clean retry.
-- When publishing changes with a pull request in this repository, open the PR ready for review by default. Use a draft PR only when the user explicitly asks for draft state.
-- **Branch model:** feature branches target `staging`, not `main`. `staging` is the integration branch, protected with the same rules as `main`. The `staging` → `main` promotion is automated by release-please using a regular merge (not squash) to preserve conventional commit history; no separate review is required when CI is green. Never open a feature PR directly against `main` unless it is a release-please release PR.
+- Keep the framework provider-agnostic. Do not encode one model vendor or IDE as core policy.
+- Keep repository-local agent instructions concise. Prefer pointers over repeated prose.
+- Think before coding: state material assumptions, surface ambiguity, and ask when uncertainty would change the implementation.
+- If multiple valid interpretations or tradeoffs exist, make them explicit instead of choosing silently.
+- Prefer the simplest solution that fully satisfies the request. Do not add speculative features, abstractions, configurability, or impossible-scenario handling.
+- Make surgical changes: touch only what the task requires, match local style, and avoid opportunistic refactors or adjacent cleanup.
+- Remove only the unused code your change creates; mention unrelated dead code without deleting it unless asked.
+- Every changed line should trace directly to the user's request or to verification required by the change.
+- Turn requests into verifiable goals before implementing. For multi-step work, define a short plan with a concrete verification check per step.
+- Before non-trivial implementation, match the task to the closest entry in `ai/SKILLS.md` and load that skill.
+- After non-trivial workflow completion, check whether `AGENTS.md`, `ai/MEMORY.md`, `ai/SKILLS.md`, `ai/PLAYBOOKS.md`, a skill, or a playbook now needs an update.
+- Treat repository settings changes as separate control-plane work unless explicitly requested.
+- Do not merge a PR until every configured merge gate on the current head SHA is complete and green.
+- If you published the PR, you own the loop through merge when policy allows it.
+- Configured AI review is substance-gating: every open CodeRabbit finding must end with a visible outcome on the thread (`fix`, `accept as follow-up`, or `won't change`) before merge.
+- Wait for CodeRabbit auto-review by default. If no CodeRabbit signal appears after about 15 seconds on a new head SHA, you may post `@coderabbitai review`. If review already started, wait up to 5 minutes before asking the user about manual recovery.
+- If thread closure is complete on the current head but `CHANGES_REQUESTED` still persists, use the canonical approval prompt from `ai/playbooks/pull-request-execution-loop.md`; do not trigger a fresh full re-review.
+- A maintainer may dismiss stale bot reviews only after current-head thread closure is complete and the dismissal message is visible.
+- Feature branches target `staging`, not `main`. The valid human-authored PR to `main` is the governed `staging` -> `main` promotion PR.
+- Open PRs ready for review by default unless the user explicitly asks for draft.
 
 ## Change Discipline
 
-- When adding a new recurring workflow, update `ai/PLAYBOOKS.md`, `ai/playbooks/` as needed, `ai/SKILLS.md`, and any corresponding `ai/skills/*.md` files.
-- When changing repo operating rules, check whether `AGENTS.md` and `ai/MEMORY.md` now need updates.
-- When introducing durable process knowledge, prefer a playbook under `ai/playbooks/` or a schema-backed artifact over burying it in memory.
+- When adding a recurring workflow, update `ai/PLAYBOOKS.md`, the relevant file under `ai/playbooks/`, `ai/SKILLS.md`, and any matching skill files.
+- When changing repo operating rules, check whether `AGENTS.md` and `ai/MEMORY.md` need updates.
+- Prefer durable process knowledge in playbooks or schema-backed artifacts, not memory.
+- Favor caution over speed on non-trivial work; use judgment on trivial tasks.
 - Do not treat transient chat as the system of record.
 
 ## Escalation Conditions
 
-Escalate or stop when any of these are true:
+Escalate or stop when:
 
 - the task would contradict schema, policy, or playbook rules
 - a high-stakes governance decision is required
-- repository intent is ambiguous and cannot be resolved from the tracked artifacts
+- repository intent is ambiguous and cannot be resolved from tracked artifacts
 - a change would grant new authority to automation without explicit policy support
 
 ## Important Paths
 
 - `spec/schema/` - canonical machine validation rules
-- `spec/examples/` - validated product and slice examples
+- `spec/examples/` - validated examples
 - `spec/policy/` - event and governance policy
-- `interfaces/interfaces.yaml` - logical tool interfaces for agent workflows
-- `docs/AI_NATIVE_FRAMEWORK.md` - normative framework prose
-- `ai/PLAYBOOKS.md` - playbook discovery index (procedures live in `ai/playbooks/`)
-- `ai/playbooks/repository-foundation.md` - governed repository baseline (CI, protection, contributor surfaces)
-- `ai/playbooks/pull-request-execution-loop.md` - pull request automation and merge policy
-- `ai/playbooks/agent-context-bundle.md` - how to install and maintain the `ai/` bundle alongside root `AGENTS.md`
-- `ai/playbooks/framework-review.md` - how to audit the framework itself for consistency, efficiency, and predictability
-- `ai/playbooks/release-management.md` - how to automate repository-level tags and GitHub Releases with a governed release PR flow
-- `ai/playbooks/publish-to-production.md` - how to publish reviewed `staging` work to production through the governed `staging` -> `main` promotion PR (includes the §8 automated back-merge of `main` into `staging` after every release)
-- `ai/playbooks/resolve-github-issues.md` - how to batch and resolve open GitHub issues with per-issue audit comments and one PR per fix group
-- `ai/playbooks/resolve-sentry-issues.md` - how to manage Sentry issues as governed incidents with assignment, notes, and evidence-based closure
-- `ai/playbooks/environment-separation.md` - how to establish and maintain the 3-tier environment model (production / staging / development) including branch setup, Vercel configuration, and analytics token scoping
-- `ai/SKILLS.md` - skill discovery index (role- and task-oriented harnesses)
-- `ai/skills/` - on-demand skill bodies selected from `ai/SKILLS.md`
-- `ai/MEMORY.md` - durable operating memory and open loops
+- `interfaces/interfaces.yaml` - logical tool interfaces
+- `docs/AI_NATIVE_FRAMEWORK.md` - long-form framework prose; opened explicitly as The Framework
+- `ai/PLAYBOOKS.md` - playbook discovery index
+- `ai/playbooks/` - canonical procedure bodies
+- `ai/SKILLS.md` - skill discovery index
+- `ai/skills/` - on-demand skill bodies
+- `ai/MEMORY.md` - durable repo memory and open loops
 
 ## Definition Of Done
 
-A framework change is not complete if it leaves the agent bundle under `ai/` stale. If your edit changes how an agent should bootstrap, choose a skill or playbook, validate work, or preserve context, update `AGENTS.md`, `ai/PLAYBOOKS.md`, `ai/SKILLS.md`, `ai/skills/`, `ai/playbooks/`, or `ai/MEMORY.md` in the same change as appropriate.
+A framework change is not complete if it leaves the `ai/` bundle stale. If your edit changes how agents bootstrap, choose skills or playbooks, validate work, or preserve context, update the relevant bundle files in the same change.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Most agent tools default to **root [AGENTS.md](AGENTS.md)**. After that, the lay
 | Location                                                     | Role                                                       |
 | ------------------------------------------------------------ | ---------------------------------------------------------- |
 | [AGENTS.md](AGENTS.md)                                     | First read: authority, commands, merge and review rules    |
-| [docs/AI_NATIVE_FRAMEWORK.md](docs/AI_NATIVE_FRAMEWORK.md) | Full framework narrative (human- and agent-oriented prose) |
+| [docs/AI_NATIVE_FRAMEWORK.md](docs/AI_NATIVE_FRAMEWORK.md) | Full framework narrative; load on demand when the task explicitly needs framework prose |
 | [ai/PLAYBOOKS.md](ai/PLAYBOOKS.md)                         | Which **unitary procedure** to open under `ai/playbooks/`  |
 | [ai/SKILLS.md](ai/SKILLS.md)                               | Which **role/task skill** to open under `ai/skills/`       |
 | [ai/MEMORY.md](ai/MEMORY.md)                               | Durable repo facts and open loops                          |
@@ -170,9 +170,10 @@ Today that validates example specs against the product schema. As the framework 
 **Agents:** start at [AGENTS.md](AGENTS.md), then follow its read order (summarized here):
 
 1. [README.md](README.md)
-2. [docs/AI_NATIVE_FRAMEWORK.md](docs/AI_NATIVE_FRAMEWORK.md)
-3. [ai/PLAYBOOKS.md](ai/PLAYBOOKS.md)
-4. The specific files under [ai/playbooks/](ai/playbooks/) or `spec/` relevant to the task
-5. [ai/SKILLS.md](ai/SKILLS.md)
-6. Only the specific files under [ai/skills/](ai/skills/) selected from the index
-7. [ai/MEMORY.md](ai/MEMORY.md)
+2. [ai/PLAYBOOKS.md](ai/PLAYBOOKS.md)
+3. The specific files under [ai/playbooks/](ai/playbooks/) or `spec/` relevant to the task
+4. [ai/SKILLS.md](ai/SKILLS.md)
+5. Only the specific files under [ai/skills/](ai/skills/) selected from the index
+6. [ai/MEMORY.md](ai/MEMORY.md)
+
+Open [docs/AI_NATIVE_FRAMEWORK.md](docs/AI_NATIVE_FRAMEWORK.md) only when the task explicitly needs The Framework or lower-order artifacts do not answer the question.

--- a/ai/MEMORY.md
+++ b/ai/MEMORY.md
@@ -1,106 +1,55 @@
 # MEMORY.md
 
-This file stores durable repository memory for agents. It is not a transcript and it is not a dumping ground for temporary notes.
+Durable repository memory only. Keep one-line facts, open loops, and dated decisions. Move normative detail into playbooks, docs, or schema.
 
 ## Stable Facts
 
-- This repository is the canonical home of an AI-native operating framework for product-led companies.
-- Canonical truth is ordered by the authority ladder in `AGENTS.md`, with schema and policy above explanatory Markdown.
-- The repository currently defines the following first-class operating playbooks (each is atomic; see `ai/PLAYBOOKS.md` for optional bootstrap order):
-  - `ai/playbooks/repository-foundation.md`
-  - `ai/playbooks/pull-request-execution-loop.md`
-  - `ai/playbooks/agent-context-bundle.md`
-  - `ai/playbooks/framework-review.md`
-  - `ai/playbooks/release-management.md`
-  - `ai/playbooks/publish-to-production.md`
-  - `ai/playbooks/resolve-github-issues.md`
-  - `ai/playbooks/resolve-sentry-issues.md`
-- The canonical validation command is `npm run validate`.
-- The framework is explicitly provider-agnostic at the core layer.
-- Provider-agnostic logical tool contracts live under `interfaces/` (`interfaces/interfaces.yaml`), separate from the repository-local agent runtime bundle under `ai/`.
-- Repository release versioning now uses root `version.txt` as the canonical repo-level runtime release source, with production telemetry expected to align to the GitHub tag form `vX.Y.Z`.
-- For this repository, pull requests should be opened ready for review by default unless the user explicitly asks for a draft PR.
-- For this repository, agents must wait for every configured merge gate on the current head SHA to complete successfully before merging, even if host branch protection is missing or misconfigured.
-- For this repository, CodeRabbit should be allowed to start automatically; `@coderabbitai review` is only for stalled automatic runs (no signal after ~15 s, or operator agrees after the in-progress wait). When `CHANGES_REQUESTED` persists after threads are addressed, use the canonical prompt in `ai/playbooks/pull-request-execution-loop.md` section 3 item 6 instead.
-- Agent runtime layout: root `AGENTS.md` only; `ai/SKILLS.md` and `ai/skills/` for skills; `ai/PLAYBOOKS.md` and `ai/playbooks/` for unitary procedures; `ai/MEMORY.md` for durable memory.
-- The top-level repository-local skills are `Designer`, `PM`, `Developer`, and `Framework Keeper`.
-- Keep `spec/policy/event-taxonomy.yaml` aligned with runtime emitters (event names, envelope fields, and payload shapes must stay consistent across policy, specs, and product code).
-- For product features in this repository, Sentry should be considered part of the default implementation surface for both frontend and backend work; detailed feature-level expectations live in `ai/skills/developer.md`.
-- The framework defines two first-class governed documentation standards: `docs/ANALYTICS_STANDARD.md` (events, PII, error monitoring) and `docs/QUALITY_STANDARD.md` (verification, testing, evals, release confidence). They are separate surfaces that cross-reference each other; do not collapse them.
-- The Quality Standard defines 3 maturity phases for products: Phase 1 (Tooling Foundation), Phase 2 (AI Reliability), Phase 3 (Scaling Confidence). Phase advancement requires checking off the required list in the standard; agents must not self-advance a phase.
-- For `products/dashboard`, authentication is now a canonical product slice. Product code should depend on the repo-owned auth boundary under `products/dashboard/lib/auth/`; provider-specific Supabase calls belong only inside that adapter layer.
-- For dashboard auth flows, identity lifecycle is part of the canonical implementation surface: successful sign-in should flow through `lib/analytics/identity.ts` and `lib/monitoring`, and sign-out should clear both analytics and monitoring identity state.
-- The Quality Standard allows a guarded E2E-only authenticated-session bypass when external auth providers make deterministic preview-browser setup impractical, but the public login flow, callback error state, and protected-route redirect behavior must still remain in the blocking browser suite.
-- GitHub issue triage in this repository now has a governed batching pattern: when multiple open issues share the same failing workflow step, file, or root cause, they should be treated as one fix group, with intent commented on every issue before editing and outcome commented on every issue after the PR exists.
-- Sentry issues in this repository are treated as active governed work items, not passive observability artifacts: assign the issue, keep it `unresolved` while the fix is in flight, leave a triage note linked to the PR, and leave a resolution note before marking it `resolved`.
-- Closing a Sentry issue requires explicit evidence: the linked PR merge timestamp, the issue `lastSeen` timestamp, and the recent issue events and releases must support closure.
-
-## Current Bundle State
-
-- `AGENTS.md` at the repository root is the first-read bootstrap file for agents.
-- `ai/SKILLS.md` is the discovery index for role- and task-oriented skills.
-- `ai/skills/` contains the full skill bodies loaded only when selected from the index.
-- `ai/PLAYBOOKS.md` indexes unitary procedures; bodies live in `ai/playbooks/`.
-- `ai/MEMORY.md` is reserved for durable facts, dated decisions, and open loops worth carrying across sessions.
+- Canonical framework home: this repository.
+- Authority order: schema -> validated examples/processes -> policy -> interfaces -> playbooks -> docs -> agent bundle.
+- Canonical validation command: `npm run validate`.
+- Provider-agnostic core is mandatory.
+- Provider-agnostic tool contracts live in `interfaces/interfaces.yaml`; repo-local agent runtime lives under `ai/`.
+- Agent runtime layout: root `AGENTS.md`; `ai/SKILLS.md`; `ai/skills/`; `ai/PLAYBOOKS.md`; `ai/playbooks/`; `ai/MEMORY.md`.
+- Top-level repo-local skills: `Designer`, `PM`, `Developer`, `Framework Keeper`, `Quality Engineer`.
+- Root `version.txt` is the canonical repo release value; production telemetry should align with tag form `vX.Y.Z`.
+- Feature PRs open ready for review by default unless the user asks for draft.
+- Feature branches target `staging`; `staging` -> `main` is the governed production path.
+- Pull requests must not merge until every configured gate on the current head SHA is green.
+- CodeRabbit is substance-gating: thread closure needs a visible outcome, not just a green check.
+- Wait for CodeRabbit auto-review first; use `@coderabbitai review` only for stalled runs.
+- If current-head thread closure is complete but `CHANGES_REQUESTED` persists, use the canonical approval prompt from the PR playbook.
+- Stale bot reviews on older SHAs may be dismissed by a maintainer only after current-head closure is complete and documented.
+- Keep `spec/policy/event-taxonomy.yaml` aligned with runtime emitters.
+- Sentry is part of the default implementation surface for frontend and backend feature work in this repo.
+- `docs/ANALYTICS_STANDARD.md` and `docs/QUALITY_STANDARD.md` are separate governed standards; do not collapse them.
+- Quality maturity phases are defined in `docs/QUALITY_STANDARD.md`; agents do not self-advance phases.
+- For `products/dashboard`, auth code outside adapters must depend on `products/dashboard/lib/auth/`.
+- Dashboard auth lifecycle must flow through shared analytics and monitoring identity helpers.
+- GitHub issue resolution uses grouped fixes when issues share a real root cause.
+- Sentry issue resolution requires assignment, in-flight notes, evidence-based closure, and PR linkage.
 
 ## Active Open Loops
 
-- Encode the current framework playbooks as machine-readable process artifacts under future `spec/processes/`.
-- Add `spec/processes/quality-standard-process.yaml` once process schemas exist, to machine-validate phase criteria and gate rules.
+- Encode playbooks as machine-readable process artifacts under future `spec/processes/`.
+- Add a process artifact for the Quality Standard once process schemas exist.
 
 ## Recent Decisions
 
-- 2026-04-11: Pull request playbook and `AGENTS.md` now state explicitly that the **executing agent** owns **merge completion** (or verifying merge-queue merge) when gates are green and policy allows; bounded polling or operator signal preferred over endless waits.
-- 2026-04-11: Agent bundle consolidated under `ai/` (indices, `playbooks/`, `skills/`, `MEMORY.md`); root keeps only `AGENTS.md` as the common entry point for tools. P0/P1/P2 remain de-emphasized as playbook identity (workflows may still use `p1-*` / `P1_*` names for traceability).
-- 2026-04-10: Adopted a repository-local agent context bundle built around `AGENTS.md` and files under `ai/`.
-- 2026-04-10: Added the agent context bundle as a first-class playbook in the framework.
-- 2026-04-11: Standardized the repository-local skills system on a low-cost `ai/SKILLS.md` index plus on-demand `ai/skills/` files, and seeded the first role-oriented skills as `Designer`, `PM`, and `Developer`.
-- 2026-04-11: Standardized pull request review policy on CodeRabbit auto-review via `.coderabbit.yaml` and moved low-risk merge execution to Mergify via `.mergify.yml`.
-- 2026-04-11: Tightened Dependabot scheduling for `npm` and GitHub Actions on `main`, grouped routine version updates, and labeled dependency PRs for the low-risk automation path.
-- 2026-04-11: Set repository-local agent behavior to open pull requests ready for review by default; draft PRs require an explicit user request.
-- 2026-04-11: Tightened pull request merge policy and `main` protection so merges wait for the full merge-gate set (`validate`, `decide`, and reviewer status) even if host protection is misconfigured.
-- 2026-04-11: Standardized CodeRabbit handling so automatic review is the default path and manual `@coderabbitai review` comments are only for stalled-review recovery.
-- 2026-04-11: Refined CodeRabbit recovery policy: auto-trigger only if no reviewer signal appears after about 15 seconds; once review has clearly started, poll up to 5 minutes and then ask the user before posting `@coderabbitai review`.
-- 2026-04-17: Documented canonical `@coderabbitai` approval prompt for clearing stale `CHANGES_REQUESTED` when threads are addressed; see playbook section 3 item 6. Reserve `@coderabbitai review` for stalled auto-runs only.
-- 2026-04-11: CodeRabbit `request_changes_workflow` enabled; pull request playbook and `AGENTS.md` require visible per-finding closure (fix or stated decision) before merge—green status alone is not enough.
-- 2026-04-11: CodeRabbit finding closure should be recorded in the review thread itself when possible, and stale or cancelled required jobs should be rerun on the current head before considering control-plane changes.
-- 2026-04-11: `p1-policy` `decide` polls required reviewer commit statuses (shared wait budget across contexts; `P1_POLICY_REVIEWER_STATUS_*` vars) so the check stays in progress while CodeRabbit is pending instead of failing immediately.
-- 2026-04-11: `decide` refreshes issue labels after earlier gates and polls for a `residual:*` label (`P1_POLICY_RESIDUAL_LABEL_*` vars) so the residual risk engine can land slightly after `decide` starts without failing red on a stale label read.
-- 2026-04-11: Added `Framework Keeper` as a repository-local skill and `ai/playbooks/framework-review.md` as the canonical procedure for auditing the framework itself for consistency, efficiency, and predictability.
-- 2026-04-12: Renamed `agents/` to `interfaces/` so provider-agnostic logical tool contracts are named for their actual role and remain distinct from the runtime bootstrap bundle under `ai/`.
-- 2026-04-12: When repository work is requested “via PR” or to “open a PR,” default execution should follow the pull request execution loop playbook rather than treating PR creation as a standalone publication step.
-- 2026-04-12: Tightened `docs/AI_NATIVE_FRAMEWORK.md` to prefer summary-level routing in large framework sections, keep detailed operating logic in canonical playbooks, pair `ai/SKILLS.md` with `ai/PLAYBOOKS.md` as adjacent but distinct surfaces, and use `skill layer` / `workflow library` terminology instead of the older `capability layer` / `process library` wording.
-- 2026-04-12: Recorded in Stable Facts that `spec/policy/event-taxonomy.yaml` must stay aligned with runtime emitters (PR #44 / dashboard product wiring).
-- 2026-04-12: Standardized repository-local developer guidance so Sentry is expected for frontend and backend feature work by default; the detailed required features and decision rules live in `ai/skills/developer.md`.
-- 2026-04-12: For review-finding closure, agents should reply directly on each CodeRabbit thread when they fix or disposition a finding; consolidated PR comments do not replace per-thread accounting, and agents should still post the direct reply even if CodeRabbit later auto-resolves the thread after re-review.
-- 2026-04-12 (PR #46 closure): **CodeRabbit rate limits** and **stale submitted reviews** can block merge even when the reviewer **status** is green. If `CHANGES_REQUESTED` remains only from older SHAs after thread closure, a maintainer may dismiss stale submissions (see playbook finding closure item 7). For **Mergify**, re-queue with `@mergifyio queue` and the queue name from `.mergify.yml`; clear a **`dequeued`** label if it blocks retry.
-- 2026-04-13: Standardized repository-level release automation on `release-please` in manifest mode with repo-wide SemVer tags, a dedicated `RELEASE_PLEASE_TOKEN` requirement for triggering downstream workflows, and a canonical release-management playbook under `ai/playbooks/release-management.md`.
-- 2026-04-13: Standardized dashboard release telemetry on a single app-release value derived from root `version.txt` for production builds and commit SHA fallback elsewhere; Sentry release sync on GitHub `release.published` is optional and activates only when Sentry secrets/vars are configured.
-- 2026-04-13: Established single-release-source principle for Sentry configurations: one `const release = getServerSentryRelease()` call drives both `Sentry.init({ release })` and `initialScope.tags.app_release` so the two values can never diverge when `SENTRY_RELEASE` is overridden externally. Never call `getAppRelease()` and a Sentry-specific resolver separately and assign them to different fields.
-- 2026-04-13: Standardized file-path resolution for repo-root artifacts consumed by nested packages: use `__dirname`-relative candidate paths (primary: `path.resolve(__dirname, "../../version.txt")`; fallback: `path.resolve(__dirname, "version.txt")`) rather than `process.cwd()`-relative paths so lookups are stable across build entrypoints regardless of invocation directory.
-- 2026-04-13: Configured CodeRabbit to skip automated review of release-please PRs via `ignore_title_patterns: ["^chore: release"]` in `.coderabbit.yaml` to eliminate review overhead on machine-generated release commits. Pattern matches the configured `pull-request-title-pattern` in `release-please-config.json` (`"chore: release ${version}"`).
-- 2026-04-13: Added `docs/QUALITY_STANDARD.md` as a first-class framework standard covering verification layers, merge-gate model, CI execution model, 3-phase maturity (Tooling Foundation → AI Reliability → Scaling Confidence), dashboard reference expectations, agent responsibilities, and incident-to-regression discipline. Default stack: Vitest, RTL, MSW, Playwright, Sentry, PostHog, Vercel previews. Keep Analytics Standard as a separate governed surface; the two cross-reference each other at observability and production feedback loop boundaries.
-- 2026-04-13: Implemented Phase 1 (Tooling Foundation) for products/dashboard: Vitest + RTL + MSW unit/component/integration tests, Playwright critical-path E2E + axe accessibility, `test.yml` and `e2e.yml` CI workflows (both added as blocking gates in `.mergify.yml`), nightly.yml for full suite. Framework artifacts: `ai/playbooks/quality-standard-execution.md` (PR gate loop, nightly triage, incident-to-regression), `ai/skills/quality-engineer.md` (skill body). Merge gate model now requires: validate + test + e2e + CodeRabbit + decide.
-- 2026-04-13: The `e2e` CI check triggers via GitHub `deployment_status` event (Vercel preview must be active). `BASE_URL` env var is passed from `github.event.deployment_status.environment_url`. If Vercel is not connected, the e2e check will not run — escalate to human operator rather than skipping the gate.
-- 2026-04-17: Canonicalized dashboard auth as a governed product slice. Durable rules: keep provider-specific auth logic inside `products/dashboard/lib/auth/`, use shared analytics/monitoring identity helpers for sign-in and sign-out lifecycle, and allow only a secret-gated E2E authenticated-session bypass for deterministic browser verification when external auth setup is otherwise unstable on previews.
-- 2026-04-17: When rebasing a PR branch that conflicts in `ai/playbooks/` or `ai/skills/`, prefer the HEAD (main) version — those files were already user-reviewed and merged; the branch copy is stale.
-- 2026-04-17: E2E tests that require an external backend need two independent skip guards: app-config visibility (e.g. `isVisible()` on the form) to check whether the feature is enabled in the deployed app, and runner env vars (e.g. `NEXT_PUBLIC_SUPABASE_URL`) to check whether the backend is reachable from the test runner. Neither guard alone is sufficient.
-- 2026-04-18: Added first-class issue-resolution playbooks for GitHub and Sentry. GitHub issue work now standardizes batching by shared root cause with required pre-edit and post-PR comments on every issue; Sentry issue work now standardizes assignment, unresolved-in-flight status, triage and resolution notes, and evidence-based closure using PR merge time plus `lastSeen` and recent event data.
-- 2026-04-19: Mergify `staging-integration` queue requires `residual:low` label + `check-success = CodeRabbit` status + all gate checks (`validate`, `test`, `e2e`, `decide`). When Mergify shows NEUTRAL on a feature→staging PR, verify the `residual:low` label is present; if it is and the queue still does not pick up the PR, try `@mergifyio queue staging-integration`; if that also fails, squash-merge manually via `gh pr merge --squash`. The Mergify merge queue is only guaranteed to auto-trigger when all queue_conditions in `.mergify.yml` are simultaneously satisfied.
-- 2026-04-19: When a Linear issue tracks an implementation task, keep it in sync at every milestone throughout the PR loop — not just at the start and end. Required touchpoints: In Progress + plan comment (start), In Review + PR link attachment (PR open), CodeRabbit round comment (each review cycle), Done + closed checklist + next-issue pointer (merge). Each comment must be self-contained so any agent can resume cold. This pattern is codified in `ai/skills/developer.md` step 16.
-- 2026-04-18: Adopted a 3-tier deployment model (production / staging / development): `staging` is a long-lived protected branch mirroring `main`; feature PRs target `staging`; `staging` → `main` is the release gate using regular merge (not squash) to preserve conventional commit history for release-please; nightly CI targets `STAGING_URL` (never production); PostHog is Production-only (token unset on Preview/Development); Sentry remains active on staging with environment tags for filtering. Full procedure in `ai/playbooks/environment-separation.md`.
-- 2026-04-19: Added `ai/playbooks/publish-to-production.md` as the canonical answer to "how do I open a PR to `main`?" in this repository. Direct feature PRs to `main` remain invalid; the governed production path is a ready-for-review `staging` -> `main` promotion PR merged through the `staging-promotion` queue with a regular merge commit, followed by release-please verification on the new `main` head.
-- 2026-04-19: Tightened PR publication discipline so agents must refresh their branch against the intended base branch before creating a PR; the post-publication branch-sync workflow remains a safety net, not a substitute for opening from a stale head.
-- 2026-04-19: Added an automated `main` → `staging` back-merge as the canonical closer of every production publish (`ai/playbooks/publish-to-production.md` §8). The publish sequence is now three PRs: feature → `staging` (squash), `staging` → `main` (merge), and `chore/back-merge-main-after-vX.Y.Z` → `staging` (merge). The third PR is opened and admin-merged by `.github/workflows/back-merge-to-staging.yml` on `release: published`, using `RELEASE_PLEASE_TOKEN` to bypass branch protection. `.mergify.yml` carries a `back-merge-to-staging` queue (`merge_method: merge`) as a fallback, and `staging-integration` now explicitly excludes `chore/back-merge-main-after-*` so a back-merge can never accidentally squash. Squashing the back-merge is the failure mode that leaves `staging` content-equal but history-divergent from `main` and forces every subsequent promotion PR open in `BEHIND`.
-- 2026-04-19: Mergify negation syntax is the `-` prefix on the whole condition, not `!~=`. An earlier `head !~= ^chore/back-merge-main-after-` exclusion in `.mergify.yml` was silently treated as a no-op, which let `staging-integration` admit back-merge PR #110 and squash it — re-breaking ancestry exactly the way the workflow was supposed to prevent. Always write `-head ~= ^pattern` for "head does not match". Also: when running the §8 manual back-merge fallback, **open the PR as draft** until checks settle, then `gh pr ready` + `gh pr merge --merge --admin` in the same step. Drafting locks Mergify out so a queue-selection race cannot squash the back-merge while you wait for checks.
-- 2026-04-19: Mergify condition strings that contain a colon (e.g. `title ~= ^chore: ...`) **MUST** be YAML-quoted, otherwise YAML parses the colon as a mapping key/value separator and the entire condition (and silently the entire queue config) becomes invalid. Mergify's `Configuration changed` check is the only signal that surfaces this — locally `.mergify.yml` looks fine. PR #109 shipped with `- title ~= ^chore: back-merge main into staging after release` (unquoted) and the `back-merge-to-staging` queue was silently dead from merge until PR #112 (promotion) failed `Configuration changed`. Always quote any Mergify condition value containing `:` and run `mergify config-check` (or rely on the GitHub `Configuration changed` status) before assuming a config change is live.
-- 2026-04-19 (PR #119 / AEL-47): For any PR initially classified `risk:high` that the residual-risk engine later downgrades to `residual:low`, the original `pull_request_review`-triggered `p1-policy` `decide` run will have failed as "human approval required" before the `residual:*` label existed. Newer `pull_request_target`-triggered `decide` runs succeed, but the older `FAILURE` rows stay in GitHub's check rollup, branch protection blocks merge, and Mergify dequeues with a `dequeued` label. **Recovery (do not wait for self-heal):** rerun the failed `decide` runs on the current head SHA, remove the `dequeued` label, and re-queue with `@mergifyio queue <queue-name>` (e.g. `staging-integration`). Codified in `ai/playbooks/pull-request-execution-loop.md` finding-closure item 6 and `ai/skills/developer.md` step 11; do not reach for admin merge or settings changes as a workaround.
-- 2026-04-19: Extended the 3-tier environment model to the data tier. One Supabase project per environment (`<product>-staging`, `<product>-production`) under one organization. CI in `.github/workflows/supabase-migrate.yml` exposes three stable check names: `migrate-validate` (PR-time lint + local apply, no-ops when migrations folder untouched), `migrate-staging` (push to `staging`, `supabase db push` against staging project via env-scoped secrets), `migrate-production` (push to `main`, same against production project, gated on the `production` GitHub Environment with required reviewers). `.mergify.yml` requires `migrate-validate` on `staging-integration` and `migrate-staging` on `staging-promotion` — the promotion PR cannot merge until staging migrations are green on the head SHA. Vercel env vars: production scope points at the production Supabase project, preview scope at staging; never share URLs across scopes. Migrations are forward-only and must be backwards-compatible across a release boundary because `migrate-production` runs in parallel with the Vercel production deploy. Full procedure in `ai/playbooks/environment-separation.md` Database tier section.
-- 2026-04-19 (post-v0.12.0 release): Each release-please cut produced two `migrate-production` runs that both required manual environment approval — one against the promotion merge commit (real `db push`) and one against the immediately following `chore: release X.Y.Z` commit (guaranteed no-op, since release-please only bumps version/CHANGELOG and never carries new migrations). Fixed by skipping the `migrate-production` job at the job-level `if:` when `github.event.head_commit.message` starts with `chore: release` followed by a space on push events (workflow_dispatch is intentionally exempt — manual operator action). `migrate-staging` is intentionally NOT subject to this skip because the `staging-promotion` Mergify queue requires `check-success = migrate-staging` on the staging head SHA — a job-level skip would produce no check and starve the next promotion. `supabase db push` is idempotent on staging so the always-runs cost there is just CI seconds. Skip rule lives only in the workflow's `if:` (job is gated before the GitHub Environment approval prompt fires); a step-level skip would still trigger the approval gate and not solve the friction.
+- 2026-04-10: Adopted the repository-local agent context bundle built around root `AGENTS.md` plus `ai/`.
+- 2026-04-11: Standardized repository-local skills and playbooks as index + on-demand body surfaces under `ai/`.
+- 2026-04-11: Standardized PR policy on CodeRabbit auto-review, Mergify execution, and executing-agent merge ownership.
+- 2026-04-12: Renamed `agents/` to `interfaces/` for provider-agnostic capability contracts.
+- 2026-04-13: Standardized repo-level release automation on `release-please`, manifest mode, and root `version.txt`.
+- 2026-04-13: Added `docs/QUALITY_STANDARD.md` and Phase 1 verification surfaces for `products/dashboard`.
+- 2026-04-17: Canonicalized dashboard auth as a governed product slice with adapter isolation and shared identity lifecycle helpers.
+- 2026-04-18: Added governed playbooks for resolving GitHub issues and Sentry incidents.
+- 2026-04-18: Adopted the 3-tier environment model: production, staging, development.
+- 2026-04-19: Canonicalized `staging` -> `main` promotion, back-merge rules, Mergify queue behavior, and Supabase environment separation.
+- 2026-04-21: Default bootstrap no longer loads `docs/AI_NATIVE_FRAMEWORK.md` unless the user references The Framework or the task needs framework prose; always-loaded surfaces were compacted to reduce token cost.
 
 ## Update Rules
 
-- Add facts only if they are likely to matter in future sessions.
-- Remove or rewrite facts when they become stale.
-- Close open loops instead of letting this file grow indefinitely.
-- If a memory item becomes normative policy, move it into schema, playbook, or framework docs and leave only a short pointer here.
+- Add only facts likely to matter in future sessions.
+- Rewrite or remove stale facts.
+- Close open loops instead of accumulating historical detail.
+- If an item becomes normative policy, move it into a playbook, doc, or schema and leave only a pointer here.

--- a/ai/PLAYBOOKS.md
+++ b/ai/PLAYBOOKS.md
@@ -1,146 +1,114 @@
 # PLAYBOOKS.md
 
-This file is the playbook discovery index for this repository. It lives under **`ai/`** next to `SKILLS.md` and the `playbooks/` subdirectory. Read it to decide which procedure applies, then open only the linked file under `playbooks/`. Agents also see matching entries in `ai/SKILLS.md` for routing; this file is the canonical inventory of procedure playbooks.
+Playbook discovery index. Choose the closest procedure, then open only that file under `ai/playbooks/`.
 
-Each playbook is **atomic**: it states its own objective, inputs, outputs, and constraints. You can open any one of them when that topic is what you need.
+## Use
 
-## How To Use This File
+1. Match the task to one playbook.
+2. Open only the linked file.
+3. Follow higher-authority references from inside that playbook.
+4. If nothing fits, finish the task conservatively and consider whether the framework needs a new playbook.
 
-1. Match the situation to the closest playbook entry below.
-2. Open only the linked playbook under `playbooks/` for the selected entry.
-3. Follow cross-references inside that playbook when they point at schema, policy, or tooling.
-4. If no entry fits, treat the gap as a signal to extend the framework or add a new playbook after the task is complete.
-
-Discovery should stay broad and cheap. Execution should stay narrow and deep.
-
-## Suggested Bootstrap Order (Not Part Of Playbook Identity)
-
-When you are **standing up a new framework-aligned repository**, work usually flows:
-
-1. Establish a governed baseline (repository foundation) so CI, checks, and protection are real.
-2. Layer pull request automation on top of that baseline.
-3. Add or refresh the material under `ai/` (this index, skills, playbooks, memory) when agents will participate repeatedly.
-
-That sequence is **practical**, not a ranking of importance: mature repos often touch only one playbook at a time.
-
-## Relationship To `SKILLS.md`
-
-- **`ai/SKILLS.md`** routes agents to the right *next file* (skills, playbooks, or spec surfaces).
-- **`PLAYBOOKS.md`** (this file) lists every procedure playbook and what each one is responsible for; bodies live in `playbooks/*.md` relative to `ai/`, the same way skill bodies live in `skills/*.md` relative to `ai/`.
-- When you add or retire a playbook, update this file and align `SKILLS.md` in this directory (and root `AGENTS.md` if the important-paths map changes).
-
-## Playbook Index
+## Index
 
 ### Repository foundation
 
-- **When to use:** creating a new repository, or auditing or repairing governance, CI, branch protection, security defaults, and contributor surfaces.
-- **Inputs:** repository name and owner; default branch; at least one passing validation workflow; maintainer handle for CODEOWNERS.
-- **Outputs:** governed execution surface with CI, protection aligned to real checks, merge defaults, governance files, and dependency or security automation as described in the playbook.
-- **Load:** [`playbooks/repository-foundation.md`](playbooks/repository-foundation.md)
-- **Constraints:** do not guess required check names; read checks the host actually emits.
+- When to use: create, audit, or repair repo governance, CI, protection, and contributor surfaces
+- Inputs: repo owner/name, default branch, passing validation workflow, maintainer handle
+- Outputs: governed repo baseline and recorded settings
+- Load: `playbooks/repository-foundation.md`
+- Constraints: bind required checks to real emitted check names
 
 ### Pull request execution loop
 
-- **When to use:** every pull request targeting a protected branch; or when designing, implementing, or reviewing PR automation, risk policy, branch freshness, or merge authority.
-- **Inputs:** PR metadata, diff, labels, required checks, CODEOWNERS, threshold policy, reviewer configuration, freshness policy, and policy decision mapping residual risk to merge authority.
-- **Outputs:** risk classification, residual-risk decision, freshness decision, validation and review evidence, and a recorded decision path (approve, escalate, request changes, or merge when allowed).
-- **Load:** [`playbooks/pull-request-execution-loop.md`](playbooks/pull-request-execution-loop.md)
-- **Constraints:** machines verify, humans decide; treat the AI reviewer and merge executor as replaceable implementations behind policy. Configured workflows in this repository use a `p1-*` / `P1_*` naming prefix for traceability; that prefix refers to this playbook, not to an ordering label.
+- When to use: any PR targeting a protected branch; PR automation, risk, review, freshness, or merge-policy work
+- Inputs: PR metadata, labels, checks, review state, branch freshness, threshold policy
+- Outputs: residual-risk decision, merge path, or escalation request
+- Load: `playbooks/pull-request-execution-loop.md`
+- Constraints: machines verify, humans decide
 
 ### Agent context bundle
 
-- **When to use:** installing or maintaining the agent bundle: root `AGENTS.md`, plus `SKILLS.md`, optional `skills/`, and `MEMORY.md` under `ai/`, whenever bootstrap behavior or the authority ladder changes.
-- **Inputs:** repository purpose; authority ladder; canonical commands; playbook inventory; glossary and architecture facts; durable memory and open loops.
-- **Outputs:** concise root `AGENTS.md`, an index-shaped `ai/SKILLS.md`, optional `ai/skills/*.md` bodies, maintained `ai/MEMORY.md`, and links from README or framework docs into `ai/`.
-- **Load:** [`playbooks/agent-context-bundle.md`](playbooks/agent-context-bundle.md)
-- **Constraints:** keep the bundle subordinate to schema and policy; do not duplicate full playbooks inside the root index files.
+- When to use: create or maintain root `AGENTS.md` and the `ai/` bundle
+- Inputs: authority ladder, commands, playbook inventory, skill inventory, durable facts, open loops
+- Outputs: maintained bootstrap bundle
+- Load: `playbooks/agent-context-bundle.md`
+- Constraints: keep bundle concise and subordinate to higher-order artifacts
 
 ### Framework review
 
-- **When to use:** auditing the framework itself for contradiction, duplication, unnecessary complexity, or missing decision rules.
-- **Inputs:** audit scope, authoritative sources in ladder order, recent framework changes, and known friction points.
-- **Outputs:** structured findings, remediation recommendations, and explicit keep-as-is decisions for stable areas.
-- **Load:** [`playbooks/framework-review.md`](playbooks/framework-review.md)
-- **Constraints:** audit the framework, not ordinary feature code; follow the authority ladder and do not weaken higher-order artifacts to satisfy lower-order drift.
+- When to use: audit the framework for contradiction, duplication, ambiguity, or operating drag
+- Inputs: audit scope, authoritative artifacts, recent changes, known pain points
+- Outputs: findings, remediations, and explicit no-change calls
+- Load: `playbooks/framework-review.md`
+- Constraints: audit the framework, not ordinary feature code
 
 ### Feature implementation (dashboard)
 
-- **When to use:** implementing any new feature in `products/dashboard/` from a completed feature request.
-- **Inputs:** completed `templates/feature-request.md`; current `spec/examples/dashboard-product.yaml`; current `products/dashboard/lib/analytics/events.ts`.
-- **Outputs:** updated spec YAML, updated `AnalyticsEvent` type registry, feature component(s), dual-pipeline analytics wiring (PostHog + internal audit), passing `npm run validate`.
-- **Load:** [`playbooks/feature-implementation.md`](playbooks/feature-implementation.md)
-- **Constraints:** spec update and type registry entry are required before any component code; `npm run validate` must pass before the PR ships; `posthog-js` may only be imported in the approved files listed in `docs/ANALYTICS_STANDARD.md` §3 — feature code must use `useAnalytics()` from `lib/analytics/events`.
+- When to use: implement a dashboard feature from a completed feature request
+- Inputs: feature request, current spec YAML, analytics event registry
+- Outputs: updated spec, registry, implementation, validation evidence
+- Load: `playbooks/feature-implementation.md`
+- Constraints: spec first; events required before code
 
 ### Release management
 
-- **When to use:** enabling or changing repository-level release automation, tags, changelog generation, or GitHub Release behavior.
-- **Inputs:** release branch, release strategy, current version baseline, token configuration, and merge policy.
-- **Outputs:** governed release workflow, repo-level SemVer tags, release PRs, and GitHub Releases.
-- **Load:** [`playbooks/release-management.md`](playbooks/release-management.md)
-- **Constraints:** release the repository as a single unit; use a dedicated automation token when downstream workflows must trigger; route changes through the normal PR loop.
+- When to use: enable, change, or audit repo-level release automation
+- Inputs: release branch, strategy, version baseline, token config, merge policy
+- Outputs: release workflow, config, tags, GitHub Releases
+- Load: `playbooks/release-management.md`
+- Constraints: release the repository as one unit
 
 ### Publish to production
 
-- **When to use:** publishing reviewed work from `staging` to production; or when someone asks how to open a PR to `main` in this repository.
-- **Inputs:** current `staging` and `main` SHAs, promotion PR state, merge-gate state, and release automation state.
-- **Outputs:** open or merged `staging` -> `main` promotion PR, plus verification that release automation observed the new `main` head.
-- **Load:** [`playbooks/publish-to-production.md`](playbooks/publish-to-production.md)
-- **Constraints:** do not open feature PRs directly to `main`; use a regular merge commit for `staging` -> `main`; do not wait for CodeRabbit on the promotion PR.
+- When to use: publish reviewed `staging` work to production or answer how PRs to `main` work here
+- Inputs: `staging` and `main` SHAs, promotion PR state, queue state, release automation state
+- Outputs: open or merged `staging` -> `main` promotion PR and publish evidence
+- Load: `playbooks/publish-to-production.md`
+- Constraints: no feature PRs directly to `main`; promotion uses regular merge
 
 ### Quality standard execution
 
-- **When to use:** PR gate failures, nightly CI triage, incident-to-regression loop, phase readiness audit.
-- **Inputs:** current phase, blocking gate state (check names and statuses), incident ID, eval results.
-- **Outputs:** all blocking gates green; regression test merged and incident closed; phase readiness evidence bundle.
-- **Load:** [`playbooks/quality-standard-execution.md`](playbooks/quality-standard-execution.md)
-- **Constraints:** follow the merge-gate model in `docs/QUALITY_STANDARD.md §6`; do not advance phase without checking off the required list; accessibility violations on critical flows are non-deferrable.
+- When to use: PR gate failures, nightly triage, incident-to-regression work, phase-readiness audit
+- Inputs: current phase, gate state, incident ID, eval or test results
+- Outputs: green gates, regression coverage, or phase evidence bundle
+- Load: `playbooks/quality-standard-execution.md`
+- Constraints: follow `docs/QUALITY_STANDARD.md`; do not self-advance phase
 
 ### Resolve GitHub issues
 
-- **When to use:** triaging and fixing open GitHub issues, especially recurring nightly or operational issues that may batch into one fix.
-- **Inputs:** open issue set, labels, comments, current `main` HEAD, relevant failing workflow evidence, validation command, PR execution policy.
-- **Outputs:** grouped issue plan, pre-change comments on every in-scope issue, one PR per fix group, and post-PR issue updates with next action.
-- **Load:** [`playbooks/resolve-github-issues.md`](playbooks/resolve-github-issues.md)
-- **Constraints:** batch only when issues share the same failing step, file, or root cause; comment intent on every issue before editing; drive the fix through the PR execution loop.
+- When to use: triage and fix open GitHub issues, especially grouped operational failures
+- Inputs: issue set, workflow evidence, validation command, PR policy
+- Outputs: grouped plan, pre-change comments, one PR per fix group, explicit issue updates
+- Load: `playbooks/resolve-github-issues.md`
+- Constraints: comment intent before editing; batch only when root cause is shared
 
 ### Resolve Sentry issues
 
-- **When to use:** triaging and closing live Sentry incidents, especially unresolved or `escalating` production issues.
-- **Inputs:** Sentry org/project, issue ID, write-capable token, linked PR, recent event data, release and deploy evidence.
-- **Outputs:** assigned issue, triage note, evidence-based closure decision, resolution note, and final Sentry state.
-- **Load:** [`playbooks/resolve-sentry-issues.md`](playbooks/resolve-sentry-issues.md)
-- **Constraints:** keep issues `unresolved` while the fix is in flight; close only with explicit evidence from merge timing and post-merge Sentry data.
+- When to use: triage and close live Sentry incidents
+- Inputs: org/project, issue ID, write token, linked PR, recent event data
+- Outputs: assignment, triage note, evidence-based closure, resolution note
+- Load: `playbooks/resolve-sentry-issues.md`
+- Constraints: keep issue unresolved until post-merge evidence supports closure
 
 ### Environment separation
 
-- **When to use:** establishing or auditing the 3-tier deployment environment model (production / staging / development) for a repository or product; when automated test traffic is polluting production analytics or error dashboards; when adding a new observability tool that needs environment-scoped tokens.
-- **Inputs:** repository owner and name, production domain, staging domain, Vercel project access, GitHub admin access, GitHub token.
-- **Outputs:** `staging` branch with identical protection to `main`; nightly CI retargeted to staging; PostHog token scoped to Production Vercel environment only; Sentry active on staging with environment tags; Mergify staging-integration and staging-promotion queues; updated framework docs.
-- **Load:** [`playbooks/environment-separation.md`](playbooks/environment-separation.md)
-- **Constraints:** never target production from nightly CI; do not use a separate PostHog project for non-production; `staging` → `main` must use regular merge to preserve conventional commit history; Vercel integration-managed variables require removal and manual re-addition to scope by environment.
+- When to use: establish or audit the 3-tier production/staging/development model
+- Inputs: repo owner/name, production and staging domains, Vercel access, GitHub admin access
+- Outputs: protected `staging`, staged CI targets, scoped observability env vars, environment docs
+- Load: `playbooks/environment-separation.md`
+- Constraints: never target production from nightly CI
 
 ### Service wiring
 
-- **When to use:** configuring external services (Supabase auth, Vercel env vars, OAuth providers) for a new environment, or debugging auth failures caused by misconfigured redirect URLs or missing env vars.
-- **Inputs:** target environment domain, list of auth providers to enable, Supabase project ref, Vercel project and team IDs.
-- **Outputs:** Supabase auth configured (Site URL, Redirect URLs, email confirmation toggle), environment variables set in `.env.local` and Vercel, provider list consistent across code and dashboard.
-- **Load:** [`playbooks/service-wiring.md`](playbooks/service-wiring.md)
-- **Constraints:** Supabase auth config and Vercel env vars cannot be updated via MCP or code — both require dashboard steps documented in the playbook. Do not search for tools that do not exist; go directly to the dashboard.
+- When to use: configure Supabase auth, Vercel env vars, or OAuth providers; debug service-side auth misconfiguration
+- Inputs: target domain, auth providers, Supabase project ref, Vercel project details
+- Outputs: aligned dashboard config, env vars, and provider exposure
+- Load: `playbooks/service-wiring.md`
+- Constraints: dashboard-only steps stay dashboard-only
 
----
+## Maintenance
 
-## Adding A New Playbook
-
-Add a new playbook document under `ai/playbooks/` when all of these are true:
-
-- the procedure recurs or governs a long-lived loop
-- the trigger and outcomes are stable enough to version in prose
-- the workflow is not already better expressed as a single `ai/skills/*.md` harness
-
-Prefer filenames `{kebab-case-slug}.md` (for example `repository-foundation.md`) so the topic reads clearly; the `playbooks/` directory under `ai/` already namespaces them. Do not encode ordering in the filename unless the repository has an explicit, stable sequence contract.
-
-For each new playbook:
-
-- add a row to this index with when to use, inputs, outputs, load path, and constraints
-- add or adjust a matching entry in `ai/SKILLS.md` when agents should route to it
-- update `docs/AI_NATIVE_FRAMEWORK.md` or `README.md` when the framework’s human-facing map should show the new procedure
+- Add a playbook only for recurring, stable procedures.
+- Keep this file index-shaped: when to use, inputs, outputs, load, constraints.
+- Update `ai/SKILLS.md` and any relevant docs when the inventory changes.

--- a/ai/SKILLS.md
+++ b/ai/SKILLS.md
@@ -1,162 +1,154 @@
 # SKILLS.md
 
-This file is the skill discovery index for the repository-local agent bundle under **`ai/`** (root `AGENTS.md` is the only agent file outside this folder). Read it to decide which skill to load, then open only the specific `skills/*.md` file next to this index or a playbook under `playbooks/` for the current task. For playbook routing alone, you may start from `PLAYBOOKS.md` in this directory instead.
+Skill discovery index. Choose one skill or routed playbook, then open only that file.
 
-## How To Use This File
+## Use
 
-1. Match the task to the closest skill or playbook entry below.
-2. Open only the linked skill file or canonical source for the selected entry.
-3. Load deeper references only when the selected skill says they are needed.
-4. If no entry fits, work conservatively and consider whether the workflow deserves a new skill after the task is complete.
+1. Match the task to the closest entry.
+2. Open only the linked skill or playbook.
+3. Load deeper references only when that file requires them.
+4. If nothing fits, work conservatively and consider whether the framework needs a new skill.
 
-Discovery should stay broad and cheap. Execution should stay narrow and deep.
-
-## Skill Index
+## Index
 
 ### Framework Bootstrap
 
-- **When to use:** orienting a new agent or starting substantial work in this repository
-- **Inputs:** repository purpose, current task, affected files
-- **Outputs:** correct read order, authority map, and validation plan
-- **Load:** `AGENTS.md`, `README.md`, `docs/AI_NATIVE_FRAMEWORK.md`, `PLAYBOOKS.md` (in this directory)
-- **Notes:** use this before making policy, playbook, or workflow changes
+- When to use: orient a new agent before substantial work
+- Inputs: repo purpose, task, affected files
+- Outputs: read path, authority map, validation plan
+- Load: `AGENTS.md`, `README.md`, `PLAYBOOKS.md`
+- Constraints: open `docs/AI_NATIVE_FRAMEWORK.md` only when the task explicitly needs The Framework
 
 ### Designer
 
-- **When to use:** creating or refining visual assets, brand elements, and design directions
-- **Inputs:** goal, brand intent, target surface, references, human feedback
-- **Outputs:** concrete design directions, selected asset, implementation-ready handoff
-- **Load:** `skills/designer.md`
+- When to use: create or refine visual assets and design directions
+- Inputs: goal, target surface, references, feedback
+- Outputs: selected direction or asset-ready handoff
+- Load: `skills/designer.md`
+- Constraints: visual exploration, not implementation
 
 ### PM
 
-- **When to use:** shaping a requested change into scope, rationale, acceptance criteria, and implementation guidance
-- **Inputs:** goal, constraints, selected concept, affected surfaces
-- **Outputs:** concise change brief, scope, non-goals, acceptance criteria
-- **Load:** `skills/pm.md`
+- When to use: turn intent into scope, rationale, and acceptance criteria
+- Inputs: goal, constraints, selected concept, affected surfaces
+- Outputs: concise brief, scope, non-goals, acceptance criteria
+- Load: `skills/pm.md`
+- Constraints: do not invent PM work when scope is already clear
 
 ### Developer
 
-- **When to use:** implementing repository changes and carrying them through validation, PR review, and merge per the pull request execution playbook
-- **Inputs:** approved scope, affected files, repository constraints, live PR state
-- **Outputs:** implementation, verification evidence, review closure, published PR state
-- **Load:** `skills/developer.md`
-
-### Feature implementation (dashboard product)
-
-- **When to use:** implementing a new feature in `products/dashboard/` from a completed `templates/feature-request.md`
-- **Inputs:** completed feature request, current spec YAML, current `AnalyticsEvent` type registry
-- **Outputs:** updated spec, updated type registry, wired component(s), passing validation, PR
-- **Load:** `playbooks/feature-implementation.md`
-- **Constraints:** spec-first; events required before code; `npm run validate` before PR
+- When to use: implement repo changes and carry them through validation, review, and merge
+- Inputs: approved scope, affected files, repo constraints, live PR state
+- Outputs: implementation, verification evidence, merged PR or explicit escalation
+- Load: `skills/developer.md`
+- Constraints: the executing agent owns convergence through merge when policy allows it
 
 ### Framework Keeper
 
-- **When to use:** auditing the framework itself for contradiction, duplication, unnecessary complexity, or underspecified decision paths
-- **Inputs:** audit scope, relevant authoritative artifacts, known operator pain points, recent framework changes
-- **Outputs:** structured findings, recommended remediations, and explicit decisions on what should remain unchanged
-- **Load:** `skills/framework-keeper.md`
-
-### Repository foundation (playbook)
-
-- **When to use:** establishing or auditing repository governance, CI, branch protection, security defaults, and contributor surfaces
-- **Inputs:** repository owner, default branch, canonical validation command, maintainer identity
-- **Outputs:** governed repo baseline and recorded settings
-- **Load:** `playbooks/repository-foundation.md`
-- **Constraints:** do not guess required check names; read real emitted checks
-
-### Pull request execution loop (playbook)
-
-- **When to use:** designing, implementing, or reviewing PR automation, risk policy, branch freshness, or merge authority behavior
-- **Inputs:** PR metadata, labels, required checks, review state, branch freshness state, threshold policy
-- **Outputs:** residual-risk decision, merge authority, or structured escalation request
-- **Load:** `playbooks/pull-request-execution-loop.md`
-- **Constraints:** machines verify, humans decide; do not convert timing gaps into human-review work
-
-### Release management (playbook)
-
-- **When to use:** enabling or revising repository-level releases, semantic version tags, release PR behavior, or GitHub Release notes.
-- **Inputs:** release branch, version baseline, token strategy, and merge policy.
-- **Outputs:** release workflow, changelog/version config, and documented operator setup.
-- **Load:** `playbooks/release-management.md`
-- **Constraints:** release the whole repository, not `products/dashboard/` alone; prefer dedicated automation credentials over `GITHUB_TOKEN`
-
-### Publish to production (playbook)
-
-- **When to use:** promoting reviewed changes from `staging` to `main`, publishing to production, or answering how a PR to `main` should work in this repository.
-- **Inputs:** current `staging` and `main` SHAs, promotion PR state, queue state, and release automation state.
-- **Outputs:** open or merged `staging` -> `main` promotion PR and post-merge release verification evidence.
-- **Load:** `playbooks/publish-to-production.md`
-- **Constraints:** feature PRs still target `staging`; `staging` -> `main` must use a regular merge commit and the promotion-specific gate
-
-### Agent context bundle (playbook)
-
-- **When to use:** creating or updating root `AGENTS.md`, or files under `ai/` (`SKILLS.md`, `skills/*.md`, `MEMORY.md`, `PLAYBOOKS.md`, `playbooks/`), or making agent bootstrap behavior explicit in a repository
-- **Inputs:** authority ladder, canonical commands, playbooks, glossary, durable facts, open loops
-- **Outputs:** maintained agent runtime bundle (`AGENTS.md` + `ai/`)
-- **Load:** `playbooks/agent-context-bundle.md`
-- **Constraints:** keep the bundle concise, index-shaped inside `ai/`, and subordinate to schema and policy
+- When to use: audit the framework for contradiction, duplication, ambiguity, or drag
+- Inputs: audit scope, authoritative artifacts, recent changes, pain points
+- Outputs: findings, remediations, and no-change decisions
+- Load: `skills/framework-keeper.md`
+- Constraints: framework work only
 
 ### Quality Engineer
 
-- **When to use:** writing or reviewing tests, triaging `test` or `e2e` CI failures, executing the incident-to-regression loop, auditing phase readiness, or setting up the test stack for a new product
-- **Inputs:** spec entry or incident ID, current test suite state, phase level, failing check output or Playwright report
-- **Outputs:** tests at the correct layer, passing `test` and `e2e` gates, regression coverage, phase evidence bundle
-- **Load:** `skills/quality-engineer.md`
-- **Notes:** for operational procedures (PR gate loop, nightly triage, incident closure), also load `playbooks/quality-standard-execution.md`.
+- When to use: write or review tests, triage `test`/`e2e` failures, run incident-to-regression work, audit phase readiness
+- Inputs: spec entry or incident ID, suite state, phase, failing output
+- Outputs: correct-layer tests, green gates, regression coverage, or phase evidence
+- Load: `skills/quality-engineer.md`
+- Constraints: follow `docs/QUALITY_STANDARD.md`; for operational loops also load `playbooks/quality-standard-execution.md`
 
-### Resolve GitHub issues (playbook)
+### Feature implementation (dashboard)
 
-- **When to use:** triaging and resolving open GitHub issues, especially when several issues appear to share the same workflow failure, file, or root cause
-- **Inputs:** open issue set, issue metadata, workflow evidence, validation command, branch and PR policy
-- **Outputs:** grouped issue plan, required issue comments, one fix PR per group, and explicit issue outcome updates
-- **Load:** `playbooks/resolve-github-issues.md`
-- **Constraints:** comment intent on every issue before editing; batch only when one fix really serves the same root cause
+- When to use: implement a dashboard feature from a completed feature request
+- Inputs: feature request, spec YAML, analytics event registry
+- Outputs: updated spec, registry, implementation, validation evidence
+- Load: `playbooks/feature-implementation.md`
+- Constraints: spec first; events required before code
 
-### Resolve Sentry issues (playbook)
+### Repository foundation
 
-- **When to use:** triaging and resolving Sentry issues that need assignment, incident notes, linked PR tracking, and evidence-based closure
-- **Inputs:** Sentry issue metadata, write-capable token, linked PR, recent events, releases, and merge timing
-- **Outputs:** assigned issue, triage note, resolution note, and final `resolved` or continued `unresolved` state
-- **Load:** `playbooks/resolve-sentry-issues.md`
-- **Constraints:** do not resolve from intuition; use merge time, `lastSeen`, and recent events/releases to justify closure
+- When to use: establish or audit repo governance, CI, protection, and contributor surfaces
+- Inputs: repo owner, default branch, validation command, maintainer identity
+- Outputs: governed repo baseline
+- Load: `playbooks/repository-foundation.md`
+- Constraints: use real emitted checks
 
-### Service wiring (playbook)
+### Pull request execution loop
 
-- **When to use:** configuring Supabase auth, Vercel environment variables, or OAuth providers for a new or existing deployment environment; or debugging auth failures that originate from external service misconfiguration rather than code
-- **Inputs:** target domain, auth providers to enable, Supabase project ref, Vercel project details
-- **Outputs:** correct Supabase URL config and provider settings, aligned env vars in `.env.local` and Vercel, working auth flow
-- **Load:** `playbooks/service-wiring.md`
-- **Constraints:** Supabase auth config and Vercel env vars require dashboard steps — no MCP tool covers them; the playbook's tooling coverage map lists exactly what is and is not automatable
+- When to use: PR automation, risk policy, freshness, review closure, or merge authority work
+- Inputs: PR metadata, labels, checks, review state, threshold policy
+- Outputs: residual-risk decision, merge path, or escalation request
+- Load: `playbooks/pull-request-execution-loop.md`
+- Constraints: machines verify, humans decide
+
+### Release management
+
+- When to use: enable or revise repo-level releases, tags, changelogs, or GitHub Releases
+- Inputs: release branch, version baseline, token strategy, merge policy
+- Outputs: release workflow, config, and operator setup
+- Load: `playbooks/release-management.md`
+- Constraints: release the whole repo, not one subpackage
+
+### Publish to production
+
+- When to use: promote reviewed changes from `staging` to `main`
+- Inputs: `staging` and `main` SHAs, promotion PR state, queue state, release state
+- Outputs: open or merged promotion PR and release verification
+- Load: `playbooks/publish-to-production.md`
+- Constraints: feature PRs still target `staging`
+
+### Agent context bundle
+
+- When to use: create or update `AGENTS.md` or files under `ai/`
+- Inputs: authority ladder, commands, inventories, durable facts, open loops
+- Outputs: maintained agent runtime bundle
+- Load: `playbooks/agent-context-bundle.md`
+- Constraints: keep the bundle concise and index-shaped
+
+### Resolve GitHub issues
+
+- When to use: triage and resolve open GitHub issues, especially shared-failure batches
+- Inputs: issue set, workflow evidence, validation command, PR policy
+- Outputs: grouped plan, issue comments, fix PR, explicit issue outcomes
+- Load: `playbooks/resolve-github-issues.md`
+- Constraints: batch only on real shared root cause
+
+### Resolve Sentry issues
+
+- When to use: triage and resolve Sentry issues with assignment and evidence-based closure
+- Inputs: Sentry issue metadata, linked PR, events, releases, merge timing
+- Outputs: triage note, resolution note, final issue state
+- Load: `playbooks/resolve-sentry-issues.md`
+- Constraints: do not resolve on intuition
+
+### Service wiring
+
+- When to use: configure deployment-service auth and env surfaces or debug service-side misconfiguration
+- Inputs: target domain, auth providers, Supabase ref, Vercel project details
+- Outputs: aligned dashboard config and env vars
+- Load: `playbooks/service-wiring.md`
+- Constraints: respect tooling coverage boundaries
 
 ### Spec Evolution
 
-- **When to use:** changing framework structure, required fields, or examples under `spec/`
-- **Inputs:** desired behavioral change, schema updates, example updates, policy impact
-- **Outputs:** aligned schema, examples, and documentation
-- **Load:** `spec/schema/product-spec.schema.json`, `spec/examples/`, `docs/AI_NATIVE_FRAMEWORK.md`
-- **Constraints:** avoid spec theater; machine validation is the source of truth
+- When to use: change framework structure, schema requirements, or examples under `spec/`
+- Inputs: desired behavior change, schema updates, example updates, policy impact
+- Outputs: aligned schema, examples, and docs
+- Load: `spec/schema/product-spec.schema.json`, `spec/examples/`, `docs/AI_NATIVE_FRAMEWORK.md`
+- Constraints: machine validation is the source of truth
 
 ### Interface Evolution
 
-- **When to use:** changing logical tool contracts or capability boundaries
-- **Inputs:** workflow need, capability boundary, interface change rationale
-- **Outputs:** updated `interfaces/interfaces.yaml` and aligned docs
-- **Load:** `interfaces/interfaces.yaml`, `docs/AI_NATIVE_FRAMEWORK.md`
-- **Constraints:** express capabilities, not mascots or vendor-specific personas
+- When to use: change logical tool contracts or capability boundaries
+- Inputs: workflow need, boundary, rationale
+- Outputs: updated `interfaces/interfaces.yaml` and aligned docs
+- Load: `interfaces/interfaces.yaml`, `docs/AI_NATIVE_FRAMEWORK.md`
+- Constraints: express capabilities, not vendor-specific personas
 
-## Adding A New Skill
+## Maintenance
 
-Add a new `ai/skills/*.md` file when all of these are true:
-
-- the workflow recurs
-- the workflow has a stable trigger
-- the workflow benefits from a reusable operating harness
-- loading the skill only when needed will save ambiguity or token cost
-
-For each new skill:
-
-- keep `ai/SKILLS.md` as the discovery pointer, not the full body
-- make the skill file operational and concise
-- include triggers, inputs, outputs, workflow steps, decision rules, escalations, and completion criteria
-- point to the canonical docs or playbooks the skill relies on
+- Add a skill only for recurring work with a stable trigger.
+- Keep this file index-shaped: when to use, inputs, outputs, load, constraints.
+- Put the operating body in `ai/skills/*.md` or the relevant playbook.

--- a/ai/playbooks/agent-context-bundle.md
+++ b/ai/playbooks/agent-context-bundle.md
@@ -1,168 +1,50 @@
 # Agent context bundle
 
-## Objective
+## Use When
 
-Install and maintain a repository-local runtime standard for agents:
-
-- **`AGENTS.md` at the repository root** — sole agent file outside `ai/`; bootstrap, authority, and commands
-- **`ai/` directory** — every other agent-facing artifact: playbook index, playbooks, skill index, skills, and memory
-
-Typical layout inside `ai/`:
-
-- `PLAYBOOKS.md` for playbook discovery
-- `playbooks/` for unitary step-by-step procedures
-- `SKILLS.md` for role- and task-oriented skill routing
-- `skills/` for deeper skill bodies loaded on demand
-- `MEMORY.md` for durable operating memory
-
-This playbook makes agent behavior inspectable, versioned, and portable across coding environments. It complements the repository foundation and pull request execution playbooks by defining how an agent enters the repository, how it chooses a procedure or skill, and how it preserves durable context between sessions. Specs, policy, and playbooks remain the durable operating system; `AGENTS.md` plus `ai/` are the bootstrap surface that points agents toward them.
-
-## When to run
-
-Run it in any repository that expects repeated agent participation. If you are adopting the full framework on a new repository, apply repository foundation first so CI and protection match what the bundle describes; the suggested order is documented in `ai/PLAYBOOKS.md`.
-
-Re-run it whenever:
-
-- the authority ladder changes
-- canonical commands change
-- key playbooks are added or retired
-- architecture or terminology changes enough to invalidate current memory
-- an agent repeatedly makes the same bootstrap mistake because repository context is not explicit enough
-
-## Outcomes
-
-At the end of this playbook, the repository should have:
-
-- a root `AGENTS.md` file that tells an agent how to enter and operate in the repo
-- an `ai/` directory containing `SKILLS.md`, `PLAYBOOKS.md`, `MEMORY.md`, and usually `skills/` and `playbooks/`
-- links from the framework docs and README to `AGENTS.md` and `ai/`
-- lightweight maintenance rules so the bundle stays accurate instead of becoming prompt theater
+- creating or maintaining root `AGENTS.md`
+- creating or maintaining files under `ai/`
+- tightening agent bootstrap, routing, or memory behavior
 
 ## Inputs
 
-- Repository purpose and scope
-- Authority ladder and normative sources
-- Canonical setup, validation, test, and release commands
-- Playbook inventory
-- Important glossary and architectural facts
-- Current open loops worth preserving across sessions
+- repo purpose and scope
+- authority ladder
+- canonical commands
+- playbook and skill inventory
+- durable facts and open loops
 
-## Procedure
+## Outputs
 
-### 1. Create root `AGENTS.md`
+- concise root `AGENTS.md`
+- compact `ai/SKILLS.md` and `ai/PLAYBOOKS.md`
+- on-demand `ai/skills/*.md` and `ai/playbooks/*.md`
+- pruned `ai/MEMORY.md`
 
-`AGENTS.md` is the first file a new agent should read.
+## Steps
 
-It should include:
+1. Keep `AGENTS.md` as the bootstrap contract: purpose, authority, commands, rules, escalation, important paths.
+2. Keep `ai/SKILLS.md` and `ai/PLAYBOOKS.md` index-shaped: when to use, inputs, outputs, load, constraints.
+3. Put operating detail in `ai/skills/*.md` and `ai/playbooks/*.md`, not in the indices.
+4. Keep `ai/MEMORY.md` to durable facts, open loops, and dated decisions; remove transient history.
+5. Update README and other routing docs when the bundle shape changes.
+6. Before closing, check for contradictions with higher-order artifacts and remove stale pointers.
 
-- Repository purpose in one paragraph
-- Authority ladder and which files override which
-- Canonical commands the agent should run before and after changes
-- Expected work style for this repository
-- Rules for editing, validation, and escalation
-- A short map of important directories and docs (including `ai/`)
+## Constraints
 
-`AGENTS.md` should stay concise. If it grows into a handbook, move detail into linked docs and keep `AGENTS.md` as the bootstrap surface.
+- keep the bundle subordinate to schema, policy, interfaces, and playbooks
+- prefer pointers over duplicated prose
+- do not let memory become a transcript or backlog substitute
 
-### 2. Create `ai/` and `ai/SKILLS.md`
+## Template
 
-`ai/SKILLS.md` is the skill index and routing layer.
+- Skill file: `Use When`, `Inputs`, `Outputs`, `Steps`, `Rules`, `Escalate When`, `Done`, `References`
+- Playbook file: `Use When`, `Inputs`, `Outputs`, `Steps`, `Constraints`, `References`
 
-Each skill entry should declare:
+## References
 
-- Name
-- Trigger or when to use it
-- Inputs required
-- Outputs expected
-- What file or canonical source to load next
-- Constraints or escalation rules
-
-`ai/SKILLS.md` should stay index-shaped. Full skill bodies belong in `ai/skills/*.md` once a workflow is rich enough to need more than a few lines. In a framework-aligned repository, the skill index typically points at the repository foundation and pull request execution playbooks among its default entries. Add more skills only when the workflow is recurring enough to justify a reusable unit.
-
-### 2.5 Create `ai/skills/`
-
-Use `ai/skills/` for the on-demand skill bodies referenced by `ai/SKILLS.md`.
-
-Each skill file should stay operational:
-
-- purpose
-- when to use it
-- when not to use it
-- inputs
-- outputs
-- workflow steps
-- decision rules
-- escalation conditions
-- completion criteria
-
-This split keeps the cost of loading the indices low while still giving agents a deeper execution harness when they need it.
-
-### 2.6 Create `ai/PLAYBOOKS.md` and `ai/playbooks/`
-
-Use `ai/PLAYBOOKS.md` as the discovery index for unitary procedures. Store each procedure body as a file under `ai/playbooks/`, the same way skill bodies live under `ai/skills/`.
-
-### 3. Create `ai/MEMORY.md`
-
-`ai/MEMORY.md` is durable operating memory, not a raw transcript.
-
-It should contain:
-
-- Stable facts about the repository
-- Current framework and playbook status
-- Open loops that matter across sessions
-- Decision notes with dates
-- Glossary terms that an agent is likely to misread without help
-
-It must separate durable memory from temporary notes. Resolved tasks, noisy logs, and transient debugging detail should be removed instead of accumulated indefinitely.
-
-### 4. Link the bundle into the framework
-
-Update README, playbook indexes, and framework docs so the bundle is part of the operating system rather than an undocumented convention.
-
-At minimum:
-
-- README links to root `AGENTS.md` and to `ai/` (indices and subfolders)
-- `ai/PLAYBOOKS.md` indexes every versioned playbook under `ai/playbooks/` (including this one)
-- framework prose recognizes `AGENTS.md` and `ai/` as repository-local context, subordinate to schema and policy
-
-### 5. Review for contradictions
-
-Before considering this playbook complete:
-
-1. Check that `AGENTS.md`, `ai/SKILLS.md`, `ai/skills/*.md`, and `ai/MEMORY.md` do not contradict schema, policy, or playbooks.
-2. Check that canonical commands still work.
-3. Check that every named skill points to a real canonical source.
-4. Remove stale facts and open loops.
-
-## Maintenance rules
-
-- `AGENTS.md` changes when repo authority, commands, workflow, or escalation rules change.
-- `ai/SKILLS.md` changes when the skill routing index changes.
-- `ai/skills/*.md` changes when a recurring workflow is added, retired, or materially changed.
-- `ai/PLAYBOOKS.md` and `ai/playbooks/*.md` change when procedures are added, retired, or materially changed.
-- `ai/MEMORY.md` changes when a durable fact changes, a decision is made, or an open loop is closed or created.
-- After any non-trivial completed workflow, evaluate whether the work produced durable learnings that should update `ai/MEMORY.md`, `ai/SKILLS.md`, `ai/skills/*.md`, `AGENTS.md`, or a playbook under `ai/playbooks/` before the task is treated as fully closed.
-- Temporary working notes should graduate into schema, playbooks, or code comments when they become durable policy.
-
-## Recommended template discipline
-
-Prefer this shape:
-
-- `AGENTS.md` at repo root: short and directive
-- `ai/SKILLS.md`: index-shaped and reusable
-- `ai/skills/`: detailed only where the selected workflow needs it
-- `ai/PLAYBOOKS.md`: index-shaped procedure routing
-- `ai/playbooks/`: unitary procedures only
-- `ai/MEMORY.md`: structured, pruned, and date-aware
-
-Avoid:
-
-- provider-specific hidden prompt assumptions
-- dumping chat transcripts into memory
-- duplicating entire playbooks in the skill registry
-- using memory as a backlog substitute when an issue tracker exists
-
-## Notes for future variants
-
-- This playbook should eventually gain a machine-readable schema under `spec/processes/`.
-- Multi-agent systems may also introduce dedicated capability-contract files outside `ai/`, but root `AGENTS.md` should remain the universal first-read surface.
+- `AGENTS.md`
+- `README.md`
+- `ai/SKILLS.md`
+- `ai/PLAYBOOKS.md`
+- `ai/MEMORY.md`

--- a/ai/playbooks/environment-separation.md
+++ b/ai/playbooks/environment-separation.md
@@ -1,279 +1,48 @@
 # Environment separation
 
-## Objective
+## Use When
 
-Establish a clean 3-tier deployment environment model (production / staging / development) so that automated test traffic never reaches production analytics or error-rate baselines, and production metrics reflect real users only.
-
-## When to run
-
-- Standing up the environment model for a new repository or product for the first time
-- Auditing or repairing an existing environment setup where test traffic is polluting production metrics
-- Adding a new observability tool that needs to be scoped by environment
-
-## Outcomes
-
-At the end of this playbook:
-
-- A long-lived `staging` branch exists with identical protection rules to `main`
-- Feature PRs target `staging`; `staging` → `main` is the automated release gate
-- Nightly CI targets the stable staging URL, never production
-- PostHog (and equivalent analytics tokens) initializes only in the Production Vercel environment
-- Sentry remains active on staging for real integration error visibility
-- Production metrics and error dashboards reflect real users exclusively
+- establishing the 3-tier production/staging/development model
+- auditing or repairing polluted production analytics or error dashboards
+- adding an observability or data service that needs environment scoping
 
 ## Inputs
 
-- Repository name and owner
-- Production domain (e.g. `ai-native-framework.app`)
-- Staging domain to assign (e.g. `staging.ai-native-framework.app`)
+- repo owner and name
+- production and staging domains
 - Vercel project access
-- GitHub admin access (for branch protection)
-- GitHub token with `repo` and `actions` scopes (for API calls)
+- GitHub admin access
+- GitHub token for API work
 
-## Tooling coverage map
+## Outputs
 
-| Action | Tool available | Where to do it |
-|---|---|---|
-| Create `staging` branch | GitHub MCP (`create_branch`) or `git push` | Automated |
-| Set branch protection rules | GitHub REST API (`PUT /branches/{branch}/protection`) | Automated with token |
-| Create `STAGING_URL` repository variable | GitHub REST API (`GET` / `PATCH` / `POST` on `/actions/variables`) | Automated with token |
-| Assign stable Vercel domain alias to `staging` branch | **None** | Vercel dashboard → Settings → Domains |
-| Scope Vercel env vars to Production only | **None** | Vercel dashboard → Settings → Environment Variables |
+- protected `staging` branch
+- feature PRs targeting `staging`
+- nightly CI targeting staging
+- observability env vars scoped by environment
+- data tier separated by environment
 
-## Procedure
+## Steps
 
-### 1. Create the staging branch
-
-```bash
-git checkout main && git pull
-git checkout -b staging
-git push -u origin staging
-```
-
-Or via GitHub MCP:
-```text
-create_branch(owner, repo, branch="staging", from_branch="main")
-```
-
-### 2. Apply branch protection to staging
-
-Mirror the exact protection rules from `main`. Retrieve the current `main` protection first:
-
-```bash
-curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
-  https://api.github.com/repos/{owner}/{repo}/branches/main/protection
-```
-
-> **Note**: The example below shows the protection rules for this repository. Use the JSON response from the command above as your payload, adjusting only the `contexts` array if your required checks differ from this baseline.
-
-Then apply the same rules to `staging`:
-
-> Note: the payload below is an example from this repository's current baseline. Reuse the JSON returned by the `main` protection `GET` above, save it to a file or variable, then adjust any branch-specific fields before the `PUT` to `staging`.
-
-```bash
-curl -s -X PUT \
-  -H "Authorization: Bearer $GITHUB_TOKEN" \
-  -H "Accept: application/vnd.github+json" \
-  https://api.github.com/repos/{owner}/{repo}/branches/staging/protection \
-  -d '{
-    "required_status_checks": { "strict": true, "contexts": ["validate", "test", "e2e", "CodeRabbit", "decide"] },
-    "enforce_admins": true,
-    "required_pull_request_reviews": {
-      "dismiss_stale_reviews": false,
-      "require_code_owner_reviews": false,
-      "required_approving_review_count": 0
-    },
-    "restrictions": null,
-    "required_linear_history": true,
-    "allow_force_pushes": false,
-    "allow_deletions": false,
-    "required_conversation_resolution": true
-  }'
-```
-
-### 3. Create STAGING_URL repository variable
-
-```bash
-# Upsert STAGING_URL so repair and audit reruns stay idempotent.
-if curl -sf \
-  -H "Authorization: Bearer $GITHUB_TOKEN" \
-  -H "Accept: application/vnd.github+json" \
-  https://api.github.com/repos/{owner}/{repo}/actions/variables/STAGING_URL >/dev/null; then
-  curl -s -X PATCH \
-    -H "Authorization: Bearer $GITHUB_TOKEN" \
-    -H "Accept: application/vnd.github+json" \
-    https://api.github.com/repos/{owner}/{repo}/actions/variables/STAGING_URL \
-    -d '{"name":"STAGING_URL","value":"https://staging.{domain}"}'
-else
-  curl -s -X POST \
-    -H "Authorization: Bearer $GITHUB_TOKEN" \
-    -H "Accept: application/vnd.github+json" \
-    https://api.github.com/repos/{owner}/{repo}/actions/variables \
-    -d '{"name":"STAGING_URL","value":"https://staging.{domain}"}'
-fi
-```
-
-### 4. Update nightly CI to target staging
-
-In the nightly workflow file (e.g. `.github/workflows/nightly.yml`):
-
-- Change the fallback URL from the production origin to `vars.STAGING_URL || 'https://staging.{domain}'`
-- Update the workflow input description from "defaults to production" to "defaults to staging"
-- Add a comment that production is never a nightly target
-- Update the error message to reference `STAGING_URL` instead of `PRODUCTION_URL`
-
-Also update `test.yml` to trigger on pushes to `staging` as well as `main`:
-
-```yaml
-on:
-  push:
-    branches: [main, staging]
-```
-
-### 5. Assign stable Vercel domain alias (manual)
-
-In Vercel → Project → Settings → Domains:
-
-1. Add domain: `staging.{domain}`
-2. Assign it to the `staging` branch
-
-Vercel automatically creates Preview deployments for every push to `staging`. The domain alias makes the URL stable for nightly CI targeting.
-
-### 6. Scope analytics tokens to Production only (manual)
-
-In Vercel → Project → Settings → Environment Variables:
-
-1. Find `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`
-   - If it shows "All Environments": click edit → uncheck Preview and Development → save
-   - If it is managed by a Vercel integration (shows "Manage Connection"): remove the integration-managed variable, then re-add it manually as a plain env var scoped to Production only
-2. Apply the same scoping to `NEXT_PUBLIC_POSTHOG_HOST`
-3. Leave `NEXT_PUBLIC_SENTRY_DSN` set for Production and Preview (Sentry stays active on staging for real error visibility)
-
-PostHog guards initialization on `Boolean(token)` — no code change required. Unset token silently skips initialization.
-
-### 7. Update Mergify for staging queues
-
-Add two queue rules to `.mergify.yml`:
-
-- **`staging-integration`**: handles feature PRs targeting `staging` with `merge_method: squash` and the full gate set (`validate`, `test`, `e2e`, `CodeRabbit`, `decide`).
-- **`staging-promotion`**: handles the `staging` → `main` promotion PR with `merge_method: merge` (not squash) to preserve conventional commit history for release-please. Requires `validate`, `test`, `decide`.
-
-### 8. Redirect PRs and update framework docs
-
-- Update `CONTRIBUTING.md`: branches are created from `staging`, PRs target `staging`
-- Update `AGENTS.md` working rules: feature PRs target `staging`; document the release gate
-- Update PR template: add checklist item confirming PR targets `staging`
-- Update `ai/MEMORY.md`: record the environment separation decision with date
-- Update `docs/QUALITY_STANDARD.md` §4: add the 3-tier environment model as a standard default stack entry
-- Update `ai/playbooks/repository-foundation.md` baseline: add `staging` branch, protection, and nightly target
-
-### 9. Database tier (Supabase)
-
-The 3-tier model also applies to the database. The same boundary that scopes Vercel envs and analytics tokens must scope hosted Supabase projects, otherwise staging app traffic mutates production data.
-
-#### 9.1 Project shape
-
-- **One Supabase project per environment.** Provision two projects in the same Supabase organization:
-  - `<product>-staging` — receives every migration on push to `staging`
-  - `<product>-production` — receives every migration on push to `main`, gated by a GitHub Environment with required reviewers
-- Same region as your Vercel deployment; same Postgres major version on both.
-- Production should be on the Pro plan (daily backups, no auto-pause, log retention) once the product carries real users. Staging on Free is fine.
-
-Provisioning can be done via the Supabase MCP (`create_project`) once the MCP is authenticated, or manually in the Supabase dashboard. Capture for each project: project ref, anon key, service-role key (only if used), and DB password.
-
-#### 9.2 GitHub secrets
-
-| Scope | Name | Value |
-|---|---|---|
-| Repository secret | `SUPABASE_ACCESS_TOKEN` | One personal access token from your Supabase account; works for both projects |
-| Environment `Staging` | `SUPABASE_PROJECT_REF` | Staging project ref (the `xxxx` in `xxxx.supabase.co`) |
-| Environment `Staging` | `SUPABASE_DB_PASSWORD` | Staging DB password |
-| Environment `Production` | `SUPABASE_PROJECT_REF` | Production project ref |
-| Environment `Production` | `SUPABASE_DB_PASSWORD` | Production DB password |
-
-Create the GitHub Environments first (`Settings → Environments → New environment`), then add the secrets. Reuse the existing Vercel-created `Production` environment (don't reuse `Preview` for the data tier — `Preview` covers every PR's preview deployment, not the long-lived staging branch only). Add `Required reviewers` to `Production` so the `migrate-production` job pauses for human approval before applying.
-
-#### 9.3 CI workflow
-
-`.github/workflows/supabase-migrate.yml` provides three stable check names that downstream automation can require:
-
-| Check | Trigger | What it does |
-|---|---|---|
-| `migrate-validate` | every PR | Spins up a temporary local Supabase, applies all committed migrations, runs `supabase db lint`. No-ops with a passing check when the PR does not touch `products/dashboard/supabase/**`. |
-| `migrate-staging` | push to `staging` | `supabase link --project-ref` (staging) + `supabase db push` against the staging project. Always runs (no commit-message skip) so the `staging-promotion` queue's `check-success = migrate-staging` requirement is satisfied on every staging head SHA. |
-| `migrate-production` | push to `main` | Same against the production project, gated on the `Production` GitHub Environment. **Skipped on `chore: release X.Y.Z` commits** (release-please's release commit only bumps version + CHANGELOG and never carries new migrations) so each release does not require approving a guaranteed-no-op `db push` against production after the real one already ran on the immediately preceding promotion merge. `workflow_dispatch` is intentionally not subject to this skip — a manual dispatch is an explicit operator action. |
-
-`.mergify.yml` requires `migrate-validate` on the `staging-integration` queue and `migrate-staging` on the `staging-promotion` queue. The promotion PR cannot merge until staging has successfully received every migration on its current head SHA.
-
-#### 9.4 Vercel env-var scoping (manual)
-
-In **Vercel → Project → Settings → Environment Variables**, set per environment:
-
-- **Production** scope:
-  - `NEXT_PUBLIC_SUPABASE_URL` → production project's URL
-  - `NEXT_PUBLIC_SUPABASE_ANON_KEY` → production project's anon key
-  - `SUPABASE_SERVICE_ROLE_KEY` → production project's service-role key *(only if server code needs admin access — otherwise omit and rely on RLS)*
-- **Preview** scope:
-  - `NEXT_PUBLIC_SUPABASE_URL` → staging project's URL
-  - `NEXT_PUBLIC_SUPABASE_ANON_KEY` → staging project's anon key
-  - `SUPABASE_SERVICE_ROLE_KEY` → staging project's service-role key *(if used)*
-- **Development** scope: same as Preview, or point at a local `supabase start` URL if developing offline.
-
-Critical: never set the same Supabase URL across Production and Preview. Doing so collapses the data-tier boundary and lets Playwright/staging traffic mutate production rows.
-
-#### 9.5 Migration discipline (forward-only, backwards-compatible)
-
-`migrate-production` runs in parallel with the Vercel production deploy on push to `main`. There is a brief window where the new app code might hit a not-yet-migrated DB (or vice versa). Two rules keep this safe:
-
-- **Additive only across a release boundary.** New columns/tables/indexes/policies are fine. Dropping a column or table that the previously deployed app still reads is not. If you must remove something, ship the code change to stop reading it first, release, then drop in a later release.
-- **Migrations are not rollback-safe.** `supabase db push` has no automated down-migration. Treat schema as forward-only; recover from a bad migration with a corrective migration, never by reverting the file.
-
-#### 9.6 First-time bootstrap on an existing schema
-
-If either project already had migrations applied manually before this workflow existed, mark them as applied in `supabase_migrations.schema_migrations` so the first CI run does not try to re-run them:
-
-```bash
-cd products/dashboard
-supabase login
-supabase link --project-ref <ref>
-supabase migration repair --status applied <timestamp>   # repeat per migration
-supabase migration list --linked                         # verify
-```
-
-### 10. Verify
-
-- [ ] `staging` branch exists and is protected (verify via GitHub → Settings → Branches)
-- [ ] `STAGING_URL` variable is set (verify via GitHub → Settings → Secrets and variables → Actions → Variables)
-- [ ] Nightly workflow falls back to staging URL, not production
-- [ ] Vercel staging alias resolves and returns the app
-- [ ] PostHog token is absent in a Vercel Preview deployment (open the staging app, check network tab — no requests to PostHog ingest)
-- [ ] Sentry reports errors from staging with `environment = staging` (or `preview`) tag
-- [ ] A feature PR targeting `staging` passes all merge gates and merges cleanly
-- [ ] `npm run validate` passes
-- [ ] Two Supabase projects exist (one staging, one production), with secrets set on the matching GitHub Environments
-- [ ] First push to `staging` shows a green `migrate-staging` check and the migrations appear in the staging project's `Database → Migrations` tab
-- [ ] `staging` → `main` promotion PR shows `migrate-staging` as a required check and cannot merge without it
-- [ ] First push to `main` pauses on the `production` GitHub Environment for required reviewer approval before applying
-- [ ] Production Vercel env points at the production Supabase project; Preview Vercel env points at the staging project; the URLs are different
+1. Create a long-lived `staging` branch from `main`.
+2. Mirror `main` branch protection onto `staging`.
+3. Create or update the `STAGING_URL` repository variable.
+4. Point nightly and other non-production automation at staging, never production.
+5. Assign a stable Vercel alias to `staging`.
+6. Scope analytics tokens to Production only and keep Sentry active on Preview/staging.
+7. Configure merge queues and docs so feature PRs target `staging` and production publishes use `staging` -> `main`.
+8. Separate the data tier as well: one hosted database project per environment, env-scoped secrets, and migration gates per branch.
+9. Verify branch protection, staging routing, env scoping, migration behavior, and validation before closing.
 
 ## Constraints
 
-- Never run nightly CI against the production origin. Automated test traffic generates synthetic events and errors that distort production dashboards.
-- Do not use a separate PostHog project for non-production — simply scope the token. Staging metrics are not useful; the goal is clean production signal, not staging observability.
-- Sentry should remain active on staging. Real integration failures on staging are worth knowing about; use `environment` tags for dashboard filtering rather than disabling error reporting.
-- The `staging` → `main` promotion must use regular merge (not squash). Squashing collapses conventional commits and breaks release-please version detection.
-- If PostHog is wired via Vercel integration, the integration-managed variable cannot be scoped per-environment from the edit UI. Remove the integration variable and re-add it manually.
-- One Supabase project per environment is non-negotiable. Sharing a project across staging and production collapses the data-tier boundary and lets test traffic mutate production rows.
-- Database migrations are forward-only and must be backwards-compatible across a release boundary. The `migrate-production` job runs in parallel with the Vercel production deploy; destructive changes in the same release as the code that depends on them will produce a brief outage window.
+- never target production from nightly CI
+- do not create a separate PostHog project for staging; scope the token instead
+- one hosted database project per environment is mandatory
+- promotion from `staging` to `main` uses regular merge, not squash
 
-## Related artifacts
+## References
 
-- `ai/playbooks/repository-foundation.md` — full baseline including staging setup
-- `ai/playbooks/release-management.md` — staging → main promotion and release-please flow
-- `ai/playbooks/publish-to-production.md` — canonical operating loop for the governed `staging` -> `main` promotion PR
-- `ai/playbooks/service-wiring.md` — Vercel env var scoping and staging alias setup
-- `docs/QUALITY_STANDARD.md` — 3-tier environment model in §4 default stack
-- `.github/workflows/nightly.yml` — nightly CI targeting staging
-- `.github/workflows/supabase-migrate.yml` — database tier CI (validate / apply-staging / apply-production)
-- `.mergify.yml` — staging-integration and staging-promotion queue rules (require `migrate-validate` and `migrate-staging` respectively)
-- `products/dashboard/supabase/config.toml` — Supabase CLI config (local stack only; hosted project ref injected by CI)
+- `ai/playbooks/repository-foundation.md`
+- `ai/playbooks/publish-to-production.md`
+- `ai/playbooks/service-wiring.md`

--- a/ai/playbooks/feature-implementation.md
+++ b/ai/playbooks/feature-implementation.md
@@ -1,252 +1,44 @@
-# Feature Implementation Playbook
+# Feature implementation
 
-**Version:** 1.0  
-**Product:** `products/dashboard`  
-**Authority:** Subordinate to `spec/schema/`, `spec/policy/`, and `docs/ANALYTICS_STANDARD.md`. Extends `ai/skills/developer.md` for dashboard product work.
+## Use When
 
----
-
-## Objective
-
-Implement a dashboard feature from a completed feature request (`templates/feature-request.md`) with observability, type safety, and spec compliance as default parts of the deliverable — not follow-up items.
-
----
+- implementing a new feature in `products/dashboard/` from a completed feature request
 
 ## Inputs
 
-- Completed `templates/feature-request.md` for the feature
-- Current state of `spec/examples/dashboard-product.yaml`
-- Current state of `products/dashboard/lib/analytics/events.ts`
-- Current state of the relevant components under `products/dashboard/`
-
-If the feature introduces or changes authentication behavior, also read the current auth surface
-under `products/dashboard/lib/auth/` before editing any routes, layouts, or client flows.
+- completed `templates/feature-request.md`
+- current `spec/examples/dashboard-product.yaml`
+- current `products/dashboard/lib/analytics/events.ts`
+- relevant product components and, for auth changes, `products/dashboard/lib/auth/`
 
 ## Outputs
 
-- Updated `spec/examples/dashboard-product.yaml` (events + metrics)
-- Updated `products/dashboard/lib/analytics/events.ts` (new event type entries)
-- Feature component(s) under `products/dashboard/`
-- PostHog capture calls in every user-action path
-- `npm run validate` passing
-- PR ready for review per `ai/playbooks/pull-request-execution-loop.md`
+- updated spec catalog and metrics
+- updated analytics event registry
+- feature implementation
+- required analytics and monitoring wiring
+- passing `npm run validate`
 
----
+## Steps
 
-## Workflow
+1. Read the feature request, spec, analytics registry, and affected implementation before editing.
+2. Update the spec first: add events to `events.catalog`, update metrics when needed, and validate before continuing.
+3. Add matching event types to `products/dashboard/lib/analytics/events.ts`.
+4. Implement the UI or route behavior.
+5. Wire the declared analytics events through the approved abstractions, not direct vendor imports.
+6. Add required monitoring coverage through `lib/monitoring`, not direct Sentry imports.
+7. Verify event names, payloads, abstraction boundaries, and `npm run validate`.
+8. Publish through the normal PR loop.
 
-### Step 1 — Read before touching anything
+## Constraints
 
-1. Read the feature request in full.
-2. Read `spec/examples/dashboard-product.yaml` — understand existing events and which slice this feature belongs to.
-3. Read `products/dashboard/lib/analytics/events.ts` — understand existing event types so you do not duplicate or conflict.
-4. Read the component(s) the feature will touch or extend. The reference implementation for the full dual-pipeline pattern is `components/shell-events.tsx` and `components/sidebar.tsx`.
+- events are required, not optional
+- spec and event registry update before feature code
+- auth provider details stay inside `lib/auth/`
+- do not import `posthog-js` or `@sentry/nextjs` directly in feature code
 
-Do not edit any file until these four reads are complete.
+## References
 
-### Step 2 — Spec first: update the event catalog
-
-Before writing any component code, add the new event(s) to `spec/examples/dashboard-product.yaml` under `events.catalog`.
-
-Each catalog entry requires:
-
-```yaml
-- name: "domain.action_past_tense"        # must match spec/policy/event-taxonomy.yaml
-  description: "..."
-  version: "1.0.0"
-  schema_version: "1.0.0"
-  classification:
-    pii: none                              # none | low | high — be honest
-    idempotency: none                      # none | recommended | required
-    ordering: at_least_once
-  emitted_by:
-    - "components.your-component"         # matches the component file/folder name
-  payload:
-    type: object
-    additionalProperties: false
-    required:
-      - key_property
-    properties:
-      key_property:
-        type: string
-```
-
-Also add or update `observability.metrics.core_metrics` if the feature introduces a trackable signal worth monitoring long-term.
-
-Run `npm run validate` after this step. **Do not continue if validation fails.**
-
-### Step 3 — Type registry: add to AnalyticsEvent
-
-Add the new event(s) to the `AnalyticsEvent` union in `products/dashboard/lib/analytics/events.ts`:
-
-```ts
-// ── [Feature domain] ──────────────────────────────────────────────────────
-| { event: 'domain.action_past_tense'; properties: { key_property: string } }
-```
-
-Rules:
-- Event name must exactly match the catalog entry added in Step 2.
-- Properties must never include email, name, or any user-entered string.
-- Group new entries under a named comment block (see existing grouping in the file).
-
-### Step 4 — Implement the component
-
-Write the UI component(s). Keep this step strictly UI — no analytics capture calls yet.
-
-Component conventions in this codebase:
-- Client components: `"use client"` at top, file in `components/`
-- Server components: no directive, file in `components/` or colocated in `app/`
-- Route handlers: `app/api/<resource>/route.ts`
-- Styles: Tailwind utility classes; use `cn()` from `@/lib/utils` for conditional classes
-- UI primitives: `components/ui/` (shadcn/ui) — do not re-implement what's already there
-
-If the feature touches authentication:
-- product code outside `lib/auth/` must depend on the repo-owned auth service, not provider APIs
-- provider-specific SDK calls belong only in the auth adapter layer
-- layouts, middleware, route handlers, and pages must import the auth service boundary instead of
-  reaching into Supabase or another provider directly
-
-### Step 5 — Wire the dual pipeline
-
-Every user-facing action that was declared in the feature request's events table must call **both** pipelines:
-
-```ts
-// 1. Internal audit pipeline — correlation_id tagged, logged to stdout via /api/events
-emitEvent("domain.action_past_tense", { key_property: value });
-
-// 2. PostHog — typed, goes to EU region via /ingest proxy
-capture("domain.action_past_tense", { key_property: value });
-```
-
-The `capture` function comes from `useAnalytics()` imported from `@/lib/analytics/events`:
-
-```ts
-import { useAnalytics } from "@/lib/analytics/events";
-
-// inside your component:
-const { capture } = useAnalytics();
-```
-
-The `emitEvent` function comes from `@/lib/events` (unchanged).
-
-**Do not call `posthog.capture()` directly. Do not import `posthog-js` in feature files.**
-
-For page-level views (equivalent to `ShellEvents`), fire on `useEffect` with the route or feature name as dependency:
-
-```ts
-useEffect(() => {
-  emitEvent("feature.viewed", { feature_name: "your-feature" });
-  capture("feature.viewed", { feature_name: "your-feature" });
-}, [capture]);
-```
-
-For action events (equivalent to `Sidebar.handlePhaseClick`), fire inline on the handler:
-
-```ts
-function handleAction() {
-  // ... business logic ...
-  emitEvent("domain.action_past_tense", { key_property: value });
-  capture("domain.action_past_tense", { key_property: value });
-}
-```
-
-### Step 6 — Error monitoring coverage
-
-**Never import `@sentry/nextjs` in feature code.** All error monitoring goes through `lib/monitoring`.
-
-Every route handler must be wrapped in `startSpan`:
-
-```ts
-import { captureError, startSpan, setMonitoringTag } from "@/lib/monitoring"
-
-return await startSpan({ name: "POST /api/my-route", op: "http.server", attributes: { "app.product_id": PRODUCT_ID } }, async () => {
-  // handler body
-})
-```
-
-Every catch block that could silently fail in production must call `captureError`:
-
-```ts
-} catch (err) {
-  captureError(err, { feature: "my-feature", extra: { correlation_id: correlationId } })
-}
-```
-
-Client components that render user data or make external calls should be wrapped in `MonitoringBoundary`:
-
-```tsx
-import { MonitoringBoundary } from "@/lib/monitoring/boundary"
-
-<MonitoringBoundary feature="my-feature" fallback={<ErrorState />}>
-  <MyComponent />
-</MonitoringBoundary>
-```
-
-Reference: `app/api/events/route.ts` is the canonical route handler example. `app/api/sentry-test/route.ts` shows `captureError` + `flush` for deliberate test captures.
-
-### Step 7 — Validate and verify
-
-```bash
-cd /path/to/repo && npm run validate
-```
-
-Must pass. If it fails, fix the YAML before continuing.
-
-Also verify manually:
-- No `import posthog` outside `lib/analytics/`
-- No `import { PostHog }` outside `lib/analytics/`
-- Every event fired in the component matches an entry in `AnalyticsEvent`
-- The spec YAML entry was added to `spec/examples/dashboard-product.yaml`, not only to `golden-product.yaml`
-
-### Step 8 — PR
-
-Follow `ai/playbooks/pull-request-execution-loop.md`.
-
-PR description must include:
-- Which feature request this implements (link or name)
-- The new event(s) added to the type registry
-- Confirmation that `npm run validate` passes
-
----
-
-## Decision Rules
-
-- If the feature request's events table is blank, stop and ask. Events are required, not optional.
-- If a property the feature naturally produces would require PII (email, name, user input), use `user_id` (UUID) instead and note the substitution in the PR.
-- If the feature introduces auth, keep provider details isolated to `lib/auth/` and treat auth as a
-  product slice with spec, tests, observability, and analytics — not as app-local wiring.
-- If the feature needs a new API route, it needs its own internal event and Sentry span — do not skip either.
-- If a new event concept would apply to multiple future features, prefer a generic form (`feature.viewed`, `feature.action_taken`) with a discriminating property over a narrow, one-off name.
-- If a feature has no user-facing action that warrants a PostHog event, document why in the spec under `observability` and leave a comment in the component. This is a legitimate decision, not a skip.
-- Never import `@sentry/nextjs` or `posthog-js` directly in feature code. Both have abstraction layers — use them.
-- For auth identity lifecycle, use `lib/analytics/identity.ts` and `lib/monitoring` instead of
-  duplicating provider-specific identify/reset behavior in components.
-
----
-
-## Reference Implementation
-
-The complete dual-pipeline pattern as shipped in the dashboard shell:
-
-| Concern | File | What it shows |
-|---------|------|---------------|
-| Event type registry | `lib/analytics/events.ts` | How to add a new event to `AnalyticsEvent` |
-| Page view tracking | `components/shell-events.tsx` | `useEffect` + dual pipeline for page-level events |
-| Action tracking | `components/sidebar.tsx` | Inline handler + dual pipeline for user actions |
-| Route handler instrumentation | `app/api/events/route.ts` | `startSpan` + `captureError` + `setMonitoringTag` |
-| Deliberate error capture | `app/api/sentry-test/route.ts` | `captureError` + `flush` pattern |
-| Server-side analytics capture | `lib/analytics/server.ts` | `captureServerEvent` for route handlers and server components |
-| Error abstraction layer | `lib/monitoring/index.ts` | All exports available to feature code |
-| React error boundary | `lib/monitoring/boundary.tsx` | `MonitoringBoundary` usage |
-
----
-
-## Canonical References
-
-- `AGENTS.md`
-- `ai/skills/developer.md`
-- `ai/playbooks/pull-request-execution-loop.md`
-- `docs/ANALYTICS_STANDARD.md` (§§ 1–8 for PostHog; § 9 for error monitoring)
+- `docs/ANALYTICS_STANDARD.md`
 - `spec/policy/event-taxonomy.yaml`
-- `spec/examples/dashboard-product.yaml`
-- `templates/feature-request.md`
+- `ai/playbooks/pull-request-execution-loop.md`

--- a/ai/playbooks/framework-review.md
+++ b/ai/playbooks/framework-review.md
@@ -1,116 +1,41 @@
 # Framework review
 
-## Objective
+## Use When
 
-Audit the framework itself for consistency, efficiency, and predictability so the operating system remains coherent, lean, and reproducible for both humans and agents.
-
-This playbook exists for framework review work only. It is not a generic code review procedure.
-
-## When to run
-
-Run it when:
-
-- a change adds or materially alters a playbook, skill, authority rule, routing surface, or framework policy
-- repeated agent confusion suggests the framework is underspecified or contradictory
-- the repository needs a periodic framework health check
-- a human explicitly asks whether the framework has accumulated ambiguity, duplication, or unnecessary complexity
-
-## Outcomes
-
-At the end of this playbook, the repository should have:
-
-- a clear audit boundary
-- findings categorized by contradiction, duplication, unnecessary complexity, ambiguity, or routing gap
-- concrete remediation options tied to the right artifact layer
-- explicit no-change decisions where the current framework is already sufficient
+- a playbook, skill, routing surface, or framework rule changed
+- repeated agent confusion suggests contradiction or underspecification
+- a periodic framework audit is requested
 
 ## Inputs
 
-- target scope or changed files
+- audit scope
 - authoritative sources in ladder order
-- recent framework decisions or bundle changes
+- recent framework changes
 - known operator or agent pain points
 
-## Procedure
+## Outputs
 
-### 1. Define the audit boundary
+- clear audit boundary
+- findings by contradiction, duplication, ambiguity, routing gap, or drag
+- concrete remediation paths and no-change calls
 
-State exactly what is being audited before reading widely:
+## Steps
 
-- a specific workflow
-- a specific surface such as the `ai/` bundle
-- a cross-cutting framework concern such as merge authority, routing, or bootstrap behavior
-
-If the scope is too broad to evaluate concretely, reduce it to the smallest coherent framework slice.
-
-### 2. Gather governing sources in authority order
-
-Read the relevant sources from highest to lowest authority:
-
-1. `spec/schema/*`
-2. validated artifacts under `spec/examples/*` and future `spec/processes/*`
-3. `spec/policy/*`
-4. `interfaces/interfaces.yaml`
-5. `ai/playbooks/*.md`
-6. `docs/*`
-7. `AGENTS.md`, `ai/PLAYBOOKS.md`, `ai/SKILLS.md`, `ai/skills/*.md`, `ai/MEMORY.md`
-
-Do not start from lower-order summaries and then rationalize contradictions upward.
-
-### 3. Check consistency
-
-Inspect whether:
-
-- lower-order artifacts contradict higher-order ones
-- the same workflow is described differently in different files
-- important terms are used with inconsistent meaning
-- routing files point to artifacts that no longer match reality
-
-Consistency findings should identify both the source of truth and the drift location.
-
-### 4. Check efficiency
-
-Inspect whether:
-
-- instructions are duplicated across multiple files without adding value
-- agents are forced to read more than necessary to act correctly
-- the framework repeats the same reconciliation work in multiple surfaces
-- a lower-value artifact should instead be replaced with a pointer to a higher-value one
-
-Efficiency findings should focus on reducing operating cost, not on prose preferences.
-
-### 5. Check predictability
-
-Inspect whether:
-
-- triggers are explicit enough that agents will choose the same workflow
-- decision rules are explicit enough that agents will reach the same conclusion
-- escalation points are clear instead of inferred
-- completion criteria are concrete instead of rhetorical
-
-If two competent agents could reasonably produce different behavior from the same inputs, treat that as a predictability gap.
-
-### 6. Report findings and remediation paths
-
-For each finding, record:
-
-- category
-- severity
-- governing source
-- affected artifact
-- why the current state creates risk or drag
-- the smallest coherent remediation
-
-Prefer remediation at the durable operating-system layer: schema, policy, interfaces, or playbooks before memory or ad hoc instructions.
+1. Define the smallest coherent audit boundary.
+2. Read relevant artifacts in authority order.
+3. Check consistency across artifacts.
+4. Check efficiency: repeated instructions, unnecessary loading, dead routing.
+5. Check predictability: same inputs should lead to the same workflow and decision.
+6. Report findings with governing source, affected artifact, risk, and smallest coherent fix.
 
 ## Constraints
 
-- Audit the framework only; do not let this playbook expand into generic repository review.
-- Follow the authority ladder for every conclusion.
-- Do not weaken a higher-order artifact to accommodate lower-order drift.
-- Treat memory and routing indices as supporting surfaces, not the primary source of policy.
+- audit the framework, not ordinary feature code
+- do not weaken higher-order artifacts to satisfy lower-order drift
+- treat memory and indices as supporting surfaces
 
-## Notes for future variants
+## References
 
-- This playbook should eventually gain a machine-readable process artifact under `spec/processes/`.
-- If the framework later introduces additional governance capabilities, this playbook should stay focused on framework integrity rather than absorbing their full operating logic.
+- `AGENTS.md`
+- `ai/PLAYBOOKS.md`
+- `ai/SKILLS.md`

--- a/ai/playbooks/publish-to-production.md
+++ b/ai/playbooks/publish-to-production.md
@@ -1,76 +1,40 @@
 # Publish to production
 
-## Objective
-
-Publish the reviewed contents of `staging` to production by promoting `staging` into `main`, then verify that repository release automation continues from the new `main` head.
-
-## When to use
+## Use When
 
 - the operator asks to publish to production
-- the operator asks how to open a PR to `main` in this repository
-- `staging` has accumulated reviewed changes that should move to production
-- you need to audit or repair the governed `staging` -> `main` promotion path
+- the operator asks how PRs to `main` work here
+- reviewed `staging` work should move to production
 
 ## Inputs
 
 - current `staging` and `main` SHAs
-- merge-gate state for the current `staging` head
-- `.mergify.yml` queue rules
-- release automation configuration from `ai/playbooks/release-management.md`
-- any operator-provided release window, hold, or escalation note
+- promotion PR state
+- queue state
+- release automation state
 
 ## Outputs
 
-- an open or updated promotion PR with `base=main` and `head=staging`
-- merged production-publish PR state when policy allows it
-- verification evidence that the merge used a regular merge commit, that `release-please` observed the new `main` head, and that the follow-on release PR auto-merged
+- open or merged `staging` -> `main` promotion PR
+- release-automation verification
+- publish evidence bundle
 
-## Constraints
+## Steps
 
-- Do not open a feature branch PR directly against `main`. In this repository, the valid human-authored PR to `main` is the `staging` -> `main` promotion PR.
-- Do not squash the promotion PR. The merge must preserve the conventional commits already reviewed on `staging`.
-- Do not wait for CodeRabbit on the promotion PR. CodeRabbit auto-review is configured for feature PRs targeting `staging`, not for `staging` -> `main` promotion.
-- Treat unexpected commits on `staging` as a stop condition. If the release scope is unclear, escalate before opening or merging the promotion PR.
-- Production publication is a governed release action. Follow the pull-request execution loop for the PR itself, but use the promotion-specific checks and merge method documented here.
+1. Confirm the operator wants a production publish, not a feature PR.
+2. Verify the release scope on `staging`; stop if unexpected commits are present.
+3. Open or refresh the ready-for-review promotion PR with `base=main`, `head=staging`, and the required release-please override block.
+4. Apply the promotion gate from `.mergify.yml`.
+5. Merge through the promotion queue using a regular merge commit.
+6. Verify that `release-please` observed the new `main` head, opened or updated the release PR, and completed the follow-on release flow.
+7. Record the publish evidence bundle.
+8. Back-merge `main` into `staging` with a regular merge commit so ancestry stays intact.
 
-## Procedure
+## Canonical Snippet
 
-### 1. Confirm the operator wants a production publish
+### Release-please override block
 
-Translate "open a PR to `main`" into the repository's actual production path:
-
-- source branch: `staging`
-- target branch: `main`
-- PR purpose: publish already reviewed integration work to production
-
-If the requested change is still a feature or fix under development, stop and route it back to a normal PR targeting `staging`.
-
-### 2. Verify the release scope on `staging`
-
-Before opening or reusing the promotion PR:
-
-1. Compare `main..staging` and confirm the commits are the intended release scope.
-2. Check whether any in-flight PRs still target `staging` and have not merged yet.
-3. Refresh the local `staging` branch from `origin/staging` before opening the PR so the published head is current.
-4. Confirm the current `staging` head has passed the required integration gates for this repository.
-
-If the diff contains work the operator does not intend to publish, stop and ask for a release-scope decision instead of opening the PR.
-
-### 3. Open or refresh the promotion PR
-
-Create a ready-for-review PR with:
-
-- `base=main`
-- `head=staging`
-- non-draft state
-- summary focused on the production publish scope and notable operational risk
-- a `BEGIN_COMMIT_OVERRIDE` / `END_COMMIT_OVERRIDE` block in the PR body with standardized conventional-commit lines for every releasable change in this promotion scope
-
-This PR is not a feature review surface. The substantive review already happened on the feature PRs that landed in `staging`.
-
-**Required release-please override block (mandatory):**
-
-Before merging any `staging` -> `main` promotion PR, include this section in the PR body:
+Use this exact block in the promotion PR body:
 
 ```md
 BEGIN_COMMIT_OVERRIDE
@@ -78,202 +42,23 @@ BEGIN_COMMIT_OVERRIDE
 END_COMMIT_OVERRIDE
 ```
 
-Standardization rules:
+Rules:
 
-- Use one line per releasable change.
-- Use only conventional commit prefixes: `feat`, `fix`, `perf`, `revert`, and optionally `chore` when release metadata is intentionally desired.
-- Keep each line in the form: `<type>(<scope>): <short summary>`.
-- Keep summaries concise and user-facing; avoid tooling noise, PR numbers, merge boilerplate, and co-author trailers.
-- Do not include `docs`, `test`, `ci`, or other non-releasable-only entries unless you intentionally want them reflected in release notes.
+- one line per releasable change
+- use conventional commit prefixes such as `feat`, `fix`, `perf`, `revert`, or intentionally `chore`
+- keep each line in the form `<type>(<scope>): <short summary>`
+- keep summaries concise and user-facing
+- omit non-releasable-only entries unless they are intentionally part of release metadata
 
-Example:
+## Constraints
 
-```md
-BEGIN_COMMIT_OVERRIDE
-feat(dashboard): workflow run controls and task retry/cancel UX
-fix(policy): require trusted bot identity for reviewer-skip paths
-END_COMMIT_OVERRIDE
-```
+- no feature PRs directly to `main`
+- do not squash the promotion or back-merge PRs
+- do not wait for CodeRabbit on the promotion PR
+- stop if the release scope on `staging` is unclear
 
-Canonical CLI sequence:
+## References
 
-```bash
-git fetch origin
-git checkout staging
-git pull --ff-only origin staging
-
-gh pr create \
-  --base main \
-  --head staging \
-  --title "Promote staging to main" \
-  --body "## Summary
-
-- Publish the current reviewed staging branch to production
-
-## Validation
-
-- [ ] \`npm run validate\`
-- [ ] \`test\` green on the current staging head
-
-## Notes
-
-- This is the governed production-publish PR for the current staging head.
-- Follow-on release automation should open a separate \`release-please\` PR after merge."
-```
-
-If a promotion PR already exists, do not open a duplicate. Reuse the existing PR and continue from its current state.
-
-### 4. Apply the promotion gate
-
-For the `staging` -> `main` PR, the canonical merge gate is the `staging-promotion` Mergify queue in `.mergify.yml`.
-
-Required conditions in this repository:
-
-- `validate` succeeds
-- `test` succeeds
-- `decide` succeeds
-- `residual:low` is present
-- PR is not draft
-- `sync:needed` is absent
-
-CodeRabbit and `e2e` are not part of this promotion gate in the current repository configuration.
-
-### 5. Merge through the queue with a regular merge commit
-
-When the conditions above are met:
-
-1. Queue the PR on `staging-promotion` if it is not already queued.
-2. Let Mergify merge it with `merge_method: merge`.
-3. If the queue drops the PR after conditions were previously satisfied, repair the cause, then re-queue with `@mergifyio queue staging-promotion`.
-
-Do not use squash or rebase merge for this path unless repository policy changes.
-
-### 6. Verify post-merge release automation
-
-After the PR merges:
-
-1. Confirm `main` advanced to the merged `staging` head via a merge commit.
-2. Confirm `.github/workflows/release-please.yml` ran on the new `main` SHA.
-3. Confirm release automation opened or updated the second PR on `main` with title pattern `chore: release X.Y.Z` when releasable conventional commits are present.
-4. Confirm the second PR receives `residual:low`, passes `validate` and `decide`, and auto-merges through the `release-please` Mergify queue in `.mergify.yml`.
-5. Confirm the merge of the second PR created the tag and GitHub Release expected by `release-please`.
-6. If no release PR appears, or it opens but does not auto-merge, inspect the failure modes in `ai/playbooks/release-management.md` before treating production publication as complete.
-7. If release-please logs report `commit could not be parsed` on the promotion merge commit, update the merged promotion PR body with a corrected `BEGIN_COMMIT_OVERRIDE` block and rerun the release-please workflow.
-
-Canonical verification sequence:
-
-```bash
-gh pr list --base main --head staging --state all
-gh run list --workflow release-please --branch main --limit 5
-gh pr list --base main --search "head:release-please" --state all
-```
-
-For the follow-on release PR, check these expectations:
-
-- branch name starts with `release-please`
-- title matches `chore: release X.Y.Z`
-- `validate` passes
-- `decide` passes
-- `residual:low` is present
-- Mergify merges it automatically via the `release-please` queue
-
-The second PR should not require manual publication work in the ordinary happy path.
-
-### 7. Record the publish evidence
-
-Capture the minimum audit bundle:
-
-- promotion PR URL
-- merge commit SHA on `main`
-- `staging` head SHA that was promoted
-- release-please workflow run URL
-- follow-on release PR URL and merge SHA
-- back-merge PR URL (from §8) and merge SHA
-- any operator-visible note about holds, exceptions, or intentionally deferred release follow-up
-
-### 8. Back-merge `main` into `staging`
-
-After release-please publishes the `vX.Y.Z` tag, `main` is two commits ahead of `staging`:
-
-1. The promotion merge commit produced by §5.
-2. `chore: release X.Y.Z` produced by release-please.
-
-Those commits **MUST** be back-merged into `staging` before the next feature PR or the next promotion. The back-merge **MUST** use a regular merge commit so `main` remains an ancestor of `staging` — a squash merge drops the second parent and leaves `staging` content-equal but history-divergent, which forces the next promotion PR open in a `BEHIND` state with `sync:needed`.
-
-**Canonical path: automated.**
-
-`.github/workflows/back-merge-to-staging.yml` runs on `release: published`. It:
-
-1. Branches `chore/back-merge-main-after-vX.Y.Z` from the current `staging` head.
-2. Performs `git merge --no-ff origin/main`.
-3. Opens a PR (`base=staging`, `head=chore/back-merge-main-after-vX.Y.Z`) with the `residual:low` label so policy auto-clears it.
-4. Merges the PR with `gh pr merge --merge --admin`, bypassing required status checks because every commit being merged has already been reviewed and shipped through its own PR.
-
-The `--admin` step requires `RELEASE_PLEASE_TOKEN` (the same maintainer PAT used by `release-please.yml`). If the token is unset the workflow opens the PR but cannot merge it; a maintainer must finish with `gh pr merge <n> --merge --admin --delete-branch`.
-
-**Mergify safety net.**
-
-If the workflow's admin merge step fails or is skipped, `.mergify.yml` defines a `back-merge-to-staging` queue that picks up any open PR whose `head` matches `^chore/back-merge-main-after-` and merges it with `merge_method: merge` once required branch-protection checks settle. The `staging-integration` (squash) queue explicitly excludes that branch pattern so the back-merge cannot accidentally land as a squash.
-
-**Manual fallback.**
-
-If both the workflow and the queue are unavailable (token missing, workflow disabled, branch protection mid-change, or this is the bootstrap run before the workflow exists on `main`), do the back-merge by hand. **Open the PR as a draft** so the `staging-integration` queue cannot race in and squash it before all checks settle and you `--admin` merge:
-
-```bash
-git fetch origin
-git checkout staging
-git pull --ff-only origin staging
-git checkout -b chore/back-merge-main-after-<tag>
-git merge --no-ff origin/main \
-  -m "chore: back-merge main into staging after release <tag>"
-git push -u origin HEAD
-
-# Draft prevents Mergify from queueing this PR while checks run.
-gh pr create --draft \
-  --base staging \
-  --head "chore/back-merge-main-after-<tag>" \
-  --title "chore: back-merge main into staging after release <tag>" \
-  --body "Manual back-merge per ai/playbooks/publish-to-production.md §8." \
-  --label "residual:low"
-
-# Wait for validate / test / e2e / decide to be green on the PR head.
-# Then mark ready and admin-merge in one motion.
-gh pr ready <pr-number>
-# IMPORTANT: must be --merge (not --squash) so main stays an ancestor of staging.
-gh pr merge <pr-number> --merge --admin --delete-branch
-```
-
-Why draft: the `back-merge-to-staging` queue accepts the PR without checks, but Mergify's queue selection between two matching queues is not deterministic across versions. If `staging-integration` ever admits the back-merge branch (a Mergify-config bug, a change in matching semantics, or a typo in the negation guard), the PR is squashed and ancestry is silently broken. Drafting locks Mergify out until you take it ready and merge in the same step.
-
-**Verification.**
-
-After the back-merge merges, confirm:
-
-- `git log origin/staging..origin/main` is empty (nothing left on `main` that is not on `staging`).
-- `gh api repos/<owner>/<repo>/compare/main...staging --jq '.behind_by'` returns `0`.
-- The merge commit on `staging` has two parents (`git show --no-patch --format='%h %p' origin/staging`).
-
-If `behind_by` is still non-zero, the back-merge probably squashed instead of merged. Repair by opening a zero-diff merge-commit PR (a fresh `git merge --no-ff origin/main` against the current `staging` head) and admin-merge it with the merge method.
-
-## Expected three-PR sequence
-
-When this repository publishes normally, the sequence is:
-
-1. Open and merge the human-authored promotion PR: `staging` -> `main`.
-2. `release-please` runs on the new `main` head.
-3. `release-please` opens or updates a second PR from a `release-please*` branch with title `chore: release X.Y.Z`.
-4. The policy workflow can set `residual:low` on that release PR without CodeRabbit, because it is automation-shaped release metadata work.
-5. Mergify auto-queues and auto-merges the second PR through the `release-please` queue when `validate` and `decide` succeed.
-6. The merge of the second PR creates the tag and GitHub Release.
-7. The `release: published` event fires `back-merge-to-staging.yml`, which opens and admin-merges a third PR (`chore/back-merge-main-after-vX.Y.Z` -> `staging`) so `main` is an ancestor of `staging` again before the next feature lands.
-
-The first PR is human-decided. The second and third are repository-managed automation; they should not require manual review work in the ordinary happy path.
-
-## Related artifacts
-
-- `ai/playbooks/pull-request-execution-loop.md`
 - `ai/playbooks/release-management.md`
-- `ai/playbooks/environment-separation.md`
+- `ai/playbooks/pull-request-execution-loop.md`
 - `.mergify.yml`
-- `.github/workflows/release-please.yml`
-- `.github/workflows/back-merge-to-staging.yml`

--- a/ai/playbooks/pull-request-execution-loop.md
+++ b/ai/playbooks/pull-request-execution-loop.md
@@ -1,356 +1,129 @@
 # Pull request execution loop
 
-## Operating target
+## Use When
 
-This playbook targets 90% of pull requests resolved entirely by automation, with no human action required. Human action is reserved for decisions that require judgment, product direction, or explicit approval of irreversible production changes. It is not reserved for checking things that a deterministic tool or a configured AI reviewer can verify.
-
-**Machines verify. Humans decide.**
-
-Any verification step that still requires human attention is a gap in tooling, not a valid human checkpoint. Escalation to a human must carry a specific, bounded decision request—not an open-ended review task—with the full evidence bundle already compiled.
-
-## Objective
-
-Automate the path from open pull request to merge while preserving explicit human authority for changes that exceed defined risk thresholds.
-
-This playbook runs continuously on repositories that use it, once a governed baseline exists (see the repository foundation playbook). It defines how agents, CI, GitHub policy, and human decision points work together on every PR. Configured workflows in this repository use a `p1-*` job naming prefix and related environment variables for traceability; those identifiers refer to this document, not to an ordering label.
-
-The AI reviewer backend **MUST** be treated as replaceable. The framework's policy layer decides authority; the reviewer implementation supplies comments, findings, and suggested changes. Merge execution tooling is also replaceable: policy decides when merge is allowed, while a merge executor performs the merge or queue operation.
-
-## When to run
-
-Use it for every pull request targeting a protected branch.
-
-## Outcomes
-
-At the end of this playbook, each PR should have:
-
-- An initial risk classification.
-- A residual risk decision after review.
-- A branch freshness decision.
-- Deterministic validation evidence.
-- Automated review output.
-- A decision: auto-approve, escalate, request changes, or merge when allowed.
-- An audit trail recorded in GitHub state, comments, labels, checks, or events.
+- any PR targets a protected branch
+- designing or operating PR automation, review policy, freshness, or merge authority
 
 ## Inputs
 
-- Pull request metadata, diff, changed files, labels, and author.
-- Branch protection rules and required check contexts.
-- Repository test and validation commands.
-- CODEOWNERS and protected path definitions.
-- Threshold policy for low, medium, and high risk changes.
-- AI reviewer backend configuration and repository-specific review instructions.
-- Freshness policy for PR branches relative to the protected base branch.
-- A policy decision check that maps residual risk to merge authority.
+- PR metadata, diff, labels, and target branch
+- branch protection and required checks
+- repo validation and test commands
+- reviewer configuration and review state
+- threshold policy and path-based risk rules
 
-## Agent self-verification toolchain
+## Outputs
 
-Agents executing this playbook **MUST** run the following toolchain before any approval or merge decision. No human checking substitutes for missing tool output.
+- initial and residual risk state
+- branch freshness state
+- validation and review evidence
+- merge, escalation, or closure decision
 
-Required tools:
+## Steps
 
-- **Canonical validation** — `npm run validate` (lint + schema validation). Failing this is an unconditional blocker.
-- **Configured AI reviewer status context** — repository-configured reviewer status for the current head SHA (currently `CodeRabbit`). Missing, pending, or failing reviewer status is an unconditional blocker. The `p1-policy` `decide` job **polls** while **any** required context is absent or `pending`, using a **single shared time budget** across all configured contexts (bounded by repo variables `P1_POLICY_REVIEWER_STATUS_WAIT_SECONDS` and `P1_POLICY_REVIEWER_STATUS_POLL_INTERVAL_SECONDS`) so the check stays **in progress** until every reviewer status is terminal, instead of failing red immediately and forcing empty commits.
-- **Latest submitted AI review on current head** — Agents **MUST** treat the host’s **submitted review record** (for example `APPROVED` vs `CHANGES_REQUESTED` from the configured reviewer bot on the current `head` SHA) as a separate signal from a green reviewer **check** row. A terminal green check does not replace verifying the latest submitted review state matches policy before merge; see also “Finding closure before merge” in section 3.
-- **`residual:*` label** — set by `p1-residual-risk-engine` (or convergence logic inside `decide`). The engine can write labels slightly after `decide` begins on the same SHA. `decide` **refreshes** issue labels after validation and reviewer gates, then **polls** the issue for a `residual:*` label until `P1_POLICY_RESIDUAL_LABEL_WAIT_SECONDS` elapses (interval `P1_POLICY_RESIDUAL_LABEL_POLL_INTERVAL_SECONDS`), so transient “label not set yet” races do not fail the check before the engine’s write is visible.
-- **Automated AI review** — Repository-configured AI reviewer set (currently CodeRabbit via app configuration). Missing review evidence on the current head SHA is an unconditional blocker.
-- **Branch freshness check** — Comparison of PR head ancestry against the protected base branch. Being behind is a blocker until resolved automatically or flagged with `sync:needed`.
+1. Refresh the branch against its base before opening or updating the PR. Do not publish a knowingly stale head.
+2. Classify initial risk from changed paths and apply the policy labels: `risk:*`, `control-plane`, `sync:needed`, `autofix:*`, `residual:*`.
+3. Run deterministic checks and wait for every configured merge gate on the current head SHA.
+4. Require current-head reviewer evidence, not just a generic green status row.
+5. Enforce branch freshness. Behind branches must sync before merge.
+6. Treat review findings as work items. Close each CodeRabbit thread with `fix`, `accept as follow-up`, or `won't change`.
+7. If review leaves only safe autofix work, run the one-shot autofix loop and re-evaluate on the new head.
+8. Set residual risk from initial risk plus current-head review state and thread state.
+9. If policy allows automation to merge, verify every gate is green and complete the merge or queue path.
+10. If policy requires a human, finish all non-human work first and post a bounded decision request with the evidence bundle.
+11. Record the resulting risk, checks, findings, and merge or escalation outcome in observable PR state.
 
-Optional tools (enable as repository matures):
+## Rules
 
-- Security scanning (e.g., CodeQL, Semgrep) — output feeds into residual risk determination.
-- Dependency audit — `npm audit` or equivalent.
-- Type checking — standalone typecheck command if separate from lint.
-- Coverage delta — ensure changes do not reduce coverage below configured threshold.
+### Operating target
 
-Adding a tool to the optional toolchain promotes it to required. Removing a tool from required is a control-plane change and follows section 6.6.
+- Machines verify. Humans decide.
+- The target is maximum automation for verification work and explicit escalation only for real judgment calls.
+- The reviewer backend and merge executor are replaceable. Policy owns authority; tools supply evidence and execution.
 
-## Risk tiers
+### Required evidence before approval or merge
 
-Initial risk answers: how carefully should this PR be reviewed?
+- `npm run validate` must pass when relevant to the change.
+- Every configured merge gate on the current head SHA must be terminal and green.
+- The configured reviewer status context is required but not sufficient by itself.
+- The latest submitted AI review state on the current head SHA matters separately from the status check.
+- Current-head review output must actually exist on the PR timeline.
+- Branch freshness against the protected base branch is a hard gate.
 
-Residual risk answers: after review and evidence, is human approval still required?
+### Risk and residual risk
 
-### Low risk
+- `risk:low`: docs, comments, templates, non-runtime metadata, safe dependency bumps.
+- `risk:med`: app logic, schemas, CI workflows, internal tooling, observability configuration.
+- `risk:high`: auth, billing, secrets, security policy, destructive migrations, production infra, irreversible effects.
+- `risk:high` always becomes `residual:high`.
+- `control-plane` PRs never auto-downgrade below `residual:med`.
+- `risk:low` or `risk:med` can become `residual:low` only when current-head reviewer state is acceptable and threads are resolved or outdated.
+- If reviewer state still requests changes or unresolved threads remain, prefer `autofix:pending` over premature residual labels.
 
-Typical examples:
+### Review order and recovery
 
-- Documentation
-- Comments
-- Templates
-- Non-runtime metadata
-- Safe dependency bumps with passing checks
+- Wait for CodeRabbit auto-review first.
+- If there is no reviewer signal after about 15 seconds on a new head SHA, `@coderabbitai review` is allowed.
+- If review clearly started, wait up to 5 minutes before asking whether to trigger recovery.
+- When current-head thread closure is complete but `CHANGES_REQUESTED` persists, use the canonical approval prompt instead of forcing a full re-review.
+- If a reviewer or bot pushes a new commit, treat it as a new head SHA and rerun the loop from current-head evidence.
 
-Default agent authority:
+### Finding closure before merge
 
-- Review: yes
-- Approve: yes
-- Merge: yes, if all required checks pass and policy gates are satisfied
+- A green reviewer check is necessary but not sufficient.
+- Blocking findings must be fixed on the head SHA or explicitly waived by a human maintainer with visible rationale.
+- Non-blocking findings still require a visible decision on the thread: `fix`, `accept as follow-up`, or `won't change`.
+- Do not resolve threads just to satisfy GitHub conversation rules without visible substance.
+- A consolidated PR comment does not replace per-thread closure when policy depends on thread state.
+- If current-head evidence is complete but a required workflow run is stale, cancelled, or superseded by a later success on the same head SHA, rerun it instead of reaching for settings changes.
+- If only stale older reviewer submissions keep `CHANGES_REQUESTED` alive after current-head closure, a maintainer may dismiss them with a visible message naming the current head and why the stale review no longer applies.
 
-Low-risk automation only works if branch protection and CODEOWNERS are scoped so that documentation-only or metadata-only changes do not still require human codeowner review.
+### Autofix loop
 
-### Medium risk
+- The autofix loop runs once when `autofix:pending` is applied.
+- Safe autofix only: formatting, style, import ordering, deterministic lint fixes, whitespace normalization.
+- Not safe for autofix: logic changes, security-sensitive code, schema migrations, test assertions, or any runtime behavior change.
+- After autofix, push, mark `autofix:applied`, post what changed, and re-evaluate on the new head.
+- Do not rerun the autofix loop indefinitely on the same PR.
 
-Typical examples:
+### Merge ownership and convergence
 
-- Application logic
-- Schemas
-- CI workflows
-- Internal tooling
-- Observability configuration
+- The executing agent owns convergence through merge when policy allows it.
+- “PR opened” is not completion. If the PR is mergeable, finish the merge or verify the queue merged it.
+- If the first merge method is rejected, retry with an allowed method in repo policy order and keep the outcome operator-visible.
+- If the PR still does not land, diagnose the real blocker: missing residual label, stale checks, dequeued queue state, draft state, sync state, conflicts, or queue stall.
+- Do not rely on unbounded polling. Use bounded waits and re-check when the operator signals checks are done.
+- Automation should converge without manual label nudges when timing between checks is the only blocker.
 
-Default agent authority:
+### Control-plane handling
 
-- Review: yes
-- Approve: yes, when residual risk is downgraded to low by the residual risk engine
-- Merge: yes, when residual risk is downgraded to low and all gates pass
+- Control-plane PRs are evaluated under currently merged policy, not the proposed policy in the PR branch.
+- Workflow, branch-protection, and review-policy changes do not self-validate before merge.
+- Document any bootstrap exception used to land a control-plane change.
 
-Escalate when:
+## Canonical Snippets
 
-- The change affects the control plane (workflows, branch protection, review policy) — see section 6.6.
-- The agent resolution loop exhausted its attempts without resolving all blocking findings.
-- The diff is large, cross-cutting, or behavior-changing without clear evidence.
+### Approval prompt
 
-### High risk
+Use this when current-head thread closure is complete but `CHANGES_REQUESTED` still persists and a full re-review is not desired:
 
-Typical examples:
+> @coderabbitai Requested changes are addressed on the current head. Please approve or clear the pending request-changes when satisfied.
 
-- Auth and permissions
-- Billing and money movement
-- Secrets handling
-- Security policy
-- Destructive migrations
-- Production infrastructure access
-- Irreversible user-facing effects
+### Decision request template
 
-Default agent authority:
+Use this when automation must stop for a human decision:
 
-- Review: yes
-- Approve: no
-- Merge: no
-
-Human decision is mandatory. Automation **MUST** produce a complete decision request (see section 5) before stopping. The human is asked to decide, not to re-verify automated work.
-
-## Procedure
-
-### 0. Refresh the branch before opening or updating the PR
-
-Before creating a PR, the implementing agent **MUST** refresh the working branch against its intended base branch so the first published head is as current as possible.
-
-Minimum sequence for same-repository branches:
-
-1. `git fetch origin`
-2. `git checkout <work-branch>`
-3. `git rebase origin/<base-branch>` or `git merge --ff-only origin/<base-branch>` when the repository explicitly prefers that shape
-4. Run the required local validation again if the refresh changed the branch head
-
-If the refresh produces conflicts, resolve them before opening the PR. Do not treat "GitHub will mark it behind later" as an acceptable substitute for refreshing first.
-
-The automated branch-sync flow in section 2.5 remains the safety net for long-running PRs after publication; it does not replace this pre-PR freshness requirement.
-
-### 1. Ingest and classify
-
-1. Read the PR diff, changed files, labels, and target branch.
-2. Map changed paths and detected behavior to a risk tier.
-3. Emit the classification as a label, status, or comment.
-4. If any changed paths match the control-plane pattern, apply the `control-plane` label in addition to the risk label.
-
-Classification should be conservative. When in doubt, move the PR upward in risk.
-
-GitHub labels should be compact but self-explanatory:
-
-- `risk:low`, `risk:med`, `risk:high` for initial risk
-- `residual:low`, `residual:med`, `residual:high` for residual risk
-- `sync:needed` when the PR branch is behind the protected base branch
-- `control-plane` when the PR modifies workflow files, branch protection definitions, or review-policy logic
-- `autofix:pending` when the residual risk engine has identified fixable findings and the resolution loop has not yet run
-- `autofix:applied` when the resolution loop has applied fixes on this PR; prevents re-running the loop and escalates remaining issues
-
-### 1.5 Determine residual risk
-
-Residual risk is determined **automatically** by the residual risk engine (`p1-residual-risk-engine`). The engine runs when a configured AI reviewer submits a review on the current head SHA. No manual label setting is expected or required.
-
-Engine rules:
-
-1. If `risk:high`: set `residual:high` unconditionally. Post a decision request.
-2. If `risk:med` and the PR has the `control-plane` label: set `residual:med`. The owner-decision path applies for personal repositories; a second human approval applies otherwise.
-3. If `risk:med`, no configured AI reviewer still requests changes on the current head SHA, and the aggregated reviewer state across active configured reviewers is `APPROVED` or `COMMENTED` with all review threads resolved or outdated: set `residual:low`.
-4. If `risk:med` and any configured AI reviewer state is `CHANGES_REQUESTED`: set `autofix:pending` and leave `residual` unset until the resolution loop runs (see step 3.5).
-5. If `risk:low`, no configured AI reviewer still requests changes on the current head SHA, the aggregated reviewer state across active configured reviewers is `APPROVED` or `COMMENTED`, and all review threads are resolved or outdated: set `residual:low`.
-6. If `risk:low`, no configured AI reviewer still requests changes on the current head SHA, the aggregated reviewer state across active configured reviewers is `APPROVED` or `COMMENTED`, and any review thread remains unresolved and not outdated: set `autofix:pending` and leave `residual` unset until the resolution loop runs.
-7. If `risk:low`, unresolved review threads remain after `autofix:applied` is already present: set `residual:med` and post a decision request instead of re-queuing the one-shot autofix loop.
-8. If `risk:low` and any configured AI reviewer state is `CHANGES_REQUESTED`: set `autofix:pending`.
-
-If the PR head changes after residual risk is set, the engine **MUST** clear the existing `residual:*` label and re-evaluate from the new review evidence.
-
-The engine **MUST NOT** skip a configured reviewer step and assign residual risk as though review had already happened.
-
-### 2. Run deterministic checks
-
-1. Execute required validation, lint, typecheck, test, and build commands for the repository.
-2. Run security and dependency checks where applicable.
-3. Fail closed when required checks are missing or inconclusive.
-4. Wait for every configured merge gate to finish on the current head SHA before any approval or merge attempt. In this repository, that includes `validate`, `decide`, and the configured reviewer status context.
-
-No PR should be approved or merged without passing required checks.
-Agents **MUST NOT** merge a PR while any configured merge gate is still pending, even if GitHub or another merge executor would technically allow the merge because branch protection is missing or misconfigured. Host protection is a second line of defense, not the agent's source of truth.
-
-The canonical required checks for this repository are `validate`, `decide`, and the configured reviewer status context (`CodeRabbit`). All additional toolchain checks should be registered as required checks in branch protection or as blocking policy gates.
-
-### 2.5 Enforce branch freshness (automated)
-
-Branch freshness is enforced automatically by the branch sync workflow (`p1-branch-sync`).
-
-1. When the risk classification detects that a PR is behind the protected base branch, it applies `sync:needed`.
-2. The branch sync workflow triggers on `sync:needed` and attempts an automatic rebase.
-3. For same-repository branches: automation rebases onto the current base, force-pushes the result, and removes `sync:needed`. The policy check re-evaluates automatically after the push.
-4. For fork branches: automation cannot push to the fork. It posts a structured sync request with the exact commands the PR author must run, then waits.
-5. If the rebase produces conflicts, automation posts the exact conflicting file paths and stops. The PR author must resolve and repush. Automation resumes on the next push.
-
-Branch freshness is a hard gate. A PR evaluation is stale if the base branch has advanced in a way that could affect policy, CI, CODEOWNERS, or runtime behavior.
-
-Typical invalidation triggers:
-
-- Branch protection or merge-policy changes
-- Workflow or CI changes on the protected branch
-- CODEOWNERS changes
-- Framework or playbook changes that alter thresholds or checkpoints
-- Behavior-changing merges into protected surfaces
-
-### 3. Perform automated review
-
-1. Run an agent review against the diff and repository context.
-2. Produce concrete findings, not generic commentary.
-3. Distinguish blocking findings from suggestions.
-4. Attempt safe autofixes only when the policy allows it.
-
-Automated review must leave an auditable artifact in the PR.
-
-Repository-specific reviewer guidance **SHOULD** live in versioned files such as `.coderabbit.yaml` or equivalent backend configuration so the AI backend can be swapped without changing the playbook's policy.
-
-For this repository, automated AI review is requested through the root `.coderabbit.yaml` configuration, which enables CodeRabbit auto-review for non-draft pull requests. The policy check **MUST** verify both that the reviewer status context completed successfully and that expected configured AI review output actually appeared on the PR for the current head SHA before it treats review as complete. Acceptable current-head output is either a formal review on that SHA or a configured-reviewer PR timeline comment that explicitly references that SHA.
-
-For this repository, the intended review order is:
-
-1. CodeRabbit review is requested automatically by app configuration from `.coderabbit.yaml`.
-2. Automation and agents **SHOULD** wait for the automatic reviewer run before taking any manual action. Do not post `@coderabbitai review` during ordinary PR flow just to speed things up or keep checks moving.
-3. If no CodeRabbit signal appears at all on a new head SHA after roughly 15 seconds, an authorized collaborator **MAY** explicitly request follow-up work by commenting `@coderabbitai review` or using the host platform's re-review UI without additional approval, because the automatic trigger likely did not fire.
-4. If CodeRabbit has already posted a "review in progress" style comment or otherwise clearly started on the current head SHA, poll for up to 5 minutes in 1-minute intervals before taking recovery action.
-5. If CodeRabbit is still not finished after that 5-minute wait window, ask the user whether to keep waiting or trigger recovery with `@coderabbitai review`. Do not post the manual trigger automatically once the reviewer has clearly started.
-6. When per-thread outcomes are posted and confirmed on the current head but **`CHANGES_REQUESTED`** persists, post **one** PR comment asking CodeRabbit to approve or clear the pending request-changes. Do **not** post `@coderabbitai review`—that triggers a full re-review and is reserved for steps 3 and 5.
-
-   Canonical prompt:
-
-   > @coderabbitai Requested changes are addressed on the current head. Please approve or clear the pending request-changes when satisfied.
-
-7. If the reviewer produces a new commit on the PR branch, automation **MUST** treat that commit like any other new head SHA: rerun required checks, require fresh review evidence where policy says so, and re-evaluate residual risk from the updated state.
-8. The policy layer waits until configured AI review output is observable on the PR timeline for the current head SHA.
-9. The residual risk engine reads the latest active review state from the configured AI reviewer set together with all review thread resolution status and the initial risk label.
-10. The residual risk engine sets the `residual:*` label from the combined evidence.
-
-**Review thread resolution ownership:**
-
-The reviewer is the primary owner of resolving their own threads. When configured AI reviewers re-review after a fix commit, they **SHOULD** resolve threads they opened and consider satisfied. However, GitHub-hosted reviewers may not always re-review or resolve threads automatically after a new commit — this is a host-platform limitation, not a policy gap.
-
-When threads are not resolved by the reviewer after fixes are confirmed, automation **MUST NOT** allow the process to deadlock. The implementing agent **MAY** resolve reviewer threads on the reviewer's behalf when all of the following conditions hold:
-
-1. The implementing agent applied fixes that address the finding.
-2. The reviewer (or the reviewer's SWE agent) has explicitly confirmed in the PR timeline that the finding is addressed.
-3. No substantive disagreement about the fix exists on the thread.
-
-Resolving threads without reviewer confirmation is not permitted. Thread resolution without confirmation bypasses verification and defeats the purpose of the review gate.
-
-**Finding closure before merge (configured AI reviewer):**
-
-1. A green reviewer status context is **necessary** but **not sufficient**. The merging agent **MUST** treat review comments as work items.
-2. **Blocking findings** (including those surfaced via CodeRabbit’s request-changes workflow when enabled) **MUST** be fixed on the head SHA or explicitly waived by the human maintainer in the PR timeline with a recorded rationale.
-3. **Non-blocking suggestions** remain the merging agent’s responsibility: fix when reasonable; otherwise reply with a clear decision using the outcomes in `.coderabbit.yaml`: **fix**, **accept as follow-up**, or **won't change** (equivalent prose: *fixed* → **fix**; *deferred* → **accept as follow-up**; *rejected* → **won't change**). Reply directly on the review thread so the resolution history stays attached to the finding, even if the reviewer may later auto-resolve or mark the thread addressed after a re-review. “Looks good” without addressing open threads is not sufficient.
-4. Agents **MUST NOT** close or resolve review threads solely to satisfy GitHub’s “conversations resolved” requirement unless the substance above is already visible on the PR.
-5. **Automation vs prose:** Section **1.5** step 3 and the **`p1-policy`** workflow (`decide` job) both consult GitHub’s **review-thread state** (threads **resolved** or **outdated**). A consolidated PR comment alone does **not** flip that state. To avoid deadlocks, the merging agent **MUST** either push fixes (threads often become **outdated**), post on **each thread** (then resolve when the finding is truly closed), or obtain an explicit **human maintainer waiver** on the PR that names the thread(s) or review comment IDs it overrides—and still ensure thread state matches reality before merge. Silent bulk-resolution without visible decisions remains forbidden.
-6. If the current head SHA satisfies the evidence requirements of this playbook but a required host-side workflow run is stale, `cancelled`, or a **superseded `FAILURE`** (i.e. the same workflow has a later `SUCCESS` run on the same head SHA — typically because the residual-risk engine downgraded `risk:high` → `residual:low` after the configured AI reviewer landed, and the original `pull_request_review`-triggered `decide` job ran before the residual label existed), rerun the failed job on the current head so GitHub's check rollup and any downstream merge queue (e.g. Mergify) see only the resolved state. Repository settings changes are separate control-plane work and **MUST NOT** be the default remediation path. When Mergify has already dequeued in response to the stale failure, complete the recovery by removing any host-applied `dequeued`-equivalent label and posting `@mergifyio queue <queue-rule-name>` per the host-platform note below; do not wait for an automatic re-pickup.
-7. **Stale submitted reviews on older SHAs:** When the current head satisfies per-thread closure (fix or stated outcome) and the configured reviewer’s **commit status** is terminal green, but GitHub’s aggregate **reviewDecision** or branch rules still see **CHANGES_REQUESTED** only from **superseded** review submissions on **earlier** commits—for example the reviewer could not submit a fresh `APPROVED` / non-blocking review before a **rate limit**—a **maintainer** authorized to dismiss pull request reviews **MAY** **dismiss** those stale submissions via the GitHub REST API (`PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals` with a required `message`, and `event: DISMISS` where applicable) or the equivalent UI. The dismissal message **MUST** state that later commits addressed the findings and name the current head (or equivalent pointer). This path **MUST NOT** substitute for fixing blocking findings, waiving threads without a visible decision, or clearing “conversations resolved” without substance (points 2–5 above still apply).
-
-Host-platform note:
-
-- `@coderabbitai review` triggers a full re-review; use it only for stalled automatic runs (steps 3 and 5 above). When threads are already addressed, use the canonical prompt in step 6 instead.
-- **Configured reviewer rate limits:** When delayed by the reviewer backend’s rate limits, if per-thread outcomes are already complete on the **current** head, prefer the **canonical approval prompt** in section 3 item 6 before another `@coderabbitai review`. Use dismissal of stale **CHANGES_REQUESTED** submissions only after thread substance is closed and the dismissal message records why a fresh submission is unavailable.
-- **Mergify merge queue:** If a pull request was removed from the queue or shows a failed “embarked” check while `queue_conditions` on `.mergify.yml` are satisfied again, a collaborator may comment `@mergifyio queue` with the **queue rule name** when the config defines one (for example `@mergifyio queue low-risk`). If the repository applies a `dequeued` (or similar) label when a run fails, remove it when re-attempting so labels and host state stay consistent.
-- When a bot or app pushes a commit to the PR branch, direct PR-scoped checks may still run normally while some downstream `workflow_run` automation can enter an approval-required or `action_required` state under GitHub's trust model. That host safeguard **MUST NOT** be misinterpreted as a PR policy failure by itself.
-
-### 3.5 Agent resolution loop
-
-Before any human escalation, automation **MUST** attempt to resolve blocking findings.
-
-The resolution loop runs when `autofix:pending` is applied:
-
-1. Check out the PR branch.
-2. Run all auto-fixable toolchain commands (e.g., `biome check --write .` for formatting and lint).
-3. Commit any changes and push. Label the PR with `autofix:applied`.
-4. Post a structured resolution comment listing what was fixed and what was not.
-5. If everything is now fixed and `npm run validate` passes: remove `autofix:pending`. Configured AI reviewers re-run on the new head SHA and the residual risk engine re-evaluates.
-6. If unfixed issues remain after the resolution loop: post a structured decision request (see section 5) for the specific remaining items. Do not run the resolution loop again on the same PR once `autofix:applied` is set.
-
-The resolution loop **MUST NOT** attempt fixes outside the safe autofix set. Changes that require reasoning about business logic, security intent, or product behavior are decision items, not autofix items.
-
-Safe autofix actions:
-
-- Formatting and style (biome, prettier, etc.)
-- Import ordering
-- Lint rule violations with deterministic fixes
-- Whitespace and trailing-newline normalization
-
-Not safe for automated fix:
-
-- Logic changes
-- Security-sensitive code paths
-- Schema migrations
-- Test assertions
-- Anything that changes observable runtime behavior
-
-### 4. Apply threshold policy
-
-Decision rules:
-
-- Initial risk sets review depth.
-- Residual risk sets approval and merge authority.
-- Residual low: automation may approve or merge when checks pass and no blocking findings remain.
-- Residual medium: approval and merge follow repository-specific threshold policy.
-- Residual high: human decision is mandatory before approval or merge.
-- In a personal-repository deployment with a single human operator, threshold policy **MAY** allow the repository owner to act as the final human checkpoint for residual medium after all evidence gates pass, even when no second human reviewer exists.
-
-A threshold policy should include at least:
-
-- Affected paths or systems
-- Diff size or complexity thresholds
-- Branch freshness requirements
-- Initial vs residual risk rules
-- Required evidence types
-- Required human approver roles
-- Rollback expectations for risky changes
-
-### 5. Resolve or escalate
-
-1. If findings are autofixable and within authority, run the resolution loop (step 3.5) and rerun checks.
-2. If findings are not autofixable, post a structured decision request (see below) with explicit findings and the exact action required.
-3. If the PR crosses a human decision point, post the decision request with the evidence bundle before stopping.
-4. If review conversations are already addressed by the latest branch state, automation **MAY** resolve those conversations explicitly after verification (see reviewer confirmation rules in section 3).
-
-**Decision request format**
-
-When automation must stop for a human, the escalation comment **MUST** follow this structure. The human should be able to act in under two minutes without reading any other document.
-
-The template below uses a `**P1 decision request**` heading so it matches comments emitted by this repository’s `p1-policy` automation (the `P1` prefix is a workflow trace tag, not a playbook ordering label).
-
-```
+```md
 **P1 decision request**
 
 [One sentence: the exact decision needed from you.]
 
 **What changed**
-[2–3 sentence summary of what this PR does, derived from the diff and PR description.]
+[2-3 sentence summary of what this PR does, derived from the diff and PR description.]
 
 **Why automation stopped**
-[Exact reason: e.g., "`auth/permissions.ts` modified — production auth gate."]
+[Exact reason: e.g., "`auth/permissions.ts` modified - production auth gate."]
 
 **Automated verification (complete)**
 - ✓ Required checks: all pass
@@ -358,168 +131,25 @@ The template below uses a `**P1 decision request**` heading so it matches commen
 - ✓ Branch: current with main
 
 **Remaining items requiring your decision**
-[Numbered list of specific findings. Each entry: file:line — description — why it cannot be auto-resolved.]
+[Numbered list of specific findings. Each entry: file:line - description - why it cannot be auto-resolved.]
 
 **Your options**
-1. **Approve** — add your GitHub approval; merge proceeds automatically.
-2. **Request changes** — push a commit addressing the items above; automation resumes on the new head.
-3. **Close** — reject this PR.
+1. **Approve** - add your GitHub approval; merge proceeds automatically.
+2. **Request changes** - push a commit addressing the items above; automation resumes on the new head.
+3. **Close** - reject this PR.
 ```
 
-If residual risk still requires human intervention, automation **MUST** finish every non-human step before stopping. At minimum this means:
+## Constraints
 
-- Branch freshness resolved or explicitly blocked with `sync:needed`
-- Required checks either green or already rerunning for the current head SHA
-- Residual risk label applied
-- Resolution loop already run (if applicable)
-- Decision request posted in the format above
-- Required reviewer or approver requested when the host supports it
-- Auto-merge enabled in advance when repository policy allows merge immediately after approval
+- machines verify; humans decide
+- current-head evidence matters more than stale older runs
+- green reviewer status alone is insufficient without visible thread closure
+- stale or superseded required checks on the current head should be rerun, not worked around
+- the executing agent owns convergence through merge when policy allows it
+- control-plane PRs are never auto-downgraded to low residual risk
 
-The workflow **MUST NOT** deadlock indefinitely on an unavailable second human reviewer if repository policy explicitly names the owner as the terminal checkpoint for that risk tier.
+## References
 
-### 6. Approve and merge
-
-When the PR is within policy and all required checks have passed:
-
-1. Apply the policy decision for the residual-risk tier.
-2. Enable the configured merge executor or merge directly according to repository policy.
-3. Ensure branch cleanup runs after merge.
-
-Merge must be blocked if required checks are pending, stale, or bypassed.
-Merge must also be blocked if the PR branch is behind the protected base branch.
-Visible success from GitHub's merge UI is not sufficient by itself; automation **MUST** independently verify that every configured merge gate for the current head SHA is complete and green before merging.
-
-#### 6.1 Agent merge ownership and coordination
-
-The **agent executing this PR loop** (for example the implementing agent following the Developer skill) **owns convergence through a merged result** when policy allows—it is not enough to open a PR and stop once checks are “probably” running.
-
-- **Merge responsibility:** When residual risk and review state authorize merge and every configured merge gate is green on the current head SHA, that agent **MUST** ensure the PR actually lands on the protected branch: either by **performing the merge** (host UI, `gh pr merge`, or equivalent) when no other executor will do it in a timely way, or by **confirming** the repository’s **configured merge executor** (for example a merge queue such as Mergify) has merged after its conditions are satisfied.
-  - **Merge-method retries:** If the host rejects the first strategy (for example merge commits are disallowed), the agent **MUST** read the error message and branch-protection rules, then **retry** using an allowed strategy in a **defined order**: **squash** first, then **rebase** onto the protected base, unless repository documentation specifies a different preference. Each attempt and its outcome **SHOULD** be **operator-visible** (for example a brief PR timeline comment or an explicit note in the agent session transcript), not only silent CLI retries.
-  - **Persistent open PR:** If preconditions look satisfied but the PR still does not land after those attempts—or the blocker is not merge-method related—the agent **MUST** diagnose persistent causes (missing `residual:low` label, merge-queue stall, draft state, `sync:needed`, conflicts with the base branch, etc.), fix them when in authority, or **escalate** with evidence. Do not hand off an “almost done” PR without explanation.
-- **Polling:** Agents **SHOULD NOT** rely on unbounded polling while waiting for checks. **MAY** use short, bounded waits consistent with repository recovery policy (for example the CodeRabbit windows in `AGENTS.md`). When a human operator **explicitly reports** that CI or review has finished on the current head, the agent **SHOULD** take that as the cue to re-verify checks and proceed with thread closure and merge steps rather than idling in a loop.
-- **Human still decides** when policy requires it (residual high, control-plane exceptions, explicit waiver paths). Those cases remain escalation—not silent merge.
-
-### 6.5 Convergence rule
-
-Automation **MUST** converge without manual label toggling when the only blocker is timing between checks.
-
-Required behavior:
-
-1. If a required validation check has not completed yet on the current head SHA, the system **MUST** avoid creating a stale blocking policy result solely because validation is still pending. Implementations MAY defer the policy decision to the validation gate or re-evaluate automatically after validation completes.
-2. If branch freshness or residual-risk state is deterministically derivable from the current PR state, automation **MUST** set or refresh that state without manual intervention.
-3. If a stale failure exists but a newer successful policy evaluation exists on the same head SHA, the newer result **MUST** control the merge decision.
-4. Manual relabeling or comment nudges **SHOULD NOT** be required for ordinary convergence.
-5. If the host platform places privileged downstream automation such as `workflow_run` jobs into an approval-required state solely because the triggering commit came from a bot or app, the implementation **SHOULD** treat direct PR-scoped required checks on the current head SHA as the primary merge signal and document the host safeguard separately.
-
-This rule prevents false human escalation caused only by event ordering.
-
-### 6.6 Control-plane changes
-
-PRs that modify the PR automation control plane itself, including workflow files, branch-protection assumptions, or review-policy logic, **MUST** be evaluated under the currently merged policy on the protected branch, not the proposed policy in the PR branch.
-
-Required behavior:
-
-1. Automation changes do not self-validate until they are merged into the protected branch.
-2. The active workflow version on the protected branch is the source of truth for labels, checks, and merge authority during review.
-3. Control-plane PRs are identified by the `control-plane` label applied during risk classification. The residual risk engine **MUST NOT** auto-downgrade a `control-plane` PR to `residual:low` regardless of reviewer state. The minimum residual risk for a control-plane PR is `residual:med`.
-4. Framework updates should record any bootstrap exception used to merge a control-plane change.
-
-On a personal repository with no second human reviewer, implementations **SHOULD** minimize bootstrap exceptions by encoding the owner-decision path directly in policy for the allowed risk tiers, rather than relying on ad hoc manual overrides.
-
-### 7. Record outcomes
-
-Record:
-
-- Initial risk tier
-- Residual risk tier
-- Branch freshness state
-- Checks executed
-- Findings summary
-- Resolution loop outcome (applied / not needed / escalated)
-- Approval source
-- Merge decision
-- Escalation reason if applicable
-
-These records should be queryable from GitHub or emitted as framework events.
-
-## Human decision points
-
-Human involvement is required when any of the following apply:
-
-- Residual high risk (auth, billing, migrations, production infrastructure, secrets)
-- Control-plane change that cannot be auto-downgraded to `residual:low`
-- Residual medium risk when repository policy requires a human checkpoint
-- Agent resolution loop exhausted (all autofix attempts completed; non-fixable issues remain)
-- Rebase conflict on a fork branch (automation cannot push; author must resolve)
-- Confidence below the configured threshold
-
-Human involvement is **NOT** required for:
-
-- Verifying that checks pass — the check status is machine-observable
-- Confirming that a configured AI reviewer approved or commented — review state is machine-observable
-- Resolving lint or formatting issues — the resolution loop handles these
-- Confirming branch freshness — the sync workflow handles this
-- Setting `residual:*` labels — the residual risk engine handles this
-
-When a human does act, they receive a decision request (section 5) with the full evidence bundle. Their action is one of: approve, request changes, or close.
-
-## Recommended implementation layers
-
-The primary implementation uses:
-
-- **GitHub Actions** for deterministic checks and PR metadata workflows
-- **Branch protection** for merge enforcement
-- **AI reviewer backend** for code review and safe autofix proposals
-- **Mergify merge queue** for low-risk merge execution after policy passes
-- **Labels and check runs** for risk classification and residual risk state
-- **Required policy check** (`decide`) that decides whether human approval is still necessary
-- **Labels and checks** for branch freshness and update requirements
-
-Implemented workflows:
-
-- `p1-risk-classification` — Classifies changed paths; applies `risk:*`, `sync:needed`, `control-plane` labels
-- `p1-residual-risk-engine` — Triggers on configured AI review submission; auto-assigns `residual:*` or `autofix:pending`
-- `p1-branch-sync` — Triggers on `sync:needed`; auto-rebases same-repo branches; posts sync command for forks
-- `p1-autofix` — Triggers on `autofix:pending`; runs tool-based fixes, commits, and posts resolution summary
-- `p1-policy` — Required check `decide`; reads labels and evidence; passes or emits a structured decision request
-- `Mergify` (`.mergify.yml`) — Auto-queues and squash-merges `residual:low` PRs on `main` when `validate` and `decide` succeed
-
-Optional later layers:
-
-- Merge queue
-- Preview environments
-- Policy engine for path-based authority
-- Structured workflow state outside GitHub
-- AI-driven semantic autofix (extends `p1-autofix` with an LLM backend for logic-level fixes)
-- Coverage and performance regression gates
-
-## Events
-
-Example event names:
-
-- `pr.opened`
-- `pr.risk_classified`
-- `pr.residual_risk_set`
-- `pr.branch_outdated`
-- `pr.branch_synced`
-- `pr.branch_sync_failed`
-- `pr.validation_completed`
-- `pr.review_completed`
-- `pr.autofix_applied`
-- `pr.autofix_escalated`
-- `pr.escalated`
-- `pr.approved`
-- `pr.auto_merge_enabled`
-- `pr.merged`
-
-## Notes for future variants
-
-- This playbook should eventually be encoded in machine-readable process definitions under `spec/processes/`.
-- Risk tiering should evolve from simple path rules toward evidence-based thresholds incorporating security scanner output, coverage delta, and diff complexity scores.
-- Approval policy should remain stricter than review policy.
-- The reviewer backend may change over time; the threshold policy should not depend on a single provider.
-- Branch freshness rules should remain policy-owned even if the repository changes reviewer backends or CI providers.
-- Event ordering between validation and policy checks should be treated as an automation-convergence concern, not as a human-review concern.
-- The resolution loop should be extended with an LLM-driven semantic fix layer once the safe autofix boundary is well-established. The tool interface for this is defined in `interfaces/interfaces.yaml`.
-- The decision request format in section 5 is machine-generatable. Future versions should produce it from structured finding objects rather than free-form text.
+- `AGENTS.md`
+- `.coderabbit.yaml`
+- `.mergify.yml`

--- a/ai/playbooks/quality-standard-execution.md
+++ b/ai/playbooks/quality-standard-execution.md
@@ -1,207 +1,44 @@
-# Playbook: Quality Standard Execution
+# Quality standard execution
 
-**Version:** 0.1  
-**Normative reference:** `docs/QUALITY_STANDARD.md`  
-**Authority:** Procedure playbook — operationalizes `docs/QUALITY_STANDARD.md` and must not override normative requirements defined there. Sits below schema, policy, and `docs/QUALITY_STANDARD.md`.
+## Use When
 
----
-
-## Objective
-
-Carry out the verification discipline defined in the Quality Standard across three recurring operational loops:
-
-1. **PR gate loop** — confirm all blocking gates are green before merge
-2. **Nightly triage loop** — review nightly CI failures before the next release
-3. **Incident-to-regression loop** — close every medium/high severity incident with a regression test
-
----
+- a PR quality gate fails
+- nightly CI fails
+- a production incident needs regression coverage
+- a phase-readiness audit is requested
 
 ## Inputs
 
-| Input | Required for |
-|-------|-------------|
-| Current phase of the product (`docs/QUALITY_STANDARD.md §8`) | Gate model |
-| PR head SHA and current check states | PR gate loop |
-| Nightly CI run URL and failure summary | Nightly triage loop |
-| Incident ID and reproduction steps | Incident-to-regression loop |
-| Vitest config and test directory location | All loops |
-| Playwright config and BASE_URL | PR gate + nightly loops |
-
----
+- current product phase
+- current check states
+- nightly run URL and failure summary
+- incident ID and repro steps
 
 ## Outputs
 
-| Output | Loop |
-|--------|------|
-| All blocking gates green; PR mergeable | PR gate loop |
-| Nightly issue opened (if failure); triaged and closed or escalated | Nightly triage |
-| Regression test merged; incident closed | Incident-to-regression |
+- green blocking gates
+- triaged nightly outcome
+- merged regression coverage
+- phase evidence bundle when requested
 
----
+## Steps
 
-## 1. PR Gate Loop
+1. For PR gates, confirm spec validity first, then test, preview/E2E, reviewer state, and policy gates.
+2. Diagnose failures in order: spec/schema, unit/component, integration, E2E, accessibility, deployment smoke.
+3. For new behavior, add tests at the correct layer before or alongside the change.
+4. For nightly failures, classify the root cause as product regression, flaky test, environment issue, or external dependency change, then set the right deadline and close only after green confirmation.
+5. For incidents, reproduce first, write the regression at the lowest correct layer, confirm it fails before the fix and passes after it, then run the full loop through merge.
+6. For AI-mediated incidents, update the golden dataset and rerun evals when the standard requires it.
+7. For phase advancement, verify each checklist item from the real repo state and present evidence; do not self-advance.
 
-### 1.1 Before opening a PR
+## Constraints
 
-1. Confirm a spec entry exists for any new behavior (`npm run validate`).
-2. Write tests at the correct layer (unit → component → integration → E2E) before or alongside the feature code.
-3. Run `npm test` locally and confirm it is green.
+- do not skip blocking gates
+- critical-flow accessibility failures block merge
+- incident closure requires merged regression coverage
+- phase advancement remains a human decision
 
-### 1.2 After opening a PR
+## References
 
-1. **Wait for `validate` check.** Must pass. If it fails: fix the spec/schema issue before anything else.
-2. **Wait for `test` check.** Must pass. If it fails:
-   - Read the failure output. Identify which test and which assertion failed.
-   - Fix the code or the test (prefer fixing the code unless the test expectation was wrong).
-   - Do not skip or mark the failing test as `todo` to unblock.
-3. **Wait for Vercel preview deployment.** The `e2e` check is triggered by `deployment_status`. If the Vercel deployment never triggers:
-   - Confirm Vercel is connected to the repository and preview deployments are enabled.
-   - If unavailable, escalate to the human operator — do not skip the E2E gate.
-4. **Wait for `e2e` check.** Must pass. If it fails:
-   - Download the Playwright HTML report artifact from the workflow run.
-   - Identify the failing spec and the specific assertion (navigation? accessibility? smoke?).
-   - Fix the underlying issue. Accessibility violations on critical flows block merge — they are not deferrable.
-5. **Wait for `CodeRabbit` and `decide` checks** per `ai/playbooks/pull-request-execution-loop.md`.
-   - Every open CodeRabbit thread **MUST** be closed with a visible resolution before merge: `fix`, `accept as follow-up`, or `won't change` per `.coderabbit.yaml`. A green CodeRabbit status check alone is not sufficient — per-thread closure is required.
-   - Reply directly on each thread with the resolution details; do not use only a consolidated PR comment.
-6. Confirm all five gates are green: `validate`, `test`, `e2e`, `CodeRabbit`, `decide`.
-
-### 1.3 Gate failure diagnosis order
-
-```text
-1. Spec/schema failure → fix spec first, all else depends on it
-2. Unit/component failure → isolate the failing assertion; fix code or test
-3. Integration failure → check MSW handler coverage; confirm mock matches real API contract
-4. E2E failure → check the Playwright trace; distinguish app bug from flaky selector
-5. Accessibility failure → run axe locally with the same page; fix the violation in the component
-6. Smoke failure → the deployment itself is broken; treat as P1
-```
-
-### 1.4 Adding new tests for the current change
-
-- New API route → add integration test in `__tests__/api/`
-- New client component → add component test in `__tests__/components/`
-- New utility function → add unit test in `__tests__/lib/`
-- New user-visible flow → add E2E scenario to `e2e/critical-paths.spec.ts` if it is a critical path, or defer to nightly suite if not
-- New accessibility requirement → add axe assertion to the relevant spec in `e2e/critical-paths.spec.ts`
-
----
-
-## 2. Nightly Triage Loop
-
-Triggered when the `nightly` CI workflow reports a failure. A GitHub issue is auto-opened with label `nightly-failure`.
-
-### 2.1 Triage procedure
-
-1. Open the nightly workflow run URL in the issue.
-2. Identify which job(s) failed: `test-full` or `e2e-full`.
-3. **Classify the failure:**
-
-   | Classification | Signal | Action |
-   |---------------|--------|--------|
-   | Product regression | A test that was green on `main` yesterday is now failing | Create fix PR with regression test before next release |
-   | Flaky test | Intermittent failure with no code change | Add retry annotation or stabilize the selector; track in a follow-up |
-   | Test environment issue | Network timeout, missing env var, infra hiccup | Fix test infrastructure; do not close issue until nightly is green two nights in a row |
-   | External dependency change | Third-party API changed behavior | Update MSW handler or test expectation; document in decision log |
-
-4. Assign a severity and deadline:
-   - Product regression → P2 minimum; fix before next release (within 48h for P2).
-   - Environment issue → fix within one business day.
-   - Flaky test → fix within one sprint; do not let accumulate.
-
-5. Close the nightly issue only when the nightly run is green after the fix is merged.
-   - For flaky tests or isolated product regressions, one subsequent green nightly run is enough.
-   - For test environment or infrastructure issues, require two consecutive green nightly runs before closure.
-
-### 2.2 Escalation
-
-Escalate to human operator if:
-- The regression touches AI-mediated behavior and requires an eval rerun.
-- The root cause cannot be determined from CI logs and local reproduction.
-- Two consecutive nights fail with different failures (suggests systemic instability).
-
----
-
-## 3. Incident-to-Regression Loop
-
-Triggered when a production incident of severity P1 or P2 is opened.
-
-### 3.1 Protocol
-
-1. **Reproduce locally.** Identify the minimal input that triggers the failure.
-
-2. **Write a failing test first.** Choose the lowest applicable layer:
-
-   ```text
-   Is it a pure logic bug? → unit test in __tests__/lib/
-   Is it a component rendering bug? → component test in __tests__/components/
-   Is it an API contract bug? → integration test in __tests__/api/
-   Is it a user-visible flow bug? → E2E test in e2e/
-   ```
-
-   The test MUST fail on the current code before the fix is applied. Commit it as a failing test or write it as part of the fix PR with a comment showing it would have failed.
-
-3. **Apply the fix.** Confirm the new test now passes.
-
-4. **Tag the test with the incident ID:**
-
-   ```typescript
-   // Regression for incident #<ID>: <brief description>
-   it("handles <condition> without <bad outcome>", ...)
-   ```
-
-5. **Run the full local suite.** Confirm green before opening a PR.
-
-6. **Open a PR** with title pattern: `fix: <description> (regression for #<incident-id>)`.
-
-7. **Confirm all gates pass** using the PR gate loop (§1).
-
-8. **After merge:** re-run the nightly suite manually via `workflow_dispatch` to confirm the fix is green in the full nightly context.
-
-9. **Close the incident** with a reference to the merged PR and the test file/line.
-
-### 3.2 AI-specific incidents
-
-If the incident involves AI-mediated behavior:
-
-1. Add the incident input/output pair to the golden dataset under `products/dashboard/evals/<feature>/golden.json`.
-2. Re-run the eval suite to confirm the new negative example is caught.
-3. Promote the updated dataset and eval results as part of the fix PR.
-4. Human must review and sign off on dataset changes before merge (Phase 2 requirement).
-
----
-
-## 4. Phase Advancement Gate
-
-Before declaring a product ready for Phase 2 or Phase 3, run through the relevant checklist from `docs/QUALITY_STANDARD.md §8`.
-
-1. For each checklist item: confirm it is true by reading the actual code/config, not just by recall.
-2. Items that are not yet complete must be tracked as open issues before phase advancement.
-3. Phase advancement is a human decision — present the evidence, do not self-advance.
-
----
-
-## Escalation Conditions
-
-Stop and escalate to the human operator when:
-
-- A blocking gate failure cannot be attributed to the current change.
-- An accessibility violation on a critical flow cannot be fixed within the current PR scope.
-- The production smoke check fails after release.
-- The nightly suite fails for two consecutive nights with different root causes.
-- AI eval results drop below threshold and the cause is ambiguous.
-- Phase advancement requires a governance decision.
-
----
-
-## Canonical References
-
-- `docs/QUALITY_STANDARD.md` — normative standard (verification layers, gate model, phase criteria)
-- `products/dashboard/vitest.config.ts` — Vitest configuration
-- `products/dashboard/playwright.config.ts` — Playwright configuration
-- `products/dashboard/__tests__/` — unit and component test suite
-- `products/dashboard/e2e/` — E2E and accessibility suite
-- `.github/workflows/test.yml` — Vitest CI workflow
-- `.github/workflows/e2e.yml` — Playwright CI workflow (deployment_status)
-- `.github/workflows/nightly.yml` — nightly confidence suite
-- `ai/playbooks/pull-request-execution-loop.md` — PR review and merge policy
+- `docs/QUALITY_STANDARD.md`
+- `ai/playbooks/pull-request-execution-loop.md`

--- a/ai/playbooks/release-management.md
+++ b/ai/playbooks/release-management.md
@@ -1,121 +1,48 @@
 # Release management
 
-## Objective
+## Use When
 
-Automate repository-level semantic version tags and GitHub Releases with a reviewable release PR, while keeping release governance aligned with the repository's pull-request policy.
-
-## When to use
-
-- enabling release automation for this repository
-- changing versioning, changelog, release-tag, or GitHub Release behavior
-- auditing why release PRs, tags, or Releases are not being created
+- enabling or changing repo-level release automation
+- auditing missing release PRs, tags, or GitHub Releases
+- changing versioning, changelog, or release-token behavior
 
 ## Inputs
 
-- default release branch (`main` in this repository)
-- canonical merge policy from `ai/playbooks/pull-request-execution-loop.md`
-- release strategy (`release-please` + Conventional Commits for this repository)
-- current release baseline and tag history
-- GitHub Actions token configuration for release automation
+- default release branch
+- release strategy
+- current version baseline and tag history
+- token configuration
+- merge policy
 
 ## Outputs
 
-- a release workflow under `.github/workflows/`
-- repository release configuration (`release-please-config.json`, `.release-please-manifest.json`, optional `.github/release.yml`)
-- a canonical repo release version file (`version.txt`) that runtime telemetry can consume without tool-specific boilerplate
-- documented operator setup requirements
-- deterministic repo tags and GitHub Releases
+- release workflow
+- release configuration
+- canonical repo release source
+- documented operator setup
+
+## Steps
+
+1. Treat the repository, not a subpackage, as the released unit unless policy changes.
+2. Keep Conventional Commits as the release signal.
+3. Configure `release-please` in manifest mode.
+4. Keep root `version.txt` as the canonical runtime release value.
+5. Require `RELEASE_PLEASE_TOKEN` when downstream workflows must trigger.
+6. Keep changelog and GitHub Releases driven by the same release flow.
+7. For runtime consumers, derive production release from the repo tag and allow non-production SHA fallback.
+8. If Sentry release sync exists, publish the same release identifier the app emits.
+9. Validate the repo after release-config changes.
 
 ## Constraints
 
-- Treat the repository as the released unit; do not version `products/dashboard/` independently unless policy changes.
-- Use a dedicated automation token for release creation when downstream PR or tag workflows must trigger. `GITHUB_TOKEN` does not trigger most follow-on workflows created by the workflow itself.
-- Keep release tags SemVer-shaped and repo-level (`vX.Y.Z`).
-- Release automation is control-plane work. Route changes through the normal PR loop and required checks.
+- release tags stay repo-level and SemVer-shaped
+- control-plane changes still go through the normal PR loop
+- `GITHUB_TOKEN` is insufficient when follow-on workflows must trigger
 
-## Procedure
+## References
 
-1. Confirm the released unit is the whole repository, not a subpackage.
-2. Keep Conventional Commits as the release signal:
-   - `feat:` => minor
-   - `fix:` => patch
-   - `!` or `BREAKING CHANGE:` => major
-3. Configure `release-please` in manifest mode for repo-root releases.
-4. Keep root `version.txt` as the canonical repo release value for runtime consumers; `simple` release strategy updates this file automatically.
-5. Seed `.release-please-manifest.json` with the current baseline version so the first automated release starts from an explicit point.
-6. Add a release workflow on `main` and `workflow_dispatch`.
-7. Require a dedicated `RELEASE_PLEASE_TOKEN` secret before automation runs:
-   - this token should belong to a GitHub App or PAT that is allowed to open PRs and create tags
-   - skipping on missing token is preferable to silently creating release PRs that bypass downstream checks
-8. Keep changelog ownership with release automation:
-   - `CHANGELOG.md` should be updated by the release PR
-   - GitHub Release entries should be generated from the same release flow
-9. Derive runtime release metadata from the canonical repo version instead of duplicating per-tool version files:
-   - production builds should emit the GitHub-tag form (`vX.Y.Z`)
-   - non-production environments may fall back to commit SHA
-10. If Sentry release sync is enabled, publish a release on `release.published` using the same identifier the app emits at runtime.
-11. If release notes need category grouping for manual GitHub Releases, maintain `.github/release.yml`.
-12. Validate the repository after configuration changes with `npm run validate`.
-
-## Observability alignment for products
-
-When wiring a new product to the canonical release source, follow these rules so all services stay in sync:
-
-1. **Read `version.txt` at build time using `__dirname`-relative candidate paths**, not `process.cwd()`:
-   ```typescript
-   const candidates = [
-     path.resolve(__dirname, "../../version.txt"), // repo root version.txt
-     path.resolve(__dirname, "version.txt"),        // local fallback beside config file
-   ];
-   ```
-   This is stable across build entrypoints regardless of invocation directory.
-
-2. **Inject the resolved release at build time** (e.g., via `next.config.ts` `env` block) so client, server, and edge runtimes all receive the same baked-in value. Also set `SENTRY_RELEASE` / `NEXT_PUBLIC_SENTRY_RELEASE` from the same resolved value if not already set externally.
-
-3. **Production → named tag; all other environments → commit SHA fallback.** Never let a non-production build emit a named release version.
-
-4. **Use a single release resolver call per Sentry runtime.** Assign it once and use it for both `Sentry.init({ release })` and `initialScope.tags.app_release` so they are guaranteed to match even when `SENTRY_RELEASE` is overridden externally:
-   ```typescript
-   const release = getServerSentryRelease();
-   Sentry.init({ release, initialScope: { tags: { app_release: release } } });
-   ```
-   Never call `getAppRelease()` and `getServerSentryRelease()` separately and assign them to different fields — they can diverge.
-
-5. **For PostHog**, call `ph.register(getReleaseProperties())` in the client `loaded` callback, and spread `getReleaseProperties()` into every server-side capture call.
-
-6. **`lib/release.ts` is the shared resolution abstraction.** Do not re-implement release reading per-service; extend that module if new resolution logic is needed.
-
-## Staging → main promotion
-
-The detailed operating loop for opening and merging the production-publish PR now lives in `ai/playbooks/publish-to-production.md`. This section keeps only the release-specific constraints that promotion must preserve.
-
-When the repository uses a 3-tier environment model (`staging` as the integration branch):
-
-1. **Do not squash** when merging `staging` → `main`. Squashing collapses conventional commit history and breaks release-please version detection. Use a regular merge commit.
-2. **No separate code review required** for the promotion PR when CI is green on `staging`. The code was already reviewed when it landed on `staging`.
-3. **release-please monitors `main`**. Conventional commits that land on `main` via the `staging` promotion trigger release PR creation or updates automatically.
-4. **Mergify staging-promotion queue** (if configured) handles the merge with `merge_method: merge`. See `.mergify.yml` for the `staging-promotion` queue rule.
-5. If the promotion PR is created manually, ensure the PR title is descriptive but does not need to follow conventional commit format — the individual feature commits on `staging` already carry the semantic version signals.
-
-## Failure modes
-
-- No release PR appears after merge to `main`:
-  - verify `RELEASE_PLEASE_TOKEN` is configured
-  - verify the workflow ran on the current `main` SHA
-  - verify merged commits follow Conventional Commits
-- Release PR opens but required checks do not run:
-  - confirm the workflow is using `RELEASE_PLEASE_TOKEN`, not `GITHUB_TOKEN`
-- Tags or Releases are missing after a release PR merge:
-  - inspect the `release-please` workflow on the merge commit
-  - verify the manifest and config paths still match the workflow inputs
-
-## Related artifacts
-
+- `version.txt`
 - `.github/workflows/release-please.yml`
 - `release-please-config.json`
 - `.release-please-manifest.json`
-- `version.txt`
-- `.github/release.yml`
-- `.github/workflows/sentry-release.yml`
-- `ai/playbooks/pull-request-execution-loop.md`
 - `ai/playbooks/publish-to-production.md`

--- a/ai/playbooks/repository-foundation.md
+++ b/ai/playbooks/repository-foundation.md
@@ -1,178 +1,43 @@
 # Repository foundation
 
-## Objective
+## Use When
 
-Create a repository that is safe to collaborate in before product, growth, or operations workflows start shipping changes.
-
-This playbook converts a raw repository into a governed execution surface with validation, review controls, security defaults, and contributor guidance.
-
-## When to run
-
-Run it when you create a new repository and before opening normal feature branches, or whenever you need to audit or repair the same surfaces in an existing repository.
-
-## Outcomes
-
-At the end of this playbook, the repository should have:
-
-- A default branch pushed and treated as the protected source of truth.
-- CI running on push and pull request.
-- Branch protection bound to real required checks.
-- Merge strategy and branch cleanup defaults configured.
-- Repository rulesets configured for any default automated review behavior.
-- Basic governance files for ownership, contribution flow, security reporting, issues, and pull requests.
-- Dependency and security automation enabled.
-- CODEOWNERS scoped to protected repository surfaces if low-risk PR automation will be allowed later.
+- creating a new governed repository
+- auditing or repairing governance, CI, protection, or contributor surfaces
 
 ## Inputs
 
-- Repository name and owner.
-- Default branch name (`main` unless policy requires otherwise).
-- At least one passing validation workflow.
-- Initial maintainer or owner handle for CODEOWNERS.
+- repo owner and name
+- default branch
+- at least one passing validation workflow
+- maintainer handle for ownership surfaces
 
-## Procedure
+## Outputs
 
-### 1. Publish the repository
+- governed repo baseline
+- required governance files
+- branch protection bound to real checks
+- security automation enabled
 
-1. Initialize git history if needed and push the default branch to GitHub.
-2. Confirm the remote URL and authenticated GitHub identity are correct.
-3. Ensure workflow publishing has the required token scopes before pushing `.github/workflows/*`.
+## Steps
 
-## 2. Establish a minimum CI baseline
+1. Publish the repository and confirm the remote and identity are correct.
+2. Add a minimum CI workflow that runs the canonical validation command and confirm a passing check on the default branch.
+3. Add governance files: `CODEOWNERS`, PR template, issue templates, `CONTRIBUTING.md`, `SECURITY.md`, `dependabot.yml`.
+4. Configure repo defaults: merge strategy, branch cleanup, issues, description, and automated reviewer setup if used.
+5. Protect the default branch with real required checks, stale-review handling, conversation resolution, linear history, and admin enforcement.
+6. Enable security automation: alerts, automated fixes, secret scanning, push protection.
+7. Verify the configuration from GitHub and record the durable baseline.
+8. If the repo uses the 3-tier model, establish protected `staging`, redirect feature PRs there, scope observability by environment, and wire release/promotion behavior.
 
-1. Add a workflow that runs on `push` and `pull_request`.
-2. Make the workflow execute the repository's canonical validation command.
-3. Prefer deterministic installs and caching where available.
-4. Push the workflow and verify at least one successful run on the default branch.
+## Constraints
 
-For this repository, the required validation command is `npm run validate` and the required check context is `validate`.
+- never guess required check names
+- CODEOWNERS should protect sensitive surfaces without blocking low-risk automation everywhere
+- control-plane behavior must be observable on real PRs, not assumed from settings alone
 
-When the golden dashboard (`products/dashboard`) is present, Vitest coverage may upload to **Codecov** from the `test` workflow. Store the repository upload token as the GitHub Actions secret `CODECOV_TOKEN`, and keep Codecov’s GitHub check **informational** unless branch protection intentionally requires it (this repository defaults to informational status in `codecov.yml`). For Dependabot pull requests, duplicate the secret under **Dependabot secrets** if uploads should run on those PRs.
+## References
 
-## 3. Add repository governance files
-
-Create the following files before broader collaboration begins:
-
-- `.github/CODEOWNERS`
-- `.github/pull_request_template.md`
-- `.github/ISSUE_TEMPLATE/*`
-- `.github/dependabot.yml`
-- `CONTRIBUTING.md`
-- `SECURITY.md`
-
-These files establish who must review changes, how work enters the repo, and how vulnerabilities are handled.
-
-If the repository will later allow low-risk automated PR approval or merge, CODEOWNERS **SHOULD** target protected surfaces instead of every file in the repository. A blanket `*` owner rule blocks low-risk automation by forcing owner review on every change.
-
-## 4. Configure repository defaults on GitHub
-
-Apply the following repository settings:
-
-- Enable squash merge.
-- Disable merge commits unless the repo has a specific reason to preserve them.
-- Disable rebase merge unless the team explicitly prefers it.
-- Enable delete branch on merge.
-- Enable issues if they are part of the operating loop.
-- Disable wiki unless it is intentionally used.
-- Set the repository description.
-- Configure automated PR review for the repository if pull request automation will depend on a repository-configured AI reviewer.
-
-These choices keep history readable and prevent the repo from accumulating unmanaged side channels.
-
-If automated PR review is enabled at the repository level, the trigger configuration belongs in repository settings, rulesets, or app configuration, while repository-specific review behavior **SHOULD** remain in versioned configuration files such as `.coderabbit.yaml` or equivalent reviewer config.
-
-If residual-risk decisions in the pull request execution playbook will depend on host-native reviewer output, that reviewer **SHOULD** be configured while applying this playbook so automated review arrives before downstream agent policy or approval actions run. This playbook **SHOULD** also verify that the expected review artifact is observable on PRs for the current head SHA, because repository configuration alone is not sufficient evidence that review actually ran.
-
-If the repository is a personal repository with a single human operator, this playbook **SHOULD** also decide which risk tiers permit an owner-decision path so pull request policy does not deadlock on a nonexistent second human reviewer.
-
-## 5. Protect the default branch
-
-Bind branch protection to the actual successful CI check emitted by GitHub Actions.
-
-Recommended minimum protection:
-
-- Require pull requests before merging.
-- Require the repository's real merge-gate checks on the protected branch.
-- Dismiss stale approvals on new commits.
-- Require conversation resolution before merge.
-- Enforce rules for administrators.
-- Require linear history.
-- Disallow force pushes.
-- Disallow branch deletion.
-- Require strict status checks so the PR branch must be up to date before merge.
-
-Do not guess the required check name. Read it from the repository's check runs after the workflow has succeeded.
-If repository policy intentionally delegates merge authority to a policy check instead of GitHub's built-in approval count, branch protection **MUST** still require every concrete merge gate status context that agents depend on. Missing branch protection is a control-plane incident and should be corrected immediately.
-
-Repositories that shift merge authority from GitHub's built-in required-review gate to a repository-specific policy check **SHOULD** document that explicitly. In that mode, GitHub branch protection may require zero built-in approvals while still requiring a policy check such as `decide` before merge.
-
-## 6. Enable security automation
-
-Enable:
-
-- Dependabot alerts
-- Automated security fixes
-- Secret scanning
-- Push protection
-
-Security automation should be on before contributors begin adding integrations, secrets, or deployment credentials.
-
-## 7. Verify and record
-
-1. Run the validation command locally.
-2. Confirm the default branch is clean and tracking the remote.
-3. Read back repository settings and branch protection from GitHub.
-4. Record the applied configuration in the framework playbook so future repos reuse the same baseline.
-
-## 8. Establish the 3-tier environment model
-
-For products with observability instrumentation (PostHog, Sentry), establish environment separation before any real user traffic lands:
-
-1. **Create a long-lived `staging` branch** from `main`. Apply identical branch protection rules to `staging` as to `main` (required checks, linear history, no force pushes, no deletions, conversation resolution, enforce admins).
-2. **Redirect feature PR targets** to `staging`. Feature branches are created from `staging` and PRs target `staging`. `main` receives feature code via the `staging` release gate (exception: repository-managed release-please release PRs).
-3. **Configure a stable Vercel alias** for the `staging` branch (e.g. `staging.{domain}`). Vercel treats `staging` as a Preview deployment; assign the stable alias in Vercel → Settings → Domains.
-4. **Scope analytics tokens to Production only.** In Vercel → Environment Variables, set `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` (and `NEXT_PUBLIC_POSTHOG_HOST`) to Production environment only. PostHog guards initialization on `Boolean(token)` — no code change required. Sentry remains enabled in Preview/staging for real error visibility; rely on environment tags for dashboard filtering.
-5. **Redirect nightly CI** from the production URL to the staging URL. Set a `STAGING_URL` repository variable pointing at the stable staging alias. Update nightly workflow defaults to use `STAGING_URL` as the fallback target instead of the production origin.
-6. **Wire release automation.** `staging` → `main` is promoted via release-please using a regular merge (not squash) to preserve conventional commit history. No separate code review is required when CI is green on `staging`.
-7. **Separate the data tier.** For products with a hosted database (e.g. Supabase), provision one project per environment (`<product>-staging`, `<product>-production`) under the same organization, set per-environment GitHub Environment secrets (`SUPABASE_PROJECT_REF`, `SUPABASE_DB_PASSWORD`) plus a repo-level access token, wire `.github/workflows/supabase-migrate.yml` (validate / apply-staging / apply-production), require the `migrate-staging` check on the `staging-promotion` Mergify queue, and scope `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` per Vercel environment so Preview points at staging and Production at production.
-
-See `ai/playbooks/environment-separation.md` for the full reusable procedure (including the Database tier section).
-
-## Baseline applied in this repository
-
-The current repository-foundation baseline in this repository applies the following concrete settings:
-
-- Default branch: `main`
-- Integration branch: `staging` (protected, identical rules to `main`)
-- Feature PR target: `staging` (not `main`)
-- Release gate: `staging` → `main` via release-please (regular merge, no squash)
-- Required checks: `validate`, `test`, `e2e`, `CodeRabbit`, `decide`
-- Merge strategy: squash only (feature branches to `staging`); regular merge for `staging` → `main`
-- Delete branch on merge: enabled
-- Branch protection: enabled on `main` and `staging`
-- Strict status checks: enabled
-- Built-in GitHub approvals required: 0
-- Merge authority delegated to policy check: yes (`decide`)
-- CODEOWNERS review required by branch protection: no
-- CODEOWNERS scope: protected surfaces only
-- Stale review dismissal: enabled
-- Conversation resolution: required
-- Linear history: required
-- Force pushes: disabled
-- Branch deletions: disabled
-- Security automation: enabled
-- Automated PR review: CodeRabbit via `.coderabbit.yaml`
-- CodeRabbit review on new pushes: enabled
-- CodeRabbit review on draft PRs: disabled
-- Policy gate for observed CodeRabbit review artifact on the current head SHA before residual-low merge authority: enabled
-- Nightly CI target: `staging.ai-native-framework.app` (`STAGING_URL` repo variable)
-- PostHog token: Vercel Production environment only
-- Sentry: active on all environments; environment tag used for dashboard filtering
-- Data tier: one Supabase project per environment (staging + production) under one organization; migrations applied via `.github/workflows/supabase-migrate.yml`; `migrate-validate` required on `staging-integration`, `migrate-staging` required on `staging-promotion`; `production` GitHub Environment requires reviewer approval before `migrate-production` runs
-
-## Notes for future variants
-
-- Organizations may add team-based CODEOWNERS, signed-commit requirements, deployment environments, or release workflows on top of this baseline.
-- Repositories that want low-risk auto-merge should keep CODEOWNERS focused on protected paths, not documentation-only surfaces.
-- Repositories with multiple validation lanes may require more than one status check.
-- If the framework later introduces machine-readable process schemas under `spec/processes/`, this playbook should be encoded there as well as in Markdown.
+- `AGENTS.md`
+- `ai/playbooks/environment-separation.md`
+- `ai/playbooks/pull-request-execution-loop.md`

--- a/ai/playbooks/resolve-github-issues.md
+++ b/ai/playbooks/resolve-github-issues.md
@@ -1,178 +1,44 @@
-# Playbook: Resolve GitHub Issues
+# Resolve GitHub issues
 
-**Version:** 0.1  
-**Authority:** Procedure playbook — operationalizes recurring GitHub issue triage and resolution loops for this repository. Sits below schema, policy, interfaces, and higher-order framework docs.
+## Use When
 
----
-
-## Objective
-
-Resolve open GitHub issues with a governed, auditable loop that:
-
-1. batches issues that share the same failing workflow step, file, or root cause
-2. records intent on every issue before any file change
-3. routes the fix through the standard PR execution loop
-4. updates every issue again once the PR exists and when the fix outcome is clear
-
-This playbook is the canonical procedure for recurring issue-resolution work such as nightly CI failures.
-
----
+- triaging and fixing open GitHub issues
+- batching recurring nightly or operational failures by shared root cause
 
 ## Inputs
 
-| Input | Required for |
-|-------|-------------|
-| Repository owner and name | Listing and updating issues |
-| Open GitHub issues with labels, body, and comments | Triage and grouping |
-| Current `main` HEAD | Branch creation |
-| Applicable validation command(s) | Fix verification |
-| `ai/playbooks/pull-request-execution-loop.md` | PR publication and merge |
-| Risk rules for affected paths | Group classification and escalation |
-
----
+- open issue set
+- issue metadata and comments
+- relevant workflow evidence
+- validation command
+- PR execution policy
 
 ## Outputs
 
-| Output | Result |
-|--------|--------|
-| Grouped issue set with rationale | Shared-fix planning and audit trail |
-| Pre-change comment on every in-scope issue | Intent recorded before edits |
-| One PR per fix group | Batched implementation with review evidence |
-| Post-PR comment on every in-scope issue | Issue-to-PR traceability |
-| Closed, merged, or explicitly escalated issue state | No silent handoff |
+- grouped fix plan
+- pre-change comments on each in-scope issue
+- one PR per fix group
+- explicit post-PR issue updates
 
----
+## Steps
 
-## 1. Fetch And Filter
+1. List open issues and collect the evidence needed to understand each one.
+2. Group only when issues share the same failing step, file, or root cause.
+3. Post an intent comment on every in-scope issue before editing: plan, grouping, branch, risk, and any required human action.
+4. Create one branch per group and implement the smallest coherent fix.
+5. Add or update regression coverage when the failure mode should stay locked down.
+6. Run the required validation.
+7. Open one PR per group and drive it through the PR execution loop.
+8. After the PR exists, update every in-scope issue with the PR link, current state, and next action.
+9. Close through the PR when merged, or escalate explicitly when policy requires a human checkpoint.
 
-1. List all open GitHub issues for the repository.
-2. Skip issues labeled `blocked`, `wontfix`, or `needs-triage`.
-3. For every remaining issue, collect:
-   - number
-   - title
-   - body
-   - labels
-   - comments
-4. If the issue source is nightly CI, also inspect the failing workflow run and identify the failing step or file before grouping.
+## Constraints
 
----
+- do not edit first and explain later
+- keep fix groups small and real
+- do not create a parallel issue workflow outside the PR loop
 
-## 2. Group And Classify
+## References
 
-1. Group issues by shared affected path, failing workflow step, or root cause.
-2. Prefer one PR per group when multiple issues point at the same fix surface.
-3. Record the grouping rationale before acting. The rationale should name:
-   - the shared failing step, file, or root cause
-   - why one PR is the smallest coherent batch
-   - which issues are intentionally kept separate
-4. Assign an initial risk tier per group using the touched-path rules:
-
-   | Tier | Paths |
-   |------|-------|
-   | Low | `docs/**`, `README.md`, `CONTRIBUTING.md`, `.github/ISSUE_TEMPLATE/**` |
-   | Med | `spec/**`, `scripts/**`, `interfaces/**`, `.github/workflows/**`, `package.json` |
-   | High | auth, billing, secrets, migrations, infra |
-
-5. Escalate immediately if a grouped fix touches a high-risk path or needs a human decision before code changes.
-
----
-
-## 3. Comment Intent Before Editing
-
-For **every** issue in scope, post a GitHub comment before any file change that states:
-
-- what you plan to fix and why
-- which other issues are batched with it, if any
-- the branch name that will carry the fix
-- the expected risk tier
-- the exact owner action needed if a human checkpoint is expected later
-
-This comment is required. Do not start editing first and explain later.
-
----
-
-## 4. Implement By Group
-
-1. Create one branch per issue group from the current `main` HEAD.
-2. Use a `fix/` or `chore/` branch prefix unless the repository or operator requested another convention.
-3. Make the minimum change that resolves the group.
-4. Add or update tests when the failure mode should be locked down as a regression.
-5. Run the required validation command(s).
-6. Continue only if validation exits successfully.
-
-If validation does not pass, keep the issue `open` and document the blocker on the issue or PR instead of forcing the change through.
-
----
-
-## 5. Open And Drive The PR
-
-1. Open one PR per issue group.
-2. The PR body must include:
-   - one `Closes #<issue>` line per resolved issue
-   - a short summary of what changed and why
-   - validation evidence
-   - initial risk tier and residual-risk assessment
-   - the checklist from `.github/pull_request_template.md`
-3. Follow `ai/playbooks/pull-request-execution-loop.md` until the PR is merged or explicitly escalated.
-4. If CodeRabbit or other required review loops open findings, close them per the PR playbook before calling the issue work complete.
-
----
-
-## 6. Update Each Issue After The PR Exists
-
-After the PR is opened, update every in-scope issue with:
-
-- the PR link
-- the current risk label on the PR
-- the next required action
-
-Use explicit next-action language such as:
-
-- `auto-merge pending`
-- `owner approval needed`
-- `waiting on required checks`
-
-Do not leave the issue as an implicit pointer to the PR with no state summary.
-
----
-
-## 7. Close Or Escalate
-
-1. Close the GitHub issue through the PR when the PR merges and the issue-closing reference is valid.
-2. If the PR reaches a residual medium or high human checkpoint, stop automation only after:
-   - all non-human steps are complete
-   - the PR is approval-ready
-   - the issue comment states the exact owner action needed
-3. Never leave the loop in a dead state. If policy makes the owner the terminal checkpoint, say explicitly whether the owner should:
-   - merge now
-   - request changes
-   - close the PR
-
----
-
-## Decision Rules
-
-- When multiple issues share the same failing workflow step or file, default to one grouped fix unless there is a clear reason to split them.
-- Keep the fix group as small as possible while still matching the real root cause.
-- Prefer issue comments that describe the decision path, not just the result.
-- Do not create a separate issue-resolution process outside the PR execution loop; this playbook complements that loop and depends on it.
-
----
-
-## Escalation Conditions
-
-Stop and escalate when:
-
-- the grouped fix would touch a high-risk path without explicit owner instruction
-- the issue set cannot be grouped confidently from available evidence
-- required validation cannot be run
-- the fix depends on repository settings or other control-plane changes not explicitly requested
-
----
-
-## Canonical References
-
-- `AGENTS.md`
 - `ai/playbooks/pull-request-execution-loop.md`
-- `ai/playbooks/quality-standard-execution.md`
 - `.github/pull_request_template.md`

--- a/ai/playbooks/resolve-sentry-issues.md
+++ b/ai/playbooks/resolve-sentry-issues.md
@@ -1,158 +1,43 @@
-# Playbook: Resolve Sentry Issues
+# Resolve Sentry issues
 
-**Version:** 0.1  
-**Authority:** Procedure playbook — operationalizes recurring Sentry incident triage and closure loops for this repository. Sits below schema, policy, interfaces, and higher-order framework docs.
+## Use When
 
----
-
-## Objective
-
-Resolve Sentry issues with the same audit-trail discipline used for GitHub issues:
-
-1. assign and acknowledge the issue
-2. keep the issue `unresolved` while the code fix is in flight
-3. leave a triage note linked to the fix PR
-4. verify closure using explicit evidence, not intuition
-5. leave a resolution note and mark the issue `resolved`
-
-This playbook applies especially to active production issues such as Sentry issues in `escalating` state.
-
----
+- triaging and closing live Sentry incidents
+- handling unresolved or escalating production issues
 
 ## Inputs
 
-| Input | Required for |
-|-------|-------------|
-| Sentry org and project | Issue lookup and mutation |
-| Sentry issue ID or short ID | Triage target |
-| Write-capable Sentry token | Assignment, notes, and resolution |
-| Linked GitHub PR or fix branch | Audit trail and closure decision |
-| Recent Sentry event data | Evidence-based resolution |
-| Release or deploy context | Post-fix verification |
-
----
+- Sentry org and project
+- issue ID
+- write-capable token
+- linked fix PR or branch
+- recent event and release data
 
 ## Outputs
 
-| Output | Result |
-|--------|--------|
-| Assigned Sentry issue | Clear ownership |
-| Triage note linked to the active PR | In-flight audit trail |
-| Evidence bundle for closure | Merge timestamp, `lastSeen`, recent events/releases |
-| Resolution note | Human-readable closing rationale |
-| `resolved` Sentry issue state | Incident loop completed |
+- assigned issue
+- triage note linked to the fix
+- evidence bundle for closure
+- resolution note and final issue state
 
----
+## Steps
 
-## 1. Select And Inspect
+1. Select the issue and gather status, timestamps, recent events, and likely fix surface.
+2. Assign it, mark it seen, and keep it unresolved.
+3. Post a triage note with the current hypothesis, PR or branch, and next action.
+4. Fix the issue through the standard engineering loop.
+5. Before resolving, compare merge time, `lastSeen`, recent events, and recent releases.
+6. Resolve only when the evidence shows the failure is not recurring after the fix.
+7. Post a resolution note with the PR, merge time, evidence summary, and reopen rule.
 
-1. List or identify the open Sentry issue to triage.
-2. Prioritize issues that are active, unresolved, or `escalating` unless the operator gives a different scope.
-3. Collect:
-   - issue ID and short ID
-   - title and root symptom
-   - assignee
-   - status
-   - priority
-   - `firstSeen` and `lastSeen`
-   - recent events
-   - release tags and deployment context
-4. Identify the likely code or configuration path before opening or updating a PR.
+## Constraints
 
----
+- assignment, triage note, and resolution note are required
+- do not resolve on confidence alone
+- keep the issue unresolved while the fix is in flight
 
-## 2. Claim The Issue
+## References
 
-As soon as the issue is accepted for work:
-
-1. assign it to the responsible owner
-2. mark it as seen
-3. keep the status as `unresolved`
-
-Do **not** resolve the issue merely because investigation started or a branch exists.
-
----
-
-## 3. Leave A Triage Note
-
-Post a Sentry note before or alongside the implementation work that records:
-
-- the working root-cause hypothesis
-- the GitHub PR link or branch carrying the fix
-- why the issue remains `unresolved`
-- the next action required before closure
-
-The note should read like issue-tracking state, not like a chat transcript.
-
----
-
-## 4. Fix Through The Standard Engineering Loop
-
-1. Implement the fix in the repository.
-2. Validate it with the appropriate local and CI evidence.
-3. Open and merge the PR using `ai/playbooks/pull-request-execution-loop.md`.
-4. Keep the Sentry issue `unresolved` until the merge and a basic post-merge evidence check are complete.
-
----
-
-## 5. Verify Closure With Explicit Evidence
-
-Before resolving the Sentry issue, collect all of the following:
-
-1. the GitHub PR merged timestamp
-2. the Sentry issue `lastSeen` timestamp
-3. recent Sentry events for the issue
-4. recent release or deploy identifiers associated with those events
-
-Use those signals to decide:
-
-- If `lastSeen` or recent events are still after the fix merge or on a newer release, keep the issue `unresolved` and investigate further.
-- If the last observed events predate the merge and no post-merge recurrences are visible on later releases, the issue may be resolved.
-
-Do not close a Sentry issue on confidence alone. The closure decision must be evidence-based.
-
----
-
-## 6. Leave A Resolution Note And Resolve
-
-When the evidence supports closure:
-
-1. post a Sentry note that states:
-   - which PR merged
-   - when it merged
-   - what the latest relevant Sentry evidence shows
-   - when the issue should be reopened
-2. mark the issue `resolved`
-
-Recommended reopen rule:
-
-- reopen if new events appear on a later release or after the merge timestamp and match the same failure mode
-
----
-
-## Decision Rules
-
-- Treat the Sentry issue as a governed parallel loop, not as passive observability metadata.
-- Assignment, triage note, and resolution note are required parts of closure, not optional polish.
-- Prefer exact timestamps and release identifiers in the closing rationale.
-- If the Sentry API surface supports issue mutation and notes, use it directly; do not require manual UI cleanup for ordinary issue management.
-
----
-
-## Escalation Conditions
-
-Stop and escalate when:
-
-- you do not have a write-capable Sentry token
-- the issue cannot be tied to a concrete fix path or PR
-- post-merge events still appear and the root cause is ambiguous
-- the issue touches a high-stakes domain that requires explicit human review
-
----
-
-## Canonical References
-
-- `AGENTS.md`
 - `ai/skills/developer.md`
 - `ai/playbooks/pull-request-execution-loop.md`
 - `docs/ANALYTICS_STANDARD.md`

--- a/ai/playbooks/service-wiring.md
+++ b/ai/playbooks/service-wiring.md
@@ -1,135 +1,42 @@
 # Service wiring
 
-## Objective
+## Use When
 
-Configure external services (Supabase, Vercel, OAuth providers) so they are ready to support a deployed application environment. This playbook documents what agents can do autonomously, what requires a dashboard, and the exact steps for each.
+- standing up a new deployment environment
+- adding an auth provider
+- debugging auth failures caused by dashboard-side configuration or env misalignment
 
-## When to run
+## Inputs
 
-- Standing up a new deployment environment (staging, production)
-- Adding a new OAuth provider
-- Debugging auth failures caused by misconfigured redirect URLs or missing env vars
+- target domain
+- auth providers to enable
+- Supabase project ref
+- Vercel project details
 
-## Outcomes
+## Outputs
 
-At the end of this playbook:
+- aligned Supabase auth config
+- aligned local and Vercel env vars
+- provider list consistent across code and dashboards
 
-- Supabase auth is configured with the correct Site URL and Redirect URLs allowlist
-- All required environment variables are set in both local `.env.local` and Vercel
-- Enabled auth providers match across code (`NEXT_PUBLIC_AUTH_PROVIDERS`), Supabase dashboard, and any OAuth provider console
+## Steps
 
-## Tooling coverage map
+1. Check the tooling boundary first: agents can edit files, but Supabase auth config and Vercel env-var scoping are dashboard work.
+2. In Supabase, set the Site URL, add `/auth/callback` to Redirect URLs, and configure provider toggles.
+3. For magic-link-only flows, confirm the email-confirmation setting matches the intended UX.
+4. In Vercel, scope env vars by environment and redeploy after changes.
+5. Keep `NEXT_PUBLIC_AUTH_PROVIDERS` aligned with the providers actually enabled in Supabase.
+6. For Google OAuth, configure the Google redirect URI, enable the provider in Supabase, and add `google` to `NEXT_PUBLIC_AUTH_PROVIDERS`.
+7. If login fails across browsers, check whether PKCE behavior rather than code is the cause.
+8. Verify the full env-var and redirect alignment before closing.
 
-Understanding what agents can and cannot do prevents wasted time searching for tools that do not exist.
+## Constraints
 
-| Action | Tool available | Where to do it |
-|---|---|---|
-| Query Supabase database, run SQL | Supabase MCP (`execute_sql`) | Automated |
-| Update Supabase auth config (Site URL, Redirect URLs) | **None** | Supabase dashboard |
-| Enable/disable Supabase auth providers | **None** | Supabase dashboard |
-| Read Vercel projects and teams | Vercel MCP (`list_projects`, `list_teams`) | Automated |
-| Add/update Vercel environment variables | **None** | Vercel dashboard |
-| Scope Vercel env vars by environment (Production/Preview/Development) | **None** | Vercel dashboard |
-| Assign stable domain alias to a branch | **None** | Vercel dashboard → Domains |
-| Create Google OAuth credentials | No MCP; `gcloud` CLI (if installed) | Google Cloud Console |
-| Edit `.env.local` | File tools | Automated |
+- do not search for nonexistent automation tools when the action is dashboard-only
+- do not leave provider exposure inconsistent between code and service dashboards
+- staging and production env values must stay scoped correctly
 
-When the Supabase MCP or Vercel MCP returns no relevant tool for a configuration action, stop searching — the tool does not exist. Go directly to the dashboard.
+## References
 
-## Supabase auth setup
-
-### Required dashboard steps (cannot be automated)
-
-Every environment needs these three settings configured in the Supabase dashboard before magic link or OAuth login will work. Skipping any one causes silent auth failure.
-
-**URL Configuration** — [supabase.com/dashboard/project/{ref}/auth/url-configuration](https://supabase.com/dashboard/project/{ref}/auth/url-configuration)
-
-1. **Site URL** — set to the app's canonical origin (e.g. `https://ai-native-framework.app`). If this is wrong, Supabase silently falls back to it for all redirects.
-2. **Redirect URLs allowlist** — add `https://{domain}/auth/callback`. If the redirect URL sent by the app is not listed here, Supabase ignores it and uses the Site URL instead. This is the most common cause of "magic link goes to the wrong domain."
-
-**Email provider** — [supabase.com/dashboard/project/{ref}/auth/providers](https://supabase.com/dashboard/project/{ref}/auth/providers)
-
-3. **Confirm email** toggle — disable for magic-link-only flows. When enabled, new users receive a "Confirm your signup" email before they can use a magic link, which creates confusion and an extra failure point.
-
-### Failure signature
-
-When Redirect URLs are not configured correctly the symptom is: the user clicks the magic link in their email and lands on a different domain than the app (typically `localhost:3000` or whatever the Supabase project's Site URL was set to at creation time). The error shown on the login page is "That sign-in link was invalid or has expired."
-
-Check the magic link email directly — the link domain reveals the misconfigured Site URL.
-
-## Vercel environment variables
-
-### Dashboard path
-
-[vercel.com/{team}/{project}/settings/environment-variables](https://vercel.com/{team}/{project}/settings/environment-variables)
-
-Set variables for **Production** (and **Preview** if needed). Variables added here require a redeploy to take effect.
-
-### Analytics and monitoring token scoping
-
-To keep production metrics clean (real users only), scope observability tokens by Vercel environment:
-
-| Variable | Production | Preview | Development |
-|---|---|---|---|
-| `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` | ✅ set | ❌ unset | ❌ unset |
-| `NEXT_PUBLIC_POSTHOG_HOST` | ✅ set | ❌ unset | ❌ unset |
-| `NEXT_PUBLIC_SENTRY_DSN` | ✅ set | ✅ set | optional |
-
-PostHog guards initialization on `Boolean(token)` — unset token silently skips initialization with no code changes required. Sentry remains active on Preview/staging to surface real integration errors; filter production dashboards by `environment = production`.
-
-**Important:** If PostHog is connected via the Vercel PostHog integration, the variables are integration-managed and cannot be directly scoped per-environment. In that case: remove the integration-managed variables via "Manage Connection" → "Remove" and re-add them manually as plain env vars with Production-only scope.
-
-### Staging alias
-
-Assign a stable domain alias to the `staging` branch in Vercel → Settings → Domains (e.g. `staging.{domain}`). Vercel creates a Preview deployment for every push to `staging`; the alias makes the URL stable for nightly CI targeting.
-
-### Auth providers variable
-
-`NEXT_PUBLIC_AUTH_PROVIDERS` controls which auth providers the login UI shows. It is a comma-separated list:
-
-- Magic link only: `magic_link`
-- Magic link + Google: `magic_link,google`
-
-This variable must be consistent with what is enabled in the Supabase dashboard. Enabling Google in the code without configuring it in Supabase (or vice versa) causes a broken sign-in button.
-
-## Adding Google OAuth
-
-Three coordinated steps are required. All three must be complete before Google sign-in works.
-
-### Step 1 — Google Cloud Console (manual)
-
-1. Go to [console.cloud.google.com](https://console.cloud.google.com) → APIs & Services → Credentials
-2. Create OAuth 2.0 Client ID → Web application
-3. Add authorized redirect URI: `https://{supabase-project-ref}.supabase.co/auth/v1/callback`
-4. Copy the Client ID and Client Secret
-
-### Step 2 — Supabase dashboard (manual)
-
-1. Go to Authentication → Providers → Google
-2. Toggle on, paste Client ID and Client Secret from step 1
-
-### Step 3 — Environment variable (automated for `.env.local`; dashboard for Vercel)
-
-Add `google` to `NEXT_PUBLIC_AUTH_PROVIDERS`:
-
-```dotenv
-NEXT_PUBLIC_AUTH_PROVIDERS=magic_link,google
-```
-
-Agents can edit `.env.local` directly. Vercel requires the dashboard (no env var management tool in the Vercel MCP; Vercel CLI must be installed separately).
-
-## PKCE and cross-browser behavior
-
-The dashboard app uses `@supabase/ssr` which enables PKCE by default for all auth flows. PKCE stores a code verifier in the browser at the time the magic link is requested. Clicking the link in a different browser or email app will fail because the verifier is absent.
-
-This is expected Supabase PKCE behavior, not a code bug. If cross-browser magic links are required, the Supabase project's auth flow must be changed to the implicit flow — which is a separate architectural decision outside this playbook's scope.
-
-## Env var alignment checklist
-
-Before closing a service wiring task, verify:
-
-- [ ] `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are set in `.env.local` and Vercel
-- [ ] `NEXT_PUBLIC_AUTH_PROVIDERS` matches the providers enabled in the Supabase dashboard
-- [ ] Supabase Site URL matches the app's production origin
-- [ ] `/auth/callback` is in the Supabase Redirect URLs allowlist
-- [ ] For Google: OAuth client redirect URI in Google Cloud matches `{supabase-ref}.supabase.co/auth/v1/callback`
+- `ai/playbooks/environment-separation.md`
+- `products/dashboard/lib/auth/`

--- a/ai/skills/designer.md
+++ b/ai/skills/designer.md
@@ -1,64 +1,51 @@
 # Designer
 
-## Purpose
-
-Create or refine visual assets through human-guided iteration while keeping the work aligned with the framework's positioning and constraints.
-
 ## Use When
 
-- the task is to create or revise logos, banners, brand motifs, diagrams, or other visual artifacts
-- the output does not yet exist and needs exploration before implementation
-- human taste and feedback are expected to shape the final direction
-
-## Do Not Use When
-
-- the task is mainly product scoping, requirements, or rollout planning
-- the task is implementation, publication, or PR execution
-- the work is a small code-only tweak to an existing asset pipeline
+- creating or revising logos, banners, diagrams, or other visual assets
+- exploring visual directions before implementation
+- the outcome depends on human taste and visible iteration
 
 ## Inputs
 
-- goal, audience, and intended surface
-- brand intent, constraints, and examples if they exist
-- repo context that explains what the framework is and what the asset should signal
-- human feedback after each visible iteration
+- goal, audience, and target surface
+- brand intent, constraints, and references
+- repo context for what the asset should communicate
+- human feedback on visible iterations
 
 ## Outputs
 
-- multiple concrete visual directions when exploration is still open
-- a selected asset or direction with rationale
-- export-ready asset files or a precise handoff to implementation
+- distinct directions when exploration is open
+- a selected direction or asset with rationale
+- an implementation-ready asset or handoff
 
-## Workflow
+## Steps
 
-1. Understand what the asset needs to communicate before drawing anything.
-2. Inspect the existing repository and current brand surface so the new asset fits the system.
-3. Produce distinct directions instead of minor variations when the concept is still open.
-4. Show the work in context whenever possible so feedback is about the real use case, not the asset in isolation.
-5. Iterate from human feedback, preserving what was selected and changing only what the feedback actually targets.
-6. Hand off the selected asset in a form the Developer skill can publish cleanly.
+1. Clarify what the asset must communicate.
+2. Inspect the existing brand surface so the work fits the system.
+3. Produce clearly different directions, not cosmetic variants, while the concept is still open.
+4. Show the work in context when possible.
+5. Iterate from human feedback without re-opening already-decided parts.
+6. Hand off the selected result in a form the Developer skill can publish cleanly.
 
-## Decision Rules
+## Rules
 
-- Prefer simple geometry and small-size legibility over decorative detail.
-- Avoid generic AI tropes unless the task explicitly calls for them.
-- Treat human taste as the final authority on public-facing visual decisions.
-- If the design tool is separate from the repository, keep the repo as the published source of truth once a direction is selected.
+- Prefer clarity, legibility, and simple geometry over decorative detail.
+- Avoid generic AI tropes unless explicitly requested.
+- Treat human taste as final on public-facing visual decisions.
 
 ## Escalate When
 
-- the asset would materially change positioning, claims, or public brand direction
-- multiple competing directions remain valid and taste is the only separator
-- the requested visual language conflicts with the framework's stated principles
+- the asset would materially change positioning or public brand direction
+- multiple valid directions remain and taste is the only separator
+- the requested visual language conflicts with framework principles
 
-## Completion Criteria
+## Done
 
-- the human selected a direction or explicitly rejected the set and asked for another round
-- the chosen asset is export-ready and named clearly
-- the implementation handoff is specific enough that the Developer skill can publish without re-discovering intent
+- a direction is selected or explicitly rejected for another round
+- the chosen asset is export-ready or the handoff is implementation-ready
 
-## Canonical References
+## References
 
 - `README.md`
-- `docs/AI_NATIVE_FRAMEWORK.md`
 - `assets/brand/`

--- a/ai/skills/developer.md
+++ b/ai/skills/developer.md
@@ -1,82 +1,60 @@
 # Developer
 
-## Purpose
-
-Implement the selected change in the repository and carry it through validation, review closure, and publication per the pull request execution playbook.
-
 ## Use When
 
-- the task requires code, asset, documentation, or configuration changes in this repository
-- a selected concept or scoped brief is ready to be implemented
-- the work must be published through a pull request and merged per the pull request execution playbook
-
-## Do Not Use When
-
-- the task is still in open-ended exploration
-- the task is mostly product framing or design iteration
-- the only missing step is a human decision that cannot be automated
+- implementing code, docs, assets, or config changes in this repo
+- a selected concept or scoped brief is ready to ship
+- the work must go through validation, review, and merge
 
 ## Inputs
 
-- approved scope or selected artifact
-- affected files and repository constraints
-- relevant playbooks, especially pull request execution and the agent context bundle
-- live PR state when the work is already under review
+- approved scope
+- affected files and repo constraints
+- relevant playbooks
+- live PR state when review is already in flight
 
 ## Outputs
 
 - repository changes with verification evidence
-- a ready-for-review PR unless the user explicitly asks for draft
-- visible review resolution details and a merge-ready PR state
+- ready-for-review PR unless the user asked for draft
+- merged PR or explicit escalation
 
-## Workflow
+## Steps
 
-1. Inspect the repo, the affected files, and the governing artifacts before editing.
-2. Implement the smallest coherent change that satisfies the requested outcome.
+1. Read the affected files and governing artifacts before editing.
+2. Implement the smallest coherent change.
 3. Run the required validation for the changed artifact class.
-4. Before creating the PR, refresh the work branch against its intended base branch (`git fetch origin` plus rebase or fast-forward as the repo allows), then rerun validation if the branch head changed.
-5. Publish through a PR targeting `staging` (not `main`) and follow the pull request execution playbook until the PR is **merged** (or you have confirmed the merge queue merged it) when policy authorizes automation to complete the loop. The only PRs that target `main` directly are release-please release PRs and `staging` → `main` promotion PRs.
-6. Reply directly on each CodeRabbit thread with the resolution details when a finding is fixed, deferred, or intentionally unchanged.
-7. Use the exact canonical outcome text from `.coderabbit.yaml` in every thread reply: `fix`, `accept as follow-up`, or `won't change`. Prefer starting the reply with `fix:`, `accept as follow-up:`, or `won't change:` so the closure is machine- and human-scannable. Do not substitute synonyms like "fixed", "addressed", or "deferred", and do not rely on a commit hash alone.
-8. If you push a commit that addresses review findings, post those per-thread outcome replies in the same work cycle before moving on to waiting for checks, reviewer reruns, or merge decisions. Do this even if CodeRabbit may auto-resolve the thread after re-review; thread history still needs the human-visible resolution note. Do not treat "fix committed" as sufficient closure by itself, and do not replace per-thread replies with a consolidated PR comment.
-9. Before considering the PR loop complete, explicitly verify that every active CodeRabbit finding has one of those exact outcome replies on the thread or is outdated/resolved by reviewer confirmation on the current head.
-10. When **`CHANGES_REQUESTED`** persists after per-thread outcomes are on the threads, post the **canonical approval prompt** from `ai/playbooks/pull-request-execution-loop.md` section 3 item 6. Do **not** post `@coderabbitai review`—it triggers a slow full re-review. Reserve that for stalled automatic runs only.
-11. If a required check is stale, cancelled, or a **superseded `FAILURE`** on the current head, rerun that job immediately before diagnosing anything else. A cancelled or superseded-failure check on the current head SHA almost always clears with a rerun in under a minute — do not reach for workarounds first. The most common case is `p1-policy` `decide` running first on `pull_request_review` (before `residual:*` is labeled, so it fails as `risk:high`) and then succeeding on later `pull_request_target` runs after the residual engine downgrades to `residual:low`; the older `FAILURE` rows stay in the rollup, GitHub branch protection blocks merge, and Mergify dequeues. Rerun every failed `decide` run on the current head, remove any `dequeued` label, and re-queue with `@mergifyio queue <queue-name>` (e.g. `staging-integration`) — do not wait for automatic re-pickup, and do not reach for admin merge.
-12. When runtime behavior changes, include observability in-slice rather than as a follow-up: baseline exception capture, release and environment tagging, and main-path trace coverage. Follow the canonical observability guidance in framework tooling reference §10 for deeper Sentry requirements such as Replay, monitors/check-ins, source maps, and AI/tool-flow instrumentation.
-13. When the task is an operational issue loop rather than a feature PR, load the matching procedure playbook instead of improvising:
-   - GitHub issues or nightly-failure batching → `ai/playbooks/resolve-github-issues.md`
-   - Sentry production incident triage and closure → `ai/playbooks/resolve-sentry-issues.md`
-   - Production publish / `staging` -> `main` promotion → `ai/playbooks/publish-to-production.md`
-14. For Sentry-backed production issues, treat the incident as an active workflow, not just a source of evidence: assign it, keep it `unresolved` while the fix is in flight, leave a triage note linked to the PR, and resolve it only after explicit post-merge evidence review (`mergedAt`, `lastSeen`, recent events, recent releases).
-15. Before treating the work as fully closed, ask whether the completed workflow revealed durable learnings that should update the framework bundle or a playbook.
-16. When every configured merge gate for the current head is green and review threads are handled per playbook, **also** confirm the latest **submitted** GitHub review from each configured AI reviewer on **that same head SHA** is not **`CHANGES_REQUESTED`** (checks alone are not enough—use the PR Reviews tab or `gh api repos/<owner>/<repo>/pulls/<n>/reviews`). If aggregate **`CHANGES_REQUESTED`** remains only on **superseded** submissions from earlier SHAs after fixes and thread closure on the current head (for example reviewer rate limit prevented a new submission), escalate to a **maintainer** to **dismiss** those stale reviews with a documented message per `ai/playbooks/pull-request-execution-loop.md`—do not treat dismissal as a substitute for substance. Then **complete the merge** using a method the repository allows; if `gh pr merge` fails for merge-method policy, read the host error, then retry **squash** first and **rebase** second unless docs say otherwise, and leave a short operator-visible note of what was tried. If the PR still does not land, diagnose queue stalls, labels, draft state, base-branch drift, or escalate with evidence. If the repo uses a merge queue (such as Mergify), **verify** the PR merged once queue conditions are met; if the PR left the queue, use `@mergifyio queue` with the queue name from `.mergify.yml` after gates are green again. Do not stop at “PR opened” or “checks running.” Prefer bounded waits or the operator signaling that checks finished over endless polling.
-17. **Linear issue tracking (when a Linear issue backs this work):** Keep the issue in sync throughout the loop — do not batch updates at the end. Milestones and required actions:
-    - **Start:** transition Backlog → In Progress; assign to self; post a plan comment that is self-contained enough for any agent to resume cold (branch, inputs read, steps planned).
-    - **PR open:** transition In Progress → In Review; attach the PR link to the issue; post a comment with branch, head SHA, and what changed.
-    - **Each CodeRabbit round:** post a comment summarising the finding, the fix commit, and the in-thread outcome reply so the next agent knows review state without reading the PR.
-    - **Merge:** transition In Review → Done; post a final comment with merge commit, closed checklist, and the identifier of the next issue in sequence.
+4. Refresh the branch against its base before opening the PR; rerun validation if the head changed.
+5. Open the PR against `staging` unless this is an allowed `main`-targeting exception.
+6. Follow `ai/playbooks/pull-request-execution-loop.md` until the PR merges or policy requires a human decision.
+7. Reply directly on every CodeRabbit thread with one canonical outcome: `fix`, `accept as follow-up`, or `won't change`.
+8. If `CHANGES_REQUESTED` persists after current-head thread closure, post the canonical approval prompt from the PR playbook; do not force a full re-review.
+9. Rerun stale, cancelled, or superseded required checks on the current head before diagnosing anything else.
+10. Include required observability work in-slice when runtime behavior changes.
+11. Use the matching issue- or incident-resolution playbook when the task is an operational loop.
+12. Before closing, ask whether durable learnings should update the agent bundle or a playbook.
 
-## Decision Rules
+## Rules
 
-- Prefer repository edits and evidence over long explanations of what could be done.
+- Prefer repo edits and evidence over long explanation.
 - Treat review findings as work items, not commentary.
-- Do not treat repository settings changes as ordinary remediation; they are separate control-plane work unless explicitly requested.
-- Do not bypass branch protection or required checks to make progress.
-- For product code, do not treat observability as optional polish. A feature is incomplete if its failure modes are materially opaque in production when the framework expects Sentry-class error monitoring.
+- Do not use settings changes as ordinary remediation.
+- Do not bypass branch protection or required checks.
+- The executing agent owns convergence through merge when policy allows it.
 
 ## Escalate When
 
 - the task conflicts with schema, policy, or playbook rules
 - the remaining blocker is a human judgment call
-- automation would need new authority or repository settings changes to continue
+- new automation authority or settings changes would be required
 
-## Completion Criteria
+## Done
 
-- the repo change is implemented and validated
-- review findings are visibly addressed in-thread
-- the PR is **merged** into the protected branch when policy allows the executing agent to finish the loop, or an explicit human decision / escalation is posted when it does not
+- changes are implemented and validated
+- review findings are visibly closed on-thread
+- the PR is merged, or an explicit human decision request is posted
 
-## Canonical References
+## References
 
 - `AGENTS.md`
 - `ai/playbooks/pull-request-execution-loop.md`

--- a/ai/skills/framework-keeper.md
+++ b/ai/skills/framework-keeper.md
@@ -1,68 +1,54 @@
 # Framework Keeper
 
-## Purpose
-
-Audit the framework itself for consistency, efficiency, and predictability so the operating system stays coherent as it evolves.
-
 ## Use When
 
 - a change adds or modifies a playbook, skill, routing surface, or framework rule
-- the framework appears to contain contradiction, duplication, or procedural drag
-- repeated agent confusion suggests an important decision path is still implicit
-- a periodic framework health check is needed
-
-## Do Not Use When
-
-- the task is ordinary feature implementation inside an already-defined workflow
-- the issue is a one-off bug with no framework-level implications
-- higher-authority artifacts already fully determine the correct behavior
+- the framework shows contradiction, duplication, ambiguity, or drag
+- repeated agent confusion suggests an implicit decision path
+- a periodic framework health check is requested
 
 ## Inputs
 
-- audit scope and target artifacts
+- audit scope
 - relevant sources in authority order
-- any known operator pain points, ambiguity, or repeated agent failures
-- recent framework changes that may have introduced drift
+- known operator pain points or repeated failures
+- recent framework changes
 
 ## Outputs
 
-- a concise audit summary
-- prioritized findings with rationale
-- recommended remediation paths tied to concrete artifacts
-- explicit no-change conclusions where the framework is already adequate
+- concise audit summary
+- prioritized findings tied to concrete artifacts
+- remediation paths or explicit no-change decisions
 
-## Workflow
+## Steps
 
-1. Define the audit boundary before collecting evidence.
-2. Read the governing sources in authority order instead of starting from lower-order summaries.
-3. Check consistency top-down: schema and policy first, then interfaces, playbooks, docs, and the `ai/` bundle.
-4. Check efficiency: duplicated instructions, dead routing, unnecessary reading cost, or avoidable procedural steps.
-5. Check predictability: whether two competent agents would likely make the same decision from the same inputs.
-6. Report findings as concrete framework work items, not as abstract criticism.
+1. Define the audit boundary before reading widely.
+2. Read governing sources in authority order.
+3. Check consistency: contradictions, drift, stale routing, inconsistent terms.
+4. Check efficiency: repeated instructions, unnecessary read cost, duplicated logic.
+5. Check predictability: would two competent agents choose the same path and decision.
+6. Report findings as concrete framework work items.
 
-## Decision Rules
+## Rules
 
 - Prefer contradiction findings over style opinions.
-- Prefer recurring operator or agent friction over isolated awkwardness.
-- Prefer explicit decision rules over prose that depends on interpretation.
-- Do not invent new policy when the current authority ladder already answers the question.
+- Prefer recurring friction over isolated awkwardness.
+- Prefer explicit decision rules over interpretive prose.
+- Do not invent new policy when the authority ladder already answers the question.
 
 ## Escalate When
 
-- fixing a finding would change governance authority or merge policy
-- the framework lacks a canonical source for a disputed behavior
-- a proposed fix would grant new automation authority without explicit support
+- a fix would change governance authority or merge policy
+- the framework lacks a canonical source for disputed behavior
+- a proposed fix would grant new automation authority
 
-## Completion Criteria
+## Done
 
-- the audit scope is explicit
-- findings are tied to concrete artifacts
-- recommended remediations are actionable
-- unresolved governance questions are called out clearly
+- scope is explicit
+- findings are actionable and artifact-specific
+- unresolved governance questions are clearly called out
 
-## Canonical References
+## References
 
 - `AGENTS.md`
-- `README.md`
-- `docs/AI_NATIVE_FRAMEWORK.md`
 - `ai/playbooks/framework-review.md`

--- a/ai/skills/pm.md
+++ b/ai/skills/pm.md
@@ -1,63 +1,52 @@
 # PM
 
-## Purpose
-
-Turn intent into a scoped change definition that explains what should change, why it matters, and what implementation must deliver.
-
 ## Use When
 
-- the task needs a PRD, change brief, acceptance criteria, or implementation handoff
-- a selected concept must be translated into repository work
-- the team needs a clear explanation of scope, rationale, and success conditions before building
-
-## Do Not Use When
-
-- the task is purely visual exploration without a selected direction
-- the task is direct implementation or PR execution
-- the work is already fully specified by a higher-authority artifact
+- turning intent into scope, rationale, and acceptance criteria
+- translating a selected concept into repo work
+- reducing ambiguity before implementation
 
 ## Inputs
 
 - user goal and constraints
-- current repository context and relevant framework rules
-- selected concept, asset, or decision from earlier work
-- any rollout, documentation, or user-facing implications
+- relevant repo and framework context
+- selected concept, asset, or earlier decision
+- rollout or user-facing implications
 
 ## Outputs
 
-- a concise product/change brief
+- concise change brief
 - explicit scope, non-goals, and acceptance criteria
-- handoff notes that let the Developer skill implement without guessing intent
+- implementation handoff without guesswork
 
-## Workflow
+## Steps
 
-1. Restate the problem in operational terms: what is changing and why.
-2. Define the target artifact or surface and the exact expected outcome.
+1. Restate the problem in operational terms.
+2. Name the target surface and exact expected outcome.
 3. Separate must-have scope from follow-ups and non-goals.
 4. Write acceptance criteria that are observable in the repo or product.
-5. Identify which parts require human approval, taste, or policy awareness.
-6. Hand the work to implementation in a way that reduces ambiguity, not by adding filler.
+5. Identify any human approval, taste, or policy checkpoints.
+6. Hand the work to implementation without filler.
 
-## Decision Rules
+## Rules
 
 - Prefer sharp scope over exhaustive prose.
-- If a change affects multiple surfaces, define the minimum publishable slice first.
-- If the task is mostly execution and no meaningful scoping remains, do not invent PM theater.
+- Define the minimum publishable slice first.
+- Do not invent PM theater when the work is already clear.
 
 ## Escalate When
 
-- the requested change alters product positioning, strategy, or policy
-- requirements conflict with higher-authority artifacts
-- success cannot be evaluated from the requested outputs
+- the change alters positioning, strategy, or policy
+- requirements conflict with higher-order artifacts
+- success cannot be judged from the requested outputs
 
-## Completion Criteria
+## Done
 
 - implementation scope is explicit
 - acceptance criteria are concrete
 - follow-ups are separated from the current slice
 
-## Canonical References
+## References
 
 - `README.md`
-- `docs/AI_NATIVE_FRAMEWORK.md`
 - `ai/playbooks/agent-context-bundle.md`

--- a/ai/skills/quality-engineer.md
+++ b/ai/skills/quality-engineer.md
@@ -1,127 +1,62 @@
 # Quality Engineer
 
-## Purpose
-
-Implement, maintain, and execute the verification system for framework-aligned products. The Quality Engineer skill covers the full scope of `docs/QUALITY_STANDARD.md`: writing tests at the correct layer, running CI gates, triaging failures, executing the incident-to-regression loop, and advancing the product's quality maturity phase.
-
 ## Use When
 
-- Writing or reviewing tests for a new feature (unit, component, integration, E2E)
-- Triaging a failing CI check (`test`, `e2e`, `validate`)
-- Executing the incident-to-regression loop after a production issue
-- Auditing a product's Phase 1/2/3 readiness against the Quality Standard checklist
-- Setting up or configuring the test stack (Vitest, Playwright, MSW) for a new product
-- Reviewing accessibility failures from axe-core and deciding fix vs. defer
-
-## Environment model
-
-- **Production** (`main` / `ai-native-framework.app`): real users only. PostHog and Sentry reflect genuine user behavior. No automated test traffic ever targets production.
-- **Staging** (`staging` branch / `staging.ai-native-framework.app`): nightly CI target and E2E gate for PRs. PostHog token is unset — no analytics events generated. Sentry is active for real integration errors.
-- **Development** (local): PostHog auto-opts out in `NODE_ENV=development`. Sentry traces at full sample rate.
-
-When diagnosing nightly failures, the target is `STAGING_URL` (repo variable), not the production origin. Do not manually point nightly runs at production.
-
-## Do Not Use When
-
-- The task is purely about event capture, PII rules, or PostHog/Sentry wiring — that is `docs/ANALYTICS_STANDARD.md` territory
-- The task is a framework-level architecture audit — use the `Framework Keeper` skill
-- The task is implementing a new product feature with no quality/test focus — use the `Developer` skill
+- writing or reviewing tests
+- triaging `test`, `e2e`, or `validate` failures
+- running the incident-to-regression loop
+- auditing phase readiness against `docs/QUALITY_STANDARD.md`
+- setting up or refining the test stack
 
 ## Inputs
 
-- The product's current phase (from `docs/QUALITY_STANDARD.md §8`)
-- The failing check name, error output, and Playwright report (if E2E)
-- The incident ID and reproduction steps (for incident-to-regression work)
-- Spec entry for the behavior under test
-- Vitest and Playwright configs for the target product
+- current product phase
+- failing check name and error output
+- incident ID and repro steps when relevant
+- spec entry for the behavior under test
+- target Vitest and Playwright configuration
 
 ## Outputs
 
-- Tests that pass in CI and are anchored to a spec entry
-- A passing `test` check and `e2e` check on the PR
-- A regression test merged before incident closure
-- A phase readiness evidence bundle (for phase advancement)
+- correct-layer tests
+- green `test` and `e2e` gates
+- merged regression coverage for incidents
+- phase-readiness evidence bundle when requested
 
-## Workflow
+## Steps
 
-### Writing a new test
+1. Trace the behavior to a spec entry; create or update the spec first if needed.
+2. Choose the lowest correct test layer: unit, component, integration, then E2E.
+3. Write or fix the test and run it locally.
+4. For failing CI, diagnose from the error or trace before changing code.
+5. Treat critical-path accessibility failures as blockers.
+6. For incidents, write the regression so it fails on the broken behavior and passes after the fix.
+7. For operational loops, also load `ai/playbooks/quality-standard-execution.md`.
 
-1. Identify the spec entry the behavior traces to. If none exists, create it first.
-2. Choose the correct layer (see decision tree below).
-3. Write the test. Run it locally: `npm test` (Vitest) or `npx playwright test` (E2E).
-4. Confirm the test is green before opening a PR.
-5. Check that coverage of new lines is reasonable — don't chase a percentage, but untested critical paths should have at least one test.
+## Rules
 
-### Layer decision tree
-
-```text
-Is it a pure function / data transform / utility?
-  → Unit test in __tests__/lib/
-
-Is it a React component (rendering, interaction, accessibility semantics)?
-  → Component test in __tests__/components/
-
-Is it a server action / API route handler / multi-component flow?
-  → Integration test in __tests__/api/ or a Vitest integration test
-
-Is it a user-visible browser flow requiring navigation or real HTTP?
-  → E2E test in e2e/
-    Critical path (≤10 scenarios)? → e2e/critical-paths.spec.ts (blocking gate)
-    Non-critical? → nightly suite or separate spec file
-```
-
-### Diagnosing a failing `test` check
-
-1. Read the error output in CI. Identify the file, test name, and assertion.
-2. Run the same test locally: `npm test -- --reporter=verbose`.
-3. If the assertion is wrong (spec changed): update the test.
-4. If the code is wrong: fix the code, not the test.
-5. Never skip or mark the test as `todo` to unblock a PR.
-
-### Diagnosing a failing `e2e` check
-
-1. Download the Playwright HTML report from the CI artifact.
-2. Check the trace viewer for the failing step.
-3. Classify: app bug, flaky selector, accessibility violation, or smoke failure.
-4. Accessibility violations on critical flows: fix in the component, don't exclude the rule.
-5. Flaky selector: use `getByRole` or `getByText` over CSS selectors; add `await expect(...).toBeVisible()` before interactions.
-
-### Incident-to-regression loop
-
-Follow `ai/playbooks/quality-standard-execution.md §3` exactly. The key invariant: the regression test must **fail** on the incident-era code and **pass** after the fix. Do not write a test that only validates the fixed behavior without demonstrating it would have caught the regression.
-
-## Decision Rules
-
-- Never skip a blocking gate to unblock a PR. If a gate is broken, fix it.
-- Accessibility violations on critical flows are non-negotiable blockers. Fix in the component.
-- Tests must trace to a spec entry. If no spec entry exists, create it first.
-- Non-blocking failures (nightly, non-critical a11y) still require a tracked issue within 24 hours.
-- Visual regression is not introduced without explicit scope — don't add screenshot tests "while you're here."
-- Phase advancement is a human decision. Present the evidence bundle; do not self-advance.
+- Never skip a blocking gate to unblock a PR.
+- Tests should trace to spec entries.
+- Critical-flow accessibility violations are non-deferrable.
+- Non-blocking failures still need tracked follow-up.
+- Phase advancement is a human decision.
 
 ## Escalate When
 
-- A blocking gate failure cannot be attributed to the current change.
-- An accessibility violation requires a significant architectural change to fix.
-- The nightly suite is flaky across multiple nights without a clear root cause.
-- An AI eval drops below threshold and the degradation is ambiguous.
-- Phase advancement requires a governance decision.
+- a blocking failure cannot be attributed to the current change
+- an accessibility fix requires major architectural change
+- nightly instability lacks a clear root cause
+- AI eval degradation is ambiguous
+- phase advancement needs governance approval
 
-## Completion Criteria
+## Done
 
-- The relevant tests exist, are anchored to spec entries, and pass in CI.
-- The `test` and `e2e` blocking gates are green on the PR.
-- Any new accessibility scan passes on critical flows.
-- Nightly failures are tracked as open issues (not silently ignored).
-- For incident work: regression test is merged and the incident is closed with a PR reference.
+- the relevant tests exist at the right layer and pass
+- blocking quality gates are green
+- incident work includes merged regression coverage
 
-## Canonical References
+## References
 
-- `docs/QUALITY_STANDARD.md` — normative standard
-- `docs/ANALYTICS_STANDARD.md` — cross-reference for observability/PII boundary
-- `ai/playbooks/quality-standard-execution.md` — operational procedure
-- `products/dashboard/vitest.config.ts` — Vitest config (dashboard reference)
-- `products/dashboard/playwright.config.ts` — Playwright config (dashboard reference)
-- `products/dashboard/__tests__/` — test suite (dashboard reference)
-- `products/dashboard/e2e/` — E2E suite (dashboard reference)
-- `products/dashboard/tests/msw/` — MSW handlers (dashboard reference)
+- `docs/QUALITY_STANDARD.md`
+- `docs/ANALYTICS_STANDARD.md`
+- `ai/playbooks/quality-standard-execution.md`

--- a/products/dashboard/__tests__/app/workflows/actions.test.ts
+++ b/products/dashboard/__tests__/app/workflows/actions.test.ts
@@ -32,6 +32,7 @@ import type {
   WorkflowEvent,
   WorkflowRepository,
   WorkflowTask,
+  WorkflowTemplate,
 } from "@/lib/workflows/types";
 
 const { mockGetRepo, mockRevalidatePath, mockCaptureError } = vi.hoisted(() => ({
@@ -60,6 +61,7 @@ import {
   resolveCheckpointAction,
   retryBlockedTaskAction,
   startTaskAction,
+  updateTemplateAction,
 } from "@/app/(dashboard)/workflows/actions";
 
 function makeTask(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
@@ -329,6 +331,82 @@ describe("workflow matrix edit actions", () => {
     expect(addInstanceEvent.mock.calls[0]?.[0]).toBe(existing.instanceId);
     expect(addInstanceEvent.mock.calls[0]?.[1].name).toBe("workflow.task_deleted");
     expect(mockRevalidatePath).toHaveBeenCalledWith("/", "layout");
+  });
+
+  it("updateTemplateAction normalizes and persists template edits", async () => {
+    const updatedTemplate: WorkflowTemplate = {
+      id: "client-delivery",
+      label: "Client Project Delivery",
+      color: "#6366f1",
+      multiInstance: true,
+      stages: [{ id: "stage-1", label: "Planning", sub: "Scope" }],
+      roles: [{ id: "role-1", label: "Product", owner: "Andres", color: "#6366f1" }],
+      taskTemplates: [
+        {
+          id: "tt-1",
+          role: "role-1",
+          stage: "stage-1",
+          title: "Define scope",
+          desc: "Trimmed",
+          agent: "PM",
+          skill: "pm",
+          playbook: "slice-spec",
+        },
+      ],
+      createdAt: "2026-04-19T12:00:00Z",
+      updatedAt: "2026-04-19T12:00:00Z",
+    };
+
+    const updateTemplate = vi.fn().mockResolvedValue(updatedTemplate);
+
+    mockGetRepo.mockResolvedValue({
+      updateTemplate,
+    } satisfies Partial<WorkflowRepository>);
+
+    const result = await updateTemplateAction(" client-delivery ", {
+      ...updatedTemplate,
+      label: "  Client Project Delivery  ",
+      stages: [{ id: " stage-1 ", label: " Planning ", sub: " Scope " }],
+      roles: [{ id: " role-1 ", label: " Product ", owner: " Andres ", color: "#6366f1" }],
+      taskTemplates: [
+        {
+          id: " tt-1 ",
+          role: " role-1 ",
+          stage: " stage-1 ",
+          title: " Define scope ",
+          desc: " Trimmed ",
+          agent: " PM ",
+          skill: " pm ",
+          playbook: " slice-spec ",
+        },
+      ],
+    });
+
+    expect(updateTemplate).toHaveBeenCalledWith("client-delivery", {
+      label: "Client Project Delivery",
+      stages: [{ id: "stage-1", label: "Planning", sub: "Scope" }],
+      roles: [{ id: "role-1", label: "Product", owner: "Andres", color: "#6366f1" }],
+      taskTemplates: [
+        {
+          id: "tt-1",
+          role: "role-1",
+          stage: "stage-1",
+          title: "Define scope",
+          desc: "Trimmed",
+          agent: "PM",
+          skill: "pm",
+          playbook: "slice-spec",
+          checkpoint: false,
+          triggers: [],
+          gates: [],
+        },
+      ],
+    });
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/", "layout");
+    expect(mockRevalidatePath).toHaveBeenCalledWith(
+      "/workflows/templates/client-delivery/edit",
+    );
+    expect(result.template.id).toBe("client-delivery");
   });
 
   it("startTaskAction uses the atomic status transition and records an event", async () => {

--- a/products/dashboard/__tests__/components/top-bar.test.tsx
+++ b/products/dashboard/__tests__/components/top-bar.test.tsx
@@ -109,6 +109,7 @@ describe("TopBar", () => {
       React.useEffect(() => {
         setConfig({
           mode: "template-editor",
+          crumbs: ["Workflows", "Client Project Delivery"],
           label: "Client Project Delivery",
           onLabelChange: vi.fn(),
           onSave: vi.fn(),
@@ -129,7 +130,35 @@ describe("TopBar", () => {
     expect(
       screen.getByRole("textbox", { name: "Workflow template name" }),
     ).toHaveValue("Client Project Delivery");
+    expect(screen.getByText("Workflows")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument();
     expect(screen.queryByTestId("topbar-my-tasks-btn")).not.toBeInTheDocument();
+  });
+
+  it("renders configured workflow-instance breadcrumbs", () => {
+    vi.mocked(usePathname).mockReturnValue("/workflows/123");
+
+    function Harness() {
+      const { setConfig } = useDashboardTopBar();
+      React.useEffect(() => {
+        setConfig({
+          mode: "workflow-instance",
+          crumbs: ["Workflows", "Client Project Delivery", "Acme rollout"],
+        });
+        return () => setConfig(null);
+      }, [setConfig]);
+
+      return <TopBar />;
+    }
+
+    render(
+      <DashboardTopBarProvider>
+        <Harness />
+      </DashboardTopBarProvider>,
+    );
+
+    expect(screen.getByText("Workflows")).toBeInTheDocument();
+    expect(screen.getByText("Client Project Delivery")).toBeInTheDocument();
+    expect(screen.getByText("Acme rollout")).toBeInTheDocument();
   });
 });

--- a/products/dashboard/__tests__/components/top-bar.test.tsx
+++ b/products/dashboard/__tests__/components/top-bar.test.tsx
@@ -14,13 +14,19 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import React from "react";
 
+import { DashboardTopBarProvider, useDashboardTopBar } from "@/components/dashboard-topbar-context";
 import { TopBar } from "@/components/top-bar";
+
+function renderWithTopBarProvider(ui: React.ReactNode) {
+  return render(<DashboardTopBarProvider>{ui}</DashboardTopBarProvider>);
+}
 
 describe("TopBar", () => {
   it("renders the Overview breadcrumb on the home route", () => {
     vi.mocked(usePathname).mockReturnValue("/");
-    render(<TopBar />);
+    renderWithTopBarProvider(<TopBar />);
     const crumb = screen.getByText("Overview");
     expect(crumb).toBeInTheDocument();
     expect(crumb).toHaveAttribute("aria-current", "page");
@@ -28,44 +34,44 @@ describe("TopBar", () => {
 
   it("renders 'Skills' on /framework/skills", () => {
     vi.mocked(usePathname).mockReturnValue("/framework/skills");
-    render(<TopBar />);
+    renderWithTopBarProvider(<TopBar />);
     expect(screen.getByText("Skills")).toBeInTheDocument();
   });
 
   it("renders 'Playbooks' on /framework/playbooks", () => {
     vi.mocked(usePathname).mockReturnValue("/framework/playbooks");
-    render(<TopBar />);
+    renderWithTopBarProvider(<TopBar />);
     expect(screen.getByText("Playbooks")).toBeInTheDocument();
   });
 
   it("renders 'Event Feed' on /events", () => {
     vi.mocked(usePathname).mockReturnValue("/events");
-    render(<TopBar />);
+    renderWithTopBarProvider(<TopBar />);
     expect(screen.getByText("Event Feed")).toBeInTheDocument();
   });
 
   it("renders 'Settings' on /settings", () => {
     vi.mocked(usePathname).mockReturnValue("/settings");
-    render(<TopBar />);
+    renderWithTopBarProvider(<TopBar />);
     expect(screen.getByText("Settings")).toBeInTheDocument();
   });
 
   it("falls back to a humanised crumb for unknown routes", () => {
     vi.mocked(usePathname).mockReturnValue("/some-future-route");
-    render(<TopBar />);
+    renderWithTopBarProvider(<TopBar />);
     expect(screen.getByText("Some Future Route")).toBeInTheDocument();
   });
 
   it("renders a header landmark", () => {
     vi.mocked(usePathname).mockReturnValue("/");
-    render(<TopBar />);
+    renderWithTopBarProvider(<TopBar />);
     expect(screen.getByTestId("topbar-header")).toBeInTheDocument();
   });
 
   it("renders the My Tasks pill and it toggles expanded state when clicked", async () => {
     vi.mocked(usePathname).mockReturnValue("/");
     const user = userEvent.setup();
-    render(<TopBar />);
+    renderWithTopBarProvider(<TopBar />);
     const pill = screen.getByTestId("topbar-my-tasks-btn");
     expect(pill).toBeInTheDocument();
     expect(pill).toHaveAttribute("aria-expanded", "false");
@@ -87,11 +93,43 @@ describe("TopBar", () => {
       prefetch: vi.fn(),
     });
 
-    render(<TopBar />);
+    renderWithTopBarProvider(<TopBar />);
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Edit" }));
 
     expect(replace).toHaveBeenCalledWith("/workflows/123?edit=1", { scroll: false });
+  });
+
+  it("renders the template-editor breadcrumb input and save pill when configured", () => {
+    vi.mocked(usePathname).mockReturnValue("/workflows/templates/client-delivery/edit");
+
+    function Harness() {
+      const { setConfig } = useDashboardTopBar();
+      React.useEffect(() => {
+        setConfig({
+          mode: "template-editor",
+          label: "Client Project Delivery",
+          onLabelChange: vi.fn(),
+          onSave: vi.fn(),
+          saveDisabled: false,
+        });
+        return () => setConfig(null);
+      }, [setConfig]);
+
+      return <TopBar />;
+    }
+
+    render(
+      <DashboardTopBarProvider>
+        <Harness />
+      </DashboardTopBarProvider>,
+    );
+
+    expect(
+      screen.getByRole("textbox", { name: "Workflow template name" }),
+    ).toHaveValue("Client Project Delivery");
+    expect(screen.getByRole("button", { name: /save workflow/i })).toBeInTheDocument();
+    expect(screen.queryByTestId("topbar-my-tasks-btn")).not.toBeInTheDocument();
   });
 });

--- a/products/dashboard/__tests__/components/top-bar.test.tsx
+++ b/products/dashboard/__tests__/components/top-bar.test.tsx
@@ -129,7 +129,7 @@ describe("TopBar", () => {
     expect(
       screen.getByRole("textbox", { name: "Workflow template name" }),
     ).toHaveValue("Client Project Delivery");
-    expect(screen.getByRole("button", { name: /save workflow/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument();
     expect(screen.queryByTestId("topbar-my-tasks-btn")).not.toBeInTheDocument();
   });
 });

--- a/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
@@ -15,6 +15,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import { DashboardTopBarProvider } from "@/components/dashboard-topbar-context";
 import { ProcessMatrix } from "@/components/workflows/process-matrix";
 import type {
   WorkflowInstanceDetail,
@@ -101,6 +102,10 @@ function instance(tasks: WorkflowTask[]): WorkflowInstanceDetail {
   };
 }
 
+function renderWithTopBarProvider(ui: React.ReactNode) {
+  return render(<DashboardTopBarProvider>{ui}</DashboardTopBarProvider>);
+}
+
 describe("ProcessMatrix", () => {
   beforeEach(() => {
     mockCreateTaskAction.mockReset();
@@ -126,7 +131,7 @@ describe("ProcessMatrix", () => {
       }),
     ]);
 
-    render(<ProcessMatrix instance={inst} template={TEMPLATE} />);
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} />);
 
     expect(
       screen.getByRole("table", { name: "Workflow process matrix" }),
@@ -155,7 +160,7 @@ describe("ProcessMatrix", () => {
       task({ id: "k-3", roleId: "sales", stageId: "validation", status: "complete" }),
     ]);
 
-    render(<ProcessMatrix instance={inst} template={TEMPLATE} />);
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} />);
 
     const stage1 = screen.getByTestId("matrix-stage-pre-sales");
     const pips = within(stage1).getAllByTestId(/^matrix-pip-/);
@@ -171,7 +176,7 @@ describe("ProcessMatrix", () => {
     ]);
     const user = userEvent.setup();
 
-    render(<ProcessMatrix instance={inst} template={TEMPLATE} />);
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} />);
 
     expect(screen.getByTestId("matrix-role-label-sales")).toBeInTheDocument();
 
@@ -193,7 +198,7 @@ describe("ProcessMatrix", () => {
 
   it("renders the placeholder when the template is missing", () => {
     const inst = instance([]);
-    render(<ProcessMatrix instance={inst} template={null} />);
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={null} />);
 
     const empty = screen.getByTestId("matrix-empty");
     expect(empty).toHaveTextContent(/no longer available/i);
@@ -201,7 +206,7 @@ describe("ProcessMatrix", () => {
 
   it("renders the placeholder when the template has no stages or roles", () => {
     const inst = instance([]);
-    render(
+    renderWithTopBarProvider(
       <ProcessMatrix
         instance={inst}
         template={{ ...TEMPLATE, stages: [], roles: [] }}
@@ -225,7 +230,7 @@ describe("ProcessMatrix", () => {
     });
     mockCreateTaskAction.mockResolvedValue({ task: created });
 
-    render(<ProcessMatrix instance={inst} template={TEMPLATE} editMode />);
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} editMode />);
 
     await user.click(screen.getByTestId("matrix-add-task-product-validation"));
     expect(screen.getByRole("dialog", { name: "New task" })).toBeInTheDocument();
@@ -249,7 +254,7 @@ describe("ProcessMatrix", () => {
     const user = userEvent.setup();
     mockDeleteTaskAction.mockResolvedValue(undefined);
 
-    render(<ProcessMatrix instance={inst} template={TEMPLATE} editMode />);
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} editMode />);
 
     await user.click(screen.getByLabelText("Remove task: Project Description"));
     expect(screen.getByRole("dialog", { name: 'Delete "Project Description"?' })).toBeInTheDocument();

--- a/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
@@ -14,6 +14,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 
 import { DashboardTopBarProvider } from "@/components/dashboard-topbar-context";
 import { ProcessMatrix } from "@/components/workflows/process-matrix";
@@ -102,7 +103,7 @@ function instance(tasks: WorkflowTask[]): WorkflowInstanceDetail {
   };
 }
 
-function renderWithTopBarProvider(ui: React.ReactNode) {
+function renderWithTopBarProvider(ui: ReactNode) {
   return render(<DashboardTopBarProvider>{ui}</DashboardTopBarProvider>);
 }
 

--- a/products/dashboard/__tests__/components/workflows/template-editor-screen.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/template-editor-screen.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TemplateEditorScreen } from "@/components/workflows/template-editor-screen";
+import type { WorkflowTemplate } from "@/lib/workflows/types";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock("@/app/(dashboard)/workflows/actions", () => ({
+  updateTemplateAction: vi.fn(),
+}));
+
+vi.mock("@/components/dashboard-topbar-context", () => ({
+  useDashboardTopBar: () => ({
+    setConfig: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/analytics/events", () => ({
+  useAnalytics: () => ({
+    capture: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/events", () => ({
+  emitEvent: vi.fn(),
+}));
+
+const TEMPLATE: WorkflowTemplate = {
+  id: "client-delivery",
+  label: "Client Project Delivery",
+  color: "#6366f1",
+  multiInstance: true,
+  stages: [
+    { id: "pre-sales", label: "Pre-Sales", sub: "Customer" },
+    { id: "validation", label: "Validation", sub: "PDR" },
+  ],
+  roles: [
+    { id: "sales", label: "Sales", owner: "Hans / Dave", color: "#7dd3fc" },
+    { id: "product", label: "Product", owner: "Andres", color: "#f9a8d4" },
+  ],
+  taskTemplates: [],
+  createdAt: "2026-04-19T12:00:00Z",
+  updatedAt: "2026-04-19T12:00:00Z",
+};
+
+describe("TemplateEditorScreen", () => {
+  it("sizes insert-role rows to the role and stage columns only", () => {
+    render(
+      <TemplateEditorScreen
+        template={TEMPLATE}
+        skillOptions={[]}
+        playbookOptions={[]}
+      />,
+    );
+
+    expect(screen.getByTestId("matrix-insert-role-1")).toHaveStyle({
+      width: "562px",
+    });
+    expect(screen.getByTestId("matrix-insert-role-end")).toHaveStyle({
+      width: "562px",
+    });
+  });
+});

--- a/products/dashboard/__tests__/lib/workflows/repository.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/repository.test.ts
@@ -368,6 +368,61 @@ describe("workflow repository", () => {
     });
   });
 
+  describe("updateTemplate", () => {
+    it("updates template label, stages, roles, and task templates", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+
+      const updated = await repo.updateTemplate("client-delivery", {
+        label: "Client Delivery v2",
+        stages: [
+          { id: "pre-sales", label: "Pre-Sales", sub: "Qualification" },
+          { id: "delivery", label: "Delivery", sub: "Execution" },
+        ],
+        roles: [
+          { id: "sales", label: "Sales", owner: "Hans / Dave", color: "#6366f1" },
+          { id: "project", label: "Project Mgmt", owner: "Patrick", color: "#10b981" },
+        ],
+        taskTemplates: [
+          {
+            id: "tt-1",
+            role: "sales",
+            stage: "pre-sales",
+            title: "Updated discovery",
+            desc: "Fresh intake",
+            agent: "Sales Ops",
+            skill: "sales-ops",
+            playbook: "presales-qualification",
+          },
+        ],
+      });
+
+      expect(updated.label).toBe("Client Delivery v2");
+      expect(updated.stages[1]).toMatchObject({
+        id: "delivery",
+        label: "Delivery",
+        sub: "Execution",
+      });
+      expect(updated.roles[1]).toMatchObject({
+        id: "project",
+        owner: "Patrick",
+        color: "#10b981",
+      });
+      expect(updated.taskTemplates[0]).toMatchObject({
+        id: "tt-1",
+        title: "Updated discovery",
+        stage: "pre-sales",
+      });
+    });
+
+    it("throws when updateTemplate receives an empty patch", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+
+      await expect(repo.updateTemplate("client-delivery", {})).rejects.toThrow(
+        /empty patch/i,
+      );
+    });
+  });
+
   describe("getTask", () => {
     it("returns a single task mapped to camelCase shape", async () => {
       const repo = createWorkflowRepository(makeFakeClient(store));

--- a/products/dashboard/app/(dashboard)/api/events/route.ts
+++ b/products/dashboard/app/(dashboard)/api/events/route.ts
@@ -27,6 +27,7 @@ const ALLOWED_EVENTS = new Set([
   "workflow.task_started",
   "workflow.run_cancelled",
   "workflow.run_retried",
+  "workflow.template_edited",
 ]);
 
 const WORKFLOW_TASK_INSTANCE_EVENTS = new Set([
@@ -92,6 +93,13 @@ function sanitizePayload(
     const instance_id = clampString(payload.instance_id, 80);
     if (!task_id || !instance_id) return null;
     return { task_id, instance_id };
+  }
+
+  if (eventName === "workflow.template_edited") {
+    const template_id = clampString(payload.template_id, 120);
+    const edited_by = clampString(payload.edited_by, 120);
+    if (!template_id || !edited_by) return null;
+    return { template_id, edited_by };
   }
 
   return null;

--- a/products/dashboard/app/(dashboard)/layout.tsx
+++ b/products/dashboard/app/(dashboard)/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/service.server";
 import { Sidebar } from "@/components/sidebar";
+import { DashboardTopBarProvider } from "@/components/dashboard-topbar-context";
 import type { SidebarInstanceView } from "@/components/workflows/sidebar-workflow-tree";
 import { TopBar } from "@/components/top-bar";
 import { AuthIdentitySync } from "@/components/auth-identity-sync";
@@ -91,15 +92,17 @@ export default async function DashboardLayout({
   return (
     <>
       <AuthIdentitySync user={user} provider={user.provider} />
-      <Sidebar
-        user={user}
-        templates={templates}
-        instancesByTemplate={instancesByTemplate}
-      />
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        <TopBar initialPendingCount={pendingCount} />
-        <main className="min-h-0 flex-1 overflow-y-auto bg-bg">{children}</main>
-      </div>
+      <DashboardTopBarProvider>
+        <Sidebar
+          user={user}
+          templates={templates}
+          instancesByTemplate={instancesByTemplate}
+        />
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <TopBar initialPendingCount={pendingCount} />
+          <main className="min-h-0 flex-1 overflow-y-auto bg-bg">{children}</main>
+        </div>
+      </DashboardTopBarProvider>
     </>
   );
 }

--- a/products/dashboard/app/(dashboard)/workflows/[instanceId]/page.tsx
+++ b/products/dashboard/app/(dashboard)/workflows/[instanceId]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { ShellEvents } from "@/components/shell-events";
 import { ProcessMatrix } from "@/components/workflows/process-matrix";
+import { WorkflowInstanceHeader } from "@/components/workflows/workflow-instance-header";
 import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
 
 /**
@@ -57,21 +58,12 @@ export default async function WorkflowInstancePage({
       <ShellEvents route="/workflows/[instanceId]" />
 
       <div className="flex h-full flex-col overflow-hidden">
-        <header className="flex-shrink-0 border-b border-border bg-bg px-6 py-4">
-          <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
-            Workflow instance
-          </p>
-          <h1 className="mt-1 text-[20px] font-bold tracking-tight text-t1">
-            {instance.label}
-          </h1>
-          <p className="mt-1 text-[13px] text-t2">
-            {instance.tasks.length}{" "}
-            {instance.tasks.length === 1 ? "task" : "tasks"} ·{" "}
-            {instance.roles.length}{" "}
-            {instance.roles.length === 1 ? "role" : "roles"} · status{" "}
-            <span className="font-medium text-t1">{instance.status}</span>
-          </p>
-        </header>
+        <WorkflowInstanceHeader
+          instanceLabel={instance.label}
+          taskCount={instance.tasks.length}
+          roleCount={instance.roles.length}
+          stageCount={template?.stages.length ?? 0}
+        />
 
         <ProcessMatrix
           instance={instance}

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -13,6 +13,7 @@ import type {
   WorkflowInstance,
   WorkflowTask,
   WorkflowTaskCreateInput,
+  WorkflowTemplate,
   WorkflowTrigger,
 } from "@/lib/workflows/types";
 
@@ -608,4 +609,80 @@ export async function deleteTaskAction(taskId: string): Promise<void> {
   }
 
   revalidatePath("/", "layout");
+}
+
+function trimTemplateLabel(value: string): string {
+  return value.trim().slice(0, MAX_LABEL_LENGTH);
+}
+
+function normalizeTemplateStages(
+  stages: WorkflowTemplate["stages"],
+): WorkflowTemplate["stages"] {
+  return stages
+    .map((stage) => ({
+      id: normalizeTaskField(stage.id, "stage.id", 80),
+      label: trimTemplateLabel(stage.label),
+      sub: trimTemplateLabel(stage.sub ?? ""),
+    }))
+    .filter((stage) => stage.id && stage.label);
+}
+
+function normalizeTemplateRoles(
+  roles: WorkflowTemplate["roles"],
+): WorkflowTemplate["roles"] {
+  return roles
+    .map((role) => ({
+      id: normalizeTaskField(role.id, "role.id", 80),
+      label: trimTemplateLabel(role.label),
+      owner: trimTemplateLabel(role.owner ?? ""),
+      color: role.color?.trim() || undefined,
+    }))
+    .filter((role) => role.id && role.label);
+}
+
+function normalizeTemplateTaskTemplates(
+  taskTemplates: WorkflowTemplate["taskTemplates"],
+): WorkflowTemplate["taskTemplates"] {
+  return taskTemplates
+    .map((task) => ({
+      ...task,
+      id: normalizeTaskField(task.id ?? "", "taskTemplate.id", 120),
+      role: normalizeTaskField(task.role, "taskTemplate.role", 80),
+      stage: normalizeTaskField(task.stage, "taskTemplate.stage", 80),
+      title: trimTemplateLabel(task.title),
+      desc: trimTemplateLabel(task.desc ?? ""),
+      agent: trimTemplateLabel(task.agent ?? ""),
+      skill: trimTemplateLabel(task.skill ?? ""),
+      playbook: trimTemplateLabel(task.playbook ?? ""),
+      triggers: task.triggers ?? [],
+      gates: task.gates ?? [],
+      checkpoint: Boolean(task.checkpoint),
+    }))
+    .filter((task) => task.id && task.role && task.stage && task.title);
+}
+
+export async function updateTemplateAction(
+  templateId: string,
+  template: WorkflowTemplate,
+): Promise<{ template: WorkflowTemplate }> {
+  const trimmedTemplateId = normalizeTaskField(templateId, "templateId", 120);
+  if (!trimmedTemplateId) {
+    throw new Error("updateTemplateAction: templateId is required");
+  }
+  if (!template.label.trim()) {
+    throw new Error("updateTemplateAction: template label is required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const updatedTemplate = await repo.updateTemplate(trimmedTemplateId, {
+    label: trimTemplateLabel(template.label),
+    stages: normalizeTemplateStages(template.stages),
+    roles: normalizeTemplateRoles(template.roles),
+    taskTemplates: normalizeTemplateTaskTemplates(template.taskTemplates),
+  });
+
+  revalidatePath("/", "layout");
+  revalidatePath(`/workflows/templates/${trimmedTemplateId}/edit`);
+
+  return { template: updatedTemplate };
 }

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -65,6 +65,36 @@ export async function createInstanceAction(
   return { instance };
 }
 
+export async function renameInstanceAction(
+  instanceId: string,
+  rawLabel: string,
+): Promise<{ instance: WorkflowInstance }> {
+  const trimmedInstanceId = normalizeTaskField(instanceId, "instanceId", 80);
+  const label = normalizeTaskField(rawLabel, "label", MAX_LABEL_LENGTH);
+  if (!trimmedInstanceId || !label) {
+    throw new Error("renameInstanceAction: instanceId and label are required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const instance = await repo.updateInstance(trimmedInstanceId, { label });
+
+  revalidatePath("/", "layout");
+  revalidatePath(`/workflows/${trimmedInstanceId}`);
+  return { instance };
+}
+
+export async function deleteInstanceAction(instanceId: string): Promise<void> {
+  const trimmedInstanceId = normalizeTaskField(instanceId, "instanceId", 80);
+  if (!trimmedInstanceId) {
+    throw new Error("deleteInstanceAction: instanceId is required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  await repo.deleteInstance(trimmedInstanceId);
+
+  revalidatePath("/", "layout");
+}
+
 /**
  * Inline checkpoint resolution from the Overview "My Tasks" card.
  *
@@ -744,4 +774,34 @@ export async function updateTemplateAction(
   revalidatePath(`/workflows/templates/${trimmedTemplateId}/edit`);
 
   return { template: updatedTemplate };
+}
+
+export async function renameTemplateAction(
+  templateId: string,
+  rawLabel: string,
+): Promise<{ template: WorkflowTemplate }> {
+  const trimmedTemplateId = normalizeTaskField(templateId, "templateId", 120);
+  const label = normalizeTaskField(rawLabel, "label", MAX_LABEL_LENGTH);
+  if (!trimmedTemplateId || !label) {
+    throw new Error("renameTemplateAction: templateId and label are required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const template = await repo.updateTemplate(trimmedTemplateId, { label });
+
+  revalidatePath("/", "layout");
+  revalidatePath(`/workflows/templates/${trimmedTemplateId}/edit`);
+  return { template };
+}
+
+export async function deleteTemplateAction(templateId: string): Promise<void> {
+  const trimmedTemplateId = normalizeTaskField(templateId, "templateId", 120);
+  if (!trimmedTemplateId) {
+    throw new Error("deleteTemplateAction: templateId is required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  await repo.deleteTemplate(trimmedTemplateId);
+
+  revalidatePath("/", "layout");
 }

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -318,6 +318,15 @@ export interface CreateTaskResult {
   task: WorkflowTask;
 }
 
+export interface UpdateTaskDetailsInput {
+  taskId: string;
+  title: string;
+  description?: string;
+  agent?: string | null;
+  skill?: string | null;
+  playbook?: string | null;
+}
+
 export async function createTaskAction(
   input: WorkflowTaskCreateInput,
 ): Promise<CreateTaskResult> {
@@ -367,6 +376,56 @@ export async function createTaskAction(
   } catch (eventError) {
     captureError(eventError, {
       feature: "workflows.create_task",
+      action: "addEvent",
+      extra: { task_id: task.id, instance_id: task.instanceId },
+    });
+  }
+
+  revalidatePath("/", "layout");
+  return { task };
+}
+
+export async function updateTaskDetailsAction(
+  input: UpdateTaskDetailsInput,
+): Promise<{ task: WorkflowTask }> {
+  const taskId = normalizeTaskField(input.taskId, "taskId", 80);
+  const title = normalizeTaskField(input.title, "title", MAX_TASK_TITLE_LENGTH);
+  const description = normalizeTaskField(
+    input.description ?? "",
+    "description",
+    MAX_TASK_DESCRIPTION_LENGTH,
+  );
+  const playbook = normalizeTaskField(
+    input.playbook ?? "",
+    "playbook",
+    MAX_PLAYBOOK_LENGTH,
+  );
+
+  if (!taskId || !title) {
+    throw new Error("updateTaskDetailsAction: taskId and title are required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const task = await repo.updateTask(taskId, {
+    title,
+    description,
+    agent: input.agent ?? null,
+    skill: input.skill ?? null,
+    playbook: playbook || null,
+  });
+
+  try {
+    await repo.addEvent(task.id, {
+      name: "workflow.task_updated",
+      description: `Updated task: ${task.title}`,
+      payload: {
+        task_id: task.id,
+        instance_id: task.instanceId,
+      },
+    });
+  } catch (eventError) {
+    captureError(eventError, {
+      feature: "workflows.update_task_details",
       action: "addEvent",
       extra: { task_id: task.id, instance_id: task.instanceId },
     });

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -739,7 +739,11 @@ function normalizeTemplateTaskTemplates(
       role: normalizeTaskField(task.role, "taskTemplate.role", 80),
       stage: normalizeTaskField(task.stage, "taskTemplate.stage", 80),
       title: trimTemplateLabel(task.title),
-      desc: trimTemplateLabel(task.desc ?? ""),
+      desc: normalizeTaskField(
+        task.desc ?? "",
+        "taskTemplate.desc",
+        MAX_TASK_DESCRIPTION_LENGTH,
+      ),
       agent: trimTemplateLabel(task.agent ?? ""),
       skill: trimTemplateLabel(task.skill ?? ""),
       playbook: trimTemplateLabel(task.playbook ?? ""),

--- a/products/dashboard/app/(dashboard)/workflows/templates/[templateId]/edit/page.tsx
+++ b/products/dashboard/app/(dashboard)/workflows/templates/[templateId]/edit/page.tsx
@@ -15,10 +15,11 @@ export default async function WorkflowTemplateEditPage({
   const { templateId } = await params;
   const repo = await getServerWorkflowRepository();
 
-  const [template, skillOptions, playbookOptions] = await Promise.all([
+  const [template, skillOptions, playbookOptions, instances] = await Promise.all([
     repo.getTemplate(templateId),
     repo.getFrameworkItems("skill"),
     repo.getFrameworkItems("playbook"),
+    repo.listInstances(templateId),
   ]);
 
   if (!template) {
@@ -28,6 +29,7 @@ export default async function WorkflowTemplateEditPage({
   return (
     <TemplateEditorScreen
       template={template}
+      instanceCount={instances.length}
       skillOptions={skillOptions}
       playbookOptions={playbookOptions}
     />

--- a/products/dashboard/app/(dashboard)/workflows/templates/[templateId]/edit/page.tsx
+++ b/products/dashboard/app/(dashboard)/workflows/templates/[templateId]/edit/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from "next/navigation";
+
+import { TemplateEditorScreen } from "@/components/workflows/template-editor-screen";
+import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
+
+interface Params {
+  templateId: string;
+}
+
+export default async function WorkflowTemplateEditPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { templateId } = await params;
+  const repo = await getServerWorkflowRepository();
+
+  const [template, skillOptions, playbookOptions] = await Promise.all([
+    repo.getTemplate(templateId),
+    repo.getFrameworkItems("skill"),
+    repo.getFrameworkItems("playbook"),
+  ]);
+
+  if (!template) {
+    notFound();
+  }
+
+  return (
+    <TemplateEditorScreen
+      template={template}
+      skillOptions={skillOptions}
+      playbookOptions={playbookOptions}
+    />
+  );
+}

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -388,6 +388,40 @@ body {
 .mx-role-owner-plain {
   font-style: normal;
 }
+.mx-entity-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.mx-entity-action {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-3);
+  color: var(--t3);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition:
+    background 0.14s,
+    border-color 0.14s,
+    color 0.14s,
+    transform 0.14s;
+}
+.mx-entity-action:hover {
+  background: var(--bg-4);
+  border-color: var(--border-hi);
+  color: var(--t1);
+  transform: translateY(-1px);
+}
+.mx-entity-action-danger:hover {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.28);
+  color: #f87171;
+}
 .mx-task-cell {
   width: 192px;
   flex-shrink: 0;
@@ -470,6 +504,104 @@ body {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+.mx-col-insert {
+  width: 6px;
+  flex-shrink: 0;
+  border: none;
+  cursor: pointer;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: var(--accent);
+  transition:
+    width 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    background 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.mx-col-insert:hover,
+.mx-col-insert.mx-col-insert-active {
+  width: 34px;
+  background: var(--primary-bg);
+}
+.mx-col-insert-icon {
+  opacity: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  white-space: nowrap;
+  transition:
+    opacity 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+  transform: translateX(-4px);
+}
+.mx-col-insert:hover .mx-col-insert-icon,
+.mx-col-insert.mx-col-insert-active .mx-col-insert-icon {
+  opacity: 1;
+  transform: translateX(0);
+}
+.mx-col-insert-body {
+  width: 6px;
+  flex-shrink: 0;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+  transition:
+    width 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    background 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.mx-col-insert-body:hover,
+.mx-col-insert-body.mx-col-insert-active {
+  width: 34px;
+  background: var(--primary-bg);
+}
+.mx-row-insert {
+  height: 8px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+  background: transparent;
+  position: relative;
+  z-index: 2;
+  transition:
+    height 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    margin 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    background 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.mx-row-insert:hover {
+  height: 28px;
+  margin-top: 0;
+  margin-bottom: 0;
+  background: var(--primary-bg);
+}
+.mx-row-insert-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  height: 100%;
+  font-size: 11px;
+  color: var(--accent);
+  opacity: 0;
+  transform: translateY(4px);
+  transition:
+    opacity 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.mx-row-insert:hover .mx-row-insert-label {
+  opacity: 1;
+  transform: translateY(0);
+}
 
 /* ── Task card ── */
 .task-card {
@@ -521,6 +653,16 @@ body {
 /* DB `blocked` / UI "failed" — keep role accent, not error red */
 .task-card.bar-cancelled::before {
   opacity: 0.4;
+}
+.task-card.task-card-default::before {
+  opacity: 0.14;
+  box-shadow: none;
+}
+.task-card.task-card-default {
+  opacity: 1;
+}
+.task-card.task-card-default:hover {
+  background: var(--bg-3);
 }
 @keyframes ainative-bar-pulse {
   0%,

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -311,6 +311,7 @@ body {
   width: 192px;
   flex-shrink: 0;
   padding: 10px 14px;
+  position: relative;
   border-right: 1px solid var(--border-2);
 }
 .mx-stage-hd:last-child {
@@ -368,6 +369,17 @@ body {
   min-height: 106px;
   transition: width 0.2s;
 }
+.mx-entity-content {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.mx-stage-hd .mx-entity-content {
+  align-items: center;
+}
 .matrix-wrap.roles-collapsed .mx-role-cell {
   width: 44px;
   padding: 10px 7px;
@@ -394,12 +406,31 @@ body {
   gap: 6px;
   flex-shrink: 0;
 }
+.mx-entity-actions-group {
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--bg-3);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  transition:
+    border-color 0.14s,
+    box-shadow 0.14s,
+    background 0.14s;
+}
+.mx-entity-actions-group:hover {
+  border-color: var(--border-hi);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 0 0 1px rgba(129, 140, 248, 0.06),
+    0 6px 14px rgba(15, 23, 42, 0.08);
+}
 .mx-entity-action {
   width: 22px;
   height: 22px;
-  border-radius: 6px;
-  border: 1px solid var(--border);
-  background: var(--bg-3);
+  border-radius: 0;
+  border: 0;
+  background: transparent;
   color: var(--t3);
   display: inline-flex;
   align-items: center;
@@ -411,16 +442,24 @@ body {
     color 0.14s,
     transform 0.14s;
 }
+.mx-entity-actions-group .mx-entity-action + .mx-entity-action {
+  border-left: 1px solid var(--border);
+}
 .mx-entity-action:hover {
   background: var(--bg-4);
-  border-color: var(--border-hi);
   color: var(--t1);
-  transform: translateY(-1px);
+  transform: none;
+}
+.mx-entity-action-danger {
+  color: #fca5a5;
 }
 .mx-entity-action-danger:hover {
-  background: rgba(239, 68, 68, 0.12);
-  border-color: rgba(239, 68, 68, 0.28);
-  color: #f87171;
+  background: linear-gradient(180deg, #ef4444, #dc2626);
+  color: #fff7f7;
+}
+.mx-entity-action-danger:focus-visible {
+  outline: 2px solid rgba(248, 113, 113, 0.85);
+  outline-offset: 2px;
 }
 .mx-task-cell {
   width: 192px;
@@ -447,62 +486,61 @@ body {
   border-radius: 7px;
   border: 1px dashed transparent;
   transition:
-    background 0.14s,
-    border-color 0.14s,
-    box-shadow 0.14s;
+    background 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .mx-task-cell:hover .mx-empty-cell {
   background: var(--bg-2);
   border-color: var(--border-hi);
+  box-shadow: inset 0 0 0 1px rgba(129, 140, 248, 0.05);
 }
 .mx-add-btn {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  min-height: 92px;
-  font-size: 0;
-  border: none;
-  border-radius: 7px;
-  background: transparent;
+  width: 32px;
+  height: 32px;
+  min-height: 32px;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  background: rgba(129, 140, 248, 0.04);
   color: var(--t3);
-  cursor: pointer;
   opacity: 0;
-  transition:
-    opacity 0.14s,
-    color 0.14s,
-    transform 0.14s;
-}
-.mx-add-btn::after {
-  content: "+";
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: 20px;
-  height: 20px;
-  margin-left: -10px;
-  margin-top: -10px;
-  color: inherit;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 20px;
-  font-weight: 300;
-  line-height: 1;
+  flex-shrink: 0;
+  padding: 0;
+  cursor: pointer;
+  transition:
+    opacity 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    color 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    background 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+  transform: translateY(6px) scale(0.92);
 }
 .mx-task-cell:hover .mx-add-btn {
   opacity: 1;
+  transform: translateY(0) scale(1);
 }
 .mx-add-btn:hover {
+  background: rgba(129, 140, 248, 0.1);
+  border-color: rgba(129, 140, 248, 0.16);
   color: var(--accent);
-  transform: translateY(-1px);
-}
-.mx-add-btn:hover::after {
-  color: var(--accent);
+  box-shadow:
+    0 0 0 1px rgba(129, 140, 248, 0.08),
+    0 8px 18px rgba(99, 102, 241, 0.08);
 }
 .mx-add-btn:focus-visible {
   opacity: 1;
+  background: rgba(129, 140, 248, 0.1);
+  border-color: rgba(129, 140, 248, 0.2);
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+  transform: translateY(0) scale(1);
+}
+.mx-add-btn svg {
+  flex-shrink: 0;
 }
 .mx-col-insert {
   width: 6px;
@@ -694,7 +732,6 @@ body {
   display: flex;
   align-items: flex-start;
   gap: 5px;
-  padding-right: 24px;
 }
 .tc-title {
   font-size: 11.5px;
@@ -801,44 +838,6 @@ body {
   flex-shrink: 0;
   box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.15);
 }
-.tc-remove {
-  position: absolute;
-  top: 7px;
-  right: 7px;
-  width: 18px;
-  height: 18px;
-  border-radius: 5px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(7, 13, 26, 0.72);
-  backdrop-filter: blur(6px);
-  color: var(--t3);
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 2;
-  opacity: 0.92;
-  padding: 0;
-  transition:
-    opacity 0.14s,
-    background 0.14s,
-    border-color 0.14s,
-    color 0.14s;
-}
-.tc-remove:hover {
-  background: rgba(239, 68, 68, 0.12);
-  border-color: rgba(239, 68, 68, 0.3);
-  color: #f87171;
-  opacity: 1;
-}
-.tc-remove:focus-visible {
-  outline: 2px solid #f87171;
-  outline-offset: 1px;
-}
-
 /*
  * Task Drawer.
  *

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -564,21 +564,40 @@ body {
   background: var(--primary-bg);
 }
 .mx-col-insert-icon {
-  opacity: 0;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  font-size: 10px;
-  white-space: nowrap;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  background: transparent;
+  color: var(--t3);
+  opacity: 0;
   transition:
-    opacity 0.18s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 0.18s cubic-bezier(0.16, 1, 0.3, 1);
-  transform: translateX(-4px);
+    opacity 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    color 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    background 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+  transform: scale(0.9);
 }
 .mx-col-insert:hover .mx-col-insert-icon,
 .mx-col-insert.mx-col-insert-active .mx-col-insert-icon {
   opacity: 1;
-  transform: translateX(0);
+  transform: scale(1);
+  background: rgba(129, 140, 248, 0.1);
+  border-color: rgba(129, 140, 248, 0.16);
+  color: var(--accent);
+  box-shadow:
+    0 0 0 1px rgba(129, 140, 248, 0.08),
+    0 8px 18px rgba(99, 102, 241, 0.08);
+}
+.mx-col-insert-icon svg {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
 }
 .mx-col-insert-body {
   width: 6px;
@@ -616,7 +635,7 @@ body {
     background 0.18s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .mx-row-insert:hover {
-  height: 28px;
+  height: 24px;
   margin-top: 0;
   margin-bottom: 0;
   background: var(--primary-bg);
@@ -625,20 +644,53 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  width: 100%;
-  height: 100%;
-  font-size: 11px;
-  color: var(--accent);
+  position: absolute;
+  left: calc((172px - 18px) / 2);
+  top: 50%;
+  width: 18px;
+  height: 18px;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  background: transparent;
+  color: var(--t3);
   opacity: 0;
-  transform: translateY(4px);
+  flex-shrink: 0;
+  pointer-events: none;
   transition:
-    opacity 0.18s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+    opacity 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    color 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    background 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+  transform: translateY(-50%) scale(0.9);
 }
 .mx-row-insert:hover .mx-row-insert-label {
   opacity: 1;
-  transform: translateY(0);
+  transform: translateY(-50%) scale(1);
+}
+.mx-row-insert:hover .mx-row-insert-label,
+.mx-row-insert:focus-visible .mx-row-insert-label {
+  background: rgba(129, 140, 248, 0.1);
+  border-color: rgba(129, 140, 248, 0.16);
+  color: var(--accent);
+  box-shadow:
+    0 0 0 1px rgba(129, 140, 248, 0.08),
+    0 8px 18px rgba(99, 102, 241, 0.08);
+}
+.mx-row-insert-label svg {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+}
+.mx-row-insert:focus-visible {
+  outline: none;
+}
+.mx-row-insert:focus-visible .mx-row-insert-label {
+  opacity: 1;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  transform: translateY(-50%) scale(1);
 }
 
 /* ── Task card ── */

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -527,6 +527,10 @@ body {
   opacity: 1;
   transform: translateY(0) scale(1);
 }
+.mx-task-cell:focus-within .mx-add-btn {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
 .mx-add-btn:hover {
   background: rgba(129, 140, 248, 0.1);
   border-color: rgba(129, 140, 248, 0.16);
@@ -563,7 +567,8 @@ body {
     opacity 0.18s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .mx-col-insert:hover,
-.mx-col-insert.mx-col-insert-active {
+.mx-col-insert.mx-col-insert-active,
+.mx-col-insert:focus-visible {
   width: 34px;
   background: var(--primary-bg);
 }
@@ -588,7 +593,8 @@ body {
   transform: scale(0.9);
 }
 .mx-col-insert:hover .mx-col-insert-icon,
-.mx-col-insert.mx-col-insert-active .mx-col-insert-icon {
+.mx-col-insert.mx-col-insert-active .mx-col-insert-icon,
+.mx-col-insert:focus-visible .mx-col-insert-icon {
   opacity: 1;
   transform: scale(1);
   background: rgba(129, 140, 248, 0.1);
@@ -598,10 +604,36 @@ body {
     0 0 0 1px rgba(129, 140, 248, 0.08),
     0 8px 18px rgba(99, 102, 241, 0.08);
 }
+.mx-col-insert:focus-visible {
+  outline: none;
+}
+.mx-col-insert:focus-visible .mx-col-insert-icon {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .mx-col-insert-icon svg {
   width: 10px;
   height: 10px;
   flex-shrink: 0;
+}
+.mx-col-insert-empty {
+  width: 192px;
+  gap: 8px;
+  justify-content: center;
+}
+.mx-col-insert-empty .mx-col-insert-icon,
+.mx-col-insert-empty:hover .mx-col-insert-icon,
+.mx-col-insert-empty:focus-visible .mx-col-insert-icon {
+  opacity: 1;
+  transform: scale(1);
+  background: rgba(129, 140, 248, 0.1);
+  border-color: rgba(129, 140, 248, 0.16);
+  color: var(--accent);
+}
+.mx-col-insert-label-text {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--t2);
 }
 .mx-col-insert-body {
   width: 6px;
@@ -615,9 +647,23 @@ body {
     background 0.18s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .mx-col-insert-body:hover,
-.mx-col-insert-body.mx-col-insert-active {
+.mx-col-insert-body.mx-col-insert-active,
+.mx-col-insert-body:focus-visible {
   width: 34px;
   background: var(--primary-bg);
+}
+@media (pointer: coarse) {
+  .mx-add-btn,
+  .mx-col-insert-icon {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  .mx-col-insert,
+  .mx-col-insert-body {
+    width: 34px;
+    background: var(--primary-bg);
+  }
 }
 .mx-row-insert {
   height: 8px;

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -369,6 +369,10 @@ body {
   min-height: 106px;
   transition: width 0.2s;
 }
+.mx-role-cell:has([data-role-color-open="true"]) {
+  z-index: 25;
+  overflow: visible;
+}
 .mx-entity-content {
   min-width: 0;
   flex: 1;

--- a/products/dashboard/components/dashboard-topbar-context.tsx
+++ b/products/dashboard/components/dashboard-topbar-context.tsx
@@ -10,13 +10,24 @@ import {
 
 interface TemplateEditorTopBarConfig {
   mode: "template-editor";
+  crumbs: string[];
   label: string;
   onLabelChange: (value: string) => void;
   onSave: () => void;
   saveDisabled: boolean;
+  actions?: ReactNode;
 }
 
-type TopBarConfig = TemplateEditorTopBarConfig | null;
+interface WorkflowInstanceTopBarConfig {
+  mode: "workflow-instance";
+  crumbs: string[];
+  actions?: ReactNode;
+}
+
+type TopBarConfig =
+  | TemplateEditorTopBarConfig
+  | WorkflowInstanceTopBarConfig
+  | null;
 
 interface DashboardTopBarContextValue {
   config: TopBarConfig;

--- a/products/dashboard/components/dashboard-topbar-context.tsx
+++ b/products/dashboard/components/dashboard-topbar-context.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface TemplateEditorTopBarConfig {
+  mode: "template-editor";
+  label: string;
+  onLabelChange: (value: string) => void;
+  onSave: () => void;
+  saveDisabled: boolean;
+}
+
+type TopBarConfig = TemplateEditorTopBarConfig | null;
+
+interface DashboardTopBarContextValue {
+  config: TopBarConfig;
+  setConfig: (config: TopBarConfig) => void;
+}
+
+const DashboardTopBarContext = createContext<DashboardTopBarContextValue | null>(null);
+
+export function DashboardTopBarProvider({ children }: { children: ReactNode }) {
+  const [config, setConfig] = useState<TopBarConfig>(null);
+
+  const value = useMemo(() => ({ config, setConfig }), [config]);
+
+  return (
+    <DashboardTopBarContext.Provider value={value}>
+      {children}
+    </DashboardTopBarContext.Provider>
+  );
+}
+
+export function useDashboardTopBar() {
+  const context = useContext(DashboardTopBarContext);
+  if (!context) {
+    throw new Error("useDashboardTopBar must be used inside DashboardTopBarProvider");
+  }
+  return context;
+}

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Bell, Pencil } from "lucide-react";
 
+import { useDashboardTopBar } from "@/components/dashboard-topbar-context";
 import { CheckpointPanel } from "@/components/workflows/checkpoint-panel";
 import { cn } from "@/lib/utils";
 
@@ -19,6 +20,7 @@ import { cn } from "@/lib/utils";
  */
 
 const WORKFLOW_INSTANCE_ROUTE_REGEX = /^\/workflows\/(?!templates(?:\/|$))[^/]+\/?$/;
+const WORKFLOW_TEMPLATE_EDIT_ROUTE_REGEX = /^\/workflows\/templates\/[^/]+\/edit\/?$/;
 
 const ROUTE_LABELS: ReadonlyArray<{ test: (path: string) => boolean; crumbs: string[] }> = [
   { test: (p) => p === "/", crumbs: ["Overview"] },
@@ -29,6 +31,10 @@ const ROUTE_LABELS: ReadonlyArray<{ test: (path: string) => boolean; crumbs: str
   {
     test: (p) => WORKFLOW_INSTANCE_ROUTE_REGEX.test(p),
     crumbs: ["Workflows", "Instance"],
+  },
+  {
+    test: (p) => WORKFLOW_TEMPLATE_EDIT_ROUTE_REGEX.test(p),
+    crumbs: ["Workflows", "Template editor"],
   },
 ];
 
@@ -50,6 +56,7 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { config } = useDashboardTopBar();
   const crumbs = deriveCrumbs(pathname);
   const isWorkflowInstanceRoute =
     !!pathname && WORKFLOW_INSTANCE_ROUTE_REGEX.test(pathname);
@@ -84,22 +91,42 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
             return (
               <span key={`${crumb}-${idx}`} className="flex items-center gap-1.5">
                 {idx > 0 && <span className="text-t3">›</span>}
-                <span
-                  className={
-                    isLast
-                      ? "truncate text-[13px] font-semibold text-t1"
-                      : "truncate text-[13px] font-medium text-t2"
-                  }
-                  aria-current={isLast ? "page" : undefined}
-                >
-                  {crumb}
-                </span>
+                {isLast && config?.mode === "template-editor" ? (
+                  <input
+                    value={config.label}
+                    onChange={(event) => config.onLabelChange(event.target.value)}
+                    className="tb-crumb-editable min-w-[140px]"
+                    aria-label="Workflow template name"
+                  />
+                ) : (
+                  <span
+                    className={
+                      isLast
+                        ? "truncate text-[13px] font-semibold text-t1"
+                        : "truncate text-[13px] font-medium text-t2"
+                    }
+                    aria-current={isLast ? "page" : undefined}
+                  >
+                    {crumb}
+                  </span>
+                )}
               </span>
             );
           })}
         </nav>
 
         <div className="flex shrink-0 items-center gap-1.5">
+          {config?.mode === "template-editor" ? (
+            <button
+              type="button"
+              onClick={config.onSave}
+              disabled={config.saveDisabled}
+              className="flex items-center gap-1.5 rounded-md border border-[#10b981] bg-[rgba(16,185,129,0.12)] px-2.5 py-1.5 text-[11.5px] font-semibold text-[#34d399] transition hover:bg-[rgba(16,185,129,0.18)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              ✓ Save workflow
+            </button>
+          ) : null}
+
           {isWorkflowInstanceRoute ? (
             <button
               type="button"
@@ -117,32 +144,34 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
             </button>
           ) : null}
 
-          <button
-            type="button"
-            aria-label={`My Tasks${hasPending ? ` — ${pendingCount} pending` : ""}`}
-            aria-expanded={panelOpen}
-            onClick={() => setPanelOpen((v) => !v)}
-            data-testid="topbar-my-tasks-btn"
-            className={cn(
-              "relative flex cursor-pointer items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[11.5px] font-medium transition",
-              "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
-              hasPending
-                ? "border-[rgba(245,158,11,0.35)] bg-[rgba(245,158,11,0.08)] text-[#fbbf24] hover:bg-[rgba(245,158,11,0.14)]"
-                : "border-border bg-bg-2 text-t2 hover:border-border-hi hover:bg-bg-3 hover:text-t1",
-            )}
-          >
-            <Bell className="h-3.5 w-3.5" />
-            My Tasks
-            {hasPending && (
-              <span
-                className="flex h-4 min-w-4 items-center justify-center rounded-full bg-[#f59e0b] px-1 font-mono text-[9px] font-bold text-white"
-                aria-hidden
-                data-testid="topbar-pending-badge"
-              >
-                {pendingCount}
-              </span>
-            )}
-          </button>
+          {config?.mode !== "template-editor" ? (
+            <button
+              type="button"
+              aria-label={`My Tasks${hasPending ? ` — ${pendingCount} pending` : ""}`}
+              aria-expanded={panelOpen}
+              onClick={() => setPanelOpen((v) => !v)}
+              data-testid="topbar-my-tasks-btn"
+              className={cn(
+                "relative flex cursor-pointer items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[11.5px] font-medium transition",
+                "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+                hasPending
+                  ? "border-[rgba(245,158,11,0.35)] bg-[rgba(245,158,11,0.08)] text-[#fbbf24] hover:bg-[rgba(245,158,11,0.14)]"
+                  : "border-border bg-bg-2 text-t2 hover:border-border-hi hover:bg-bg-3 hover:text-t1",
+              )}
+            >
+              <Bell className="h-3.5 w-3.5" />
+              My Tasks
+              {hasPending && (
+                <span
+                  className="flex h-4 min-w-4 items-center justify-center rounded-full bg-[#f59e0b] px-1 font-mono text-[9px] font-bold text-white"
+                  aria-hidden
+                  data-testid="topbar-pending-badge"
+                >
+                  {pendingCount}
+                </span>
+              )}
+            </button>
+          ) : null}
         </div>
       </header>
 

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Bell, Pencil } from "lucide-react";
 
@@ -64,6 +64,13 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
 
   const [panelOpen, setPanelOpen] = useState(false);
   const [pendingCount, setPendingCount] = useState(initialPendingCount);
+  const [templateLabelDraft, setTemplateLabelDraft] = useState("");
+
+  useEffect(() => {
+    if (config?.mode === "template-editor") {
+      setTemplateLabelDraft(config.label);
+    }
+  }, [config]);
 
   function toggleEditMode() {
     if (!pathname) return;
@@ -93,8 +100,23 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
                 {idx > 0 && <span className="text-t3">›</span>}
                 {isLast && config?.mode === "template-editor" ? (
                   <input
-                    value={config.label}
-                    onChange={(event) => config.onLabelChange(event.target.value)}
+                    value={templateLabelDraft}
+                    onChange={(event) => {
+                      const nextValue = event.target.value;
+                      setTemplateLabelDraft(nextValue);
+                      config.onLabelChange(nextValue);
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        void config.onSave();
+                      }
+                      if (event.key === "Escape") {
+                        event.preventDefault();
+                        setTemplateLabelDraft(config.label);
+                        config.onLabelChange(config.label);
+                      }
+                    }}
                     className="min-w-[140px] bg-transparent p-0 text-[13px] font-semibold text-t1 outline-none placeholder:text-t3"
                     aria-label="Workflow template name"
                   />

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -121,9 +121,21 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
               type="button"
               onClick={config.onSave}
               disabled={config.saveDisabled}
-              className="flex items-center gap-1.5 rounded-md border border-[#10b981] bg-[rgba(16,185,129,0.12)] px-2.5 py-1.5 text-[11.5px] font-semibold text-[#34d399] transition hover:bg-[rgba(16,185,129,0.18)] disabled:cursor-not-allowed disabled:opacity-50"
+              className={cn(
+                "flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11.5px] font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+                config.saveDisabled
+                  ? "cursor-not-allowed border border-border bg-bg-2 text-t3 opacity-70"
+                  : "border border-[#10b981] bg-[#10b981] text-white shadow-[0_0_0_1px_rgba(16,185,129,0.16),0_8px_22px_rgba(16,185,129,0.24)] hover:bg-[#22c55e]",
+              )}
             >
-              ✓ Save workflow
+              <span
+                aria-hidden
+                className={cn(
+                  "h-1.5 w-1.5 rounded-full",
+                  config.saveDisabled ? "bg-t3" : "bg-white shadow-[0_0_10px_rgba(255,255,255,0.7)]",
+                )}
+              />
+              Save
             </button>
           ) : null}
 

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -57,7 +57,7 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { config } = useDashboardTopBar();
-  const crumbs = deriveCrumbs(pathname);
+  const crumbs = config?.crumbs ?? deriveCrumbs(pathname);
   const isWorkflowInstanceRoute =
     !!pathname && WORKFLOW_INSTANCE_ROUTE_REGEX.test(pathname);
   const editMode = searchParams.get("edit") === "1";
@@ -95,7 +95,7 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
                   <input
                     value={config.label}
                     onChange={(event) => config.onLabelChange(event.target.value)}
-                    className="tb-crumb-editable min-w-[140px]"
+                    className="min-w-[140px] bg-transparent p-0 text-[13px] font-semibold text-t1 outline-none placeholder:text-t3"
                     aria-label="Workflow template name"
                   />
                 ) : (
@@ -116,6 +116,8 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
         </nav>
 
         <div className="flex shrink-0 items-center gap-1.5">
+          {config?.actions ?? null}
+
           {config?.mode === "template-editor" ? (
             <button
               type="button"
@@ -144,7 +146,7 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
               type="button"
               aria-pressed={editMode}
               onClick={toggleEditMode}
-              title={editMode ? "Finish editing tasks" : "Edit workflow tasks"}
+              title={editMode ? "Save workflow changes" : "Edit workflow tasks"}
               className={
                 editMode
                   ? "flex cursor-pointer items-center gap-1.5 rounded-md border border-primary bg-primary-bg px-2.5 py-1.5 text-[11.5px] font-medium text-accent shadow-[inset_0_0_0_1px_rgba(99,102,241,0.08)] transition hover:bg-[rgba(99,102,241,0.16)] hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
@@ -152,7 +154,7 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
               }
             >
               <Pencil className="h-3.5 w-3.5" />
-              {editMode ? "Done" : "Edit"}
+              {editMode ? "Save" : "Edit"}
             </button>
           ) : null}
 

--- a/products/dashboard/components/ui/confirm-modal.tsx
+++ b/products/dashboard/components/ui/confirm-modal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useEffect, useId, useRef } from "react";
 
 interface ConfirmModalProps {
   title: string;
-  description: string;
+  description: ReactNode;
   confirmLabel?: string;
   onConfirm: () => void;
   onCancel: () => void;

--- a/products/dashboard/components/ui/text-input-modal.tsx
+++ b/products/dashboard/components/ui/text-input-modal.tsx
@@ -3,6 +3,14 @@
 import type { ReactNode } from "react";
 import { useEffect, useId, useRef, useState } from "react";
 
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  );
+}
+
 interface TextInputModalProps {
   title: string;
   description?: ReactNode;
@@ -27,6 +35,7 @@ export function TextInputModal({
   const titleId = useId();
   const descriptionId = useId();
   const inputId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const [value, setValue] = useState(initialValue);
@@ -41,6 +50,28 @@ export function TextInputModal({
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         onClose();
+        return;
+      }
+
+      if (event.key !== "Tab" || !dialogRef.current) {
+        return;
+      }
+
+      const focusable = getFocusableElements(dialogRef.current);
+      if (focusable.length === 0) {
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
       }
     }
 
@@ -62,6 +93,7 @@ export function TextInputModal({
       }}
     >
       <div
+        ref={dialogRef}
         className="w-full max-w-[420px] rounded-[14px] border border-border-hi bg-bg-2 p-7 shadow-[var(--shadow-canvas)]"
         role="dialog"
         aria-modal="true"

--- a/products/dashboard/components/ui/text-input-modal.tsx
+++ b/products/dashboard/components/ui/text-input-modal.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect, useId, useRef, useState } from "react";
+
+interface TextInputModalProps {
+  title: string;
+  description?: ReactNode;
+  label: string;
+  initialValue: string;
+  submitLabel?: string;
+  isValid?: (value: string) => boolean;
+  onSubmit: (value: string) => void | Promise<void>;
+  onClose: () => void;
+}
+
+export function TextInputModal({
+  title,
+  description,
+  label,
+  initialValue,
+  submitLabel = "Save",
+  isValid,
+  onSubmit,
+  onClose,
+}: TextInputModalProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const [value, setValue] = useState(initialValue);
+  const canSubmit = isValid ? isValid(value) : Boolean(value.trim());
+
+  useEffect(() => {
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    inputRef.current?.focus();
+    inputRef.current?.select();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      previousFocusRef.current?.focus();
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-(--overlay) p-4 backdrop-blur-[3px]"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        className="w-full max-w-[420px] rounded-[14px] border border-border-hi bg-bg-2 p-7 shadow-[var(--shadow-canvas)]"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={description ? descriptionId : undefined}
+      >
+        <div id={titleId} className="text-[16px] font-bold tracking-tight text-t1">
+          {title}
+        </div>
+        {description ? (
+          <div id={descriptionId} className="mt-1 text-[12.5px] leading-[1.6] text-t3">
+            {description}
+          </div>
+        ) : null}
+        <label htmlFor={inputId} className="mb-1.5 mt-4 block text-[11px] font-medium text-t2">
+          {label}
+        </label>
+        <input
+          id={inputId}
+          ref={inputRef}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          className="block w-full rounded-lg border border-border bg-bg-3 px-3 py-2.5 text-[13px] text-t1 placeholder:text-t3 focus:border-primary focus:outline-none"
+        />
+        <div className="mt-6 flex justify-end gap-2">
+          <button
+            type="button"
+            className="rounded-lg border border-border bg-bg-3 px-4 py-2 text-[13px] font-medium text-t2 transition hover:bg-bg-4 hover:text-t1"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (!canSubmit) return;
+              void onSubmit(value);
+            }}
+            disabled={!canSubmit}
+            className="rounded-lg bg-primary px-5 py-2 text-[13px] font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/products/dashboard/components/workflows/add-role-modal.tsx
+++ b/products/dashboard/components/workflows/add-role-modal.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type { WorkflowRole } from "@/lib/workflows/types";
+import { cn } from "@/lib/utils";
+
+const AVAILABLE_ROLES = [
+  { label: "Sales", owner: "Assign owner", skill: "sales-ops", icon: "🤝" },
+  { label: "Product", owner: "Assign owner", skill: "pm", icon: "📋" },
+  { label: "Project Mgmt", owner: "Assign owner", skill: "project", icon: "🗂️" },
+  { label: "Development", owner: "Assign owner", skill: "builder", icon: "⚡" },
+  { label: "Infra / DevOps", owner: "Assign owner", skill: "devops", icon: "🔧" },
+  { label: "Finance", owner: "Assign owner", skill: "finance-ops", icon: "💰" },
+  { label: "Design", owner: "Assign owner", skill: "designer", icon: "🎨" },
+  { label: "Quality", owner: "Assign owner", skill: "qa", icon: "✅" },
+  { label: "Support", owner: "Assign owner", skill: "support", icon: "🎧" },
+  { label: "Growth", owner: "Assign owner", skill: "growth", icon: "📈" },
+  { label: "Research", owner: "Assign owner", skill: "researcher", icon: "🔍" },
+  { label: "Strategy", owner: "Assign owner", skill: "strategist", icon: "🧭" },
+] as const;
+
+interface AddRoleModalProps {
+  mode?: "create" | "edit";
+  initialRole?: Pick<WorkflowRole, "label" | "owner">;
+  onClose: () => void;
+  onSubmit: (role: Pick<WorkflowRole, "label" | "owner">) => void;
+}
+
+export function AddRoleModal({
+  mode = "create",
+  initialRole,
+  onClose,
+  onSubmit,
+}: AddRoleModalProps) {
+  const initialPreset = useMemo(
+    () => AVAILABLE_ROLES.find((role) => role.label === initialRole?.label),
+    [initialRole?.label],
+  );
+  const [selectedLabel, setSelectedLabel] = useState<string>(initialRole?.label ?? "");
+  const [customRole, setCustomRole] = useState(initialPreset ? "" : initialRole?.label ?? "");
+  const [owner, setOwner] = useState(initialRole?.owner ?? "");
+
+  const selectedPreset = AVAILABLE_ROLES.find((role) => role.label === selectedLabel);
+  const usingCustom =
+    (!selectedPreset && Boolean(initialRole?.label)) || Boolean(customRole.trim());
+
+  const roleName = usingCustom
+    ? customRole.trim() || initialRole?.label?.trim() || ""
+    : selectedPreset?.label || "";
+  const canSubmit = roleName.length > 0;
+
+  return (
+    <div
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-(--overlay) p-4 backdrop-blur-[3px]"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        className="w-full max-w-[500px] rounded-[14px] border border-border-hi bg-bg-2 p-7 shadow-[var(--shadow-canvas)]"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-role-modal-title"
+      >
+        <div id="add-role-modal-title" className="text-[16px] font-bold tracking-tight text-t1">
+          {mode === "edit" ? "Edit role" : "Add role"}
+        </div>
+        <div className="mb-4 mt-1 text-[12.5px] text-t3">
+          Choose from pre-defined roles or define a custom one.
+        </div>
+
+        <div className="mb-4 grid max-h-[220px] grid-cols-1 gap-2 overflow-y-auto md:grid-cols-3">
+          {AVAILABLE_ROLES.map((role) => {
+            const selected = role.label === selectedLabel && !usingCustom;
+            return (
+              <button
+                key={role.label}
+                type="button"
+                onClick={() => {
+                  setSelectedLabel(role.label);
+                  setCustomRole("");
+                  if (!owner.trim() && mode === "create") {
+                    setOwner(role.owner);
+                  }
+                }}
+                className={cn(
+                  "flex items-center gap-2 rounded-lg border px-3 py-2 text-left transition",
+                  selected
+                    ? "border-primary bg-primary-bg text-accent"
+                    : "border-border bg-bg-3 text-t2 hover:bg-bg-4 hover:text-t1",
+                )}
+              >
+                <span className="text-[16px]">{role.icon}</span>
+                <span className="min-w-0">
+                  <span className="block truncate text-[12px] font-semibold">
+                    {role.label}
+                  </span>
+                  <span className="block truncate font-mono text-[10px] text-t3">
+                    {role.skill}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <label className="mb-1.5 block text-[11px] font-medium text-t2">
+          Or custom role
+        </label>
+        <input
+          value={customRole}
+          onChange={(event) => {
+            setCustomRole(event.target.value);
+            setSelectedLabel("");
+          }}
+          placeholder="Custom role name"
+          className="mb-3 block w-full rounded-lg border border-border bg-bg-3 px-3 py-2.5 text-[13px] text-t1 placeholder:text-t3 focus:border-primary focus:outline-none"
+        />
+
+        <label className="mb-1.5 block text-[11px] font-medium text-t2">
+          Owner (optional)
+        </label>
+        <input
+          value={owner}
+          onChange={(event) => setOwner(event.target.value)}
+          placeholder="Name or team"
+          className="mb-5 block w-full rounded-lg border border-border bg-bg-3 px-3 py-2.5 text-[13px] text-t1 placeholder:text-t3 focus:border-primary focus:outline-none"
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-border bg-bg-3 px-4 py-2 text-[13px] font-medium text-t2 transition hover:bg-bg-4 hover:text-t1"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canSubmit}
+            onClick={() => {
+              if (!canSubmit) return;
+              const resolvedPreset = selectedPreset || initialPreset;
+              onSubmit({
+                label: roleName,
+                owner: owner.trim() || resolvedPreset?.owner || "Unassigned",
+              });
+              onClose();
+            }}
+            className="rounded-lg bg-primary px-5 py-2 text-[13px] font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {mode === "edit" ? "Save role →" : "Add role →"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/products/dashboard/components/workflows/add-role-modal.tsx
+++ b/products/dashboard/components/workflows/add-role-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { WorkflowRole } from "@/lib/workflows/types";
 import { cn } from "@/lib/utils";
@@ -49,6 +49,17 @@ export function AddRoleModal({
     ? customRole.trim() || initialRole?.label?.trim() || ""
     : selectedPreset?.label || "";
   const canSubmit = roleName.length > 0;
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
 
   return (
     <div

--- a/products/dashboard/components/workflows/add-stage-modal.tsx
+++ b/products/dashboard/components/workflows/add-stage-modal.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+
+import type { WorkflowStage } from "@/lib/workflows/types";
+
+interface AddStageModalProps {
+  mode?: "create" | "edit";
+  initialStage?: Pick<WorkflowStage, "label" | "sub">;
+  onClose: () => void;
+  onSubmit: (stage: Pick<WorkflowStage, "label" | "sub">) => void;
+}
+
+export function AddStageModal({
+  mode = "create",
+  initialStage,
+  onClose,
+  onSubmit,
+}: AddStageModalProps) {
+  const [label, setLabel] = useState(initialStage?.label ?? "");
+  const [sub, setSub] = useState(initialStage?.sub ?? "");
+
+  const canSubmit = label.trim().length > 0;
+
+  return (
+    <div
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-(--overlay) p-4 backdrop-blur-[3px]"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        className="w-full max-w-[420px] rounded-[14px] border border-border-hi bg-bg-2 p-7 shadow-[var(--shadow-canvas)]"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-stage-modal-title"
+      >
+        <div id="add-stage-modal-title" className="text-[16px] font-bold tracking-tight text-t1">
+          {mode === "edit" ? "Edit stage" : "Add stage"}
+        </div>
+        <div className="mb-4 mt-1 text-[12.5px] text-t3">
+          Define the stage label and optional subtitle.
+        </div>
+
+        <label className="mb-1.5 block text-[11px] font-medium text-t2">
+          Stage name
+        </label>
+        <input
+          autoFocus
+          value={label}
+          onChange={(event) => setLabel(event.target.value)}
+          placeholder="Stage name"
+          className="mb-3 block w-full rounded-lg border border-border bg-bg-3 px-3 py-2.5 text-[13px] text-t1 placeholder:text-t3 focus:border-primary focus:outline-none"
+        />
+
+        <label className="mb-1.5 block text-[11px] font-medium text-t2">
+          Subtitle (optional)
+        </label>
+        <input
+          value={sub}
+          onChange={(event) => setSub(event.target.value)}
+          placeholder="Short description"
+          className="mb-5 block w-full rounded-lg border border-border bg-bg-3 px-3 py-2.5 text-[13px] text-t1 placeholder:text-t3 focus:border-primary focus:outline-none"
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-border bg-bg-3 px-4 py-2 text-[13px] font-medium text-t2 transition hover:bg-bg-4 hover:text-t1"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canSubmit}
+            onClick={() => {
+              if (!canSubmit) return;
+              onSubmit({ label: label.trim(), sub: sub.trim() });
+              onClose();
+            }}
+            className="rounded-lg bg-primary px-5 py-2 text-[13px] font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {mode === "edit" ? "Save stage →" : "Add stage →"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/products/dashboard/components/workflows/add-stage-modal.tsx
+++ b/products/dashboard/components/workflows/add-stage-modal.tsx
@@ -17,6 +17,8 @@ export function AddStageModal({
   onClose,
   onSubmit,
 }: AddStageModalProps) {
+  const nameId = "stage-name";
+  const subId = "stage-sub";
   const [label, setLabel] = useState(initialStage?.label ?? "");
   const [sub, setSub] = useState(initialStage?.sub ?? "");
 
@@ -45,10 +47,11 @@ export function AddStageModal({
           Define the stage label and optional subtitle.
         </div>
 
-        <label className="mb-1.5 block text-[11px] font-medium text-t2">
+        <label htmlFor={nameId} className="mb-1.5 block text-[11px] font-medium text-t2">
           Stage name
         </label>
         <input
+          id={nameId}
           autoFocus
           value={label}
           onChange={(event) => setLabel(event.target.value)}
@@ -56,10 +59,11 @@ export function AddStageModal({
           className="mb-3 block w-full rounded-lg border border-border bg-bg-3 px-3 py-2.5 text-[13px] text-t1 placeholder:text-t3 focus:border-primary focus:outline-none"
         />
 
-        <label className="mb-1.5 block text-[11px] font-medium text-t2">
+        <label htmlFor={subId} className="mb-1.5 block text-[11px] font-medium text-t2">
           Subtitle (optional)
         </label>
         <input
+          id={subId}
           value={sub}
           onChange={(event) => setSub(event.target.value)}
           placeholder="Short description"

--- a/products/dashboard/components/workflows/add-task-modal.tsx
+++ b/products/dashboard/components/workflows/add-task-modal.tsx
@@ -21,15 +21,23 @@ const AGENTS = [
 ] as const;
 
 interface AddTaskModalProps {
+  mode?: "create" | "edit";
   instanceId: string;
   roleId: string;
   stageId: string;
   roleName: string;
   stageName: string;
+  initialTask?: {
+    title: string;
+    description?: string;
+    agent?: string | null;
+    skill?: string | null;
+    playbook?: string | null;
+  };
   skillOptions?: FrameworkItem[];
   playbookOptions?: FrameworkItem[];
   onClose: () => void;
-  onCreate: (input: WorkflowTaskCreateInput) => void;
+  onSubmit: (input: WorkflowTaskCreateInput) => void;
 }
 
 interface PickerProps {
@@ -131,15 +139,17 @@ function SearchablePicker({
 }
 
 export function AddTaskModal({
+  mode = "create",
   instanceId,
   roleId,
   stageId,
   roleName,
   stageName,
+  initialTask,
   skillOptions = [],
   playbookOptions = [],
   onClose,
-  onCreate,
+  onSubmit,
 }: AddTaskModalProps) {
   const [form, setForm] = useState<{
     title: string;
@@ -148,11 +158,11 @@ export function AddTaskModal({
     skill: string | null;
     playbook: string;
   }>({
-    title: "",
-    description: "",
-    agent: "PM",
-    skill: "pm",
-    playbook: "",
+    title: initialTask?.title ?? "",
+    description: initialTask?.description ?? "",
+    agent: initialTask?.agent ?? "PM",
+    skill: initialTask?.skill ?? "pm",
+    playbook: initialTask?.playbook ?? "",
   });
 
   const normalizedSkillOptions = useMemo(
@@ -204,7 +214,7 @@ export function AddTaskModal({
           id="add-task-modal-title"
           className="text-[16px] font-bold tracking-tight text-t1"
         >
-          New task
+          {mode === "edit" ? "Edit task" : "New task"}
         </div>
         <div className="mb-[18px] mt-1 text-[12.5px] text-t3">
           {roleName} · {stageName}
@@ -284,7 +294,7 @@ export function AddTaskModal({
             disabled={!form.title.trim()}
             onClick={() => {
               if (!form.title.trim()) return;
-              onCreate({
+              onSubmit({
                 instanceId,
                 roleId,
                 stageId,
@@ -296,7 +306,7 @@ export function AddTaskModal({
               });
             }}
           >
-            Create task →
+            {mode === "edit" ? "Save task →" : "Create task →"}
           </button>
         </div>
       </div>

--- a/products/dashboard/components/workflows/add-task-modal.tsx
+++ b/products/dashboard/components/workflows/add-task-modal.tsx
@@ -20,6 +20,13 @@ const AGENTS = [
   ["QA Engineer", "qa"],
 ] as const;
 
+function hasSkillOption(
+  options: Array<{ id: string }>,
+  skill: string | null | undefined,
+): skill is string {
+  return Boolean(skill) && options.some((option) => option.id === skill);
+}
+
 interface AddTaskModalProps {
   mode?: "create" | "edit";
   instanceId: string;
@@ -151,20 +158,6 @@ export function AddTaskModal({
   onClose,
   onSubmit,
 }: AddTaskModalProps) {
-  const [form, setForm] = useState<{
-    title: string;
-    description: string;
-    agent: string | null;
-    skill: string | null;
-    playbook: string;
-  }>({
-    title: initialTask?.title ?? "",
-    description: initialTask?.description ?? "",
-    agent: initialTask?.agent ?? "PM",
-    skill: initialTask?.skill ?? "pm",
-    playbook: initialTask?.playbook ?? "",
-  });
-
   const normalizedSkillOptions = useMemo(
     () =>
       (skillOptions.length > 0
@@ -193,6 +186,34 @@ export function AddTaskModal({
       })),
     [playbookOptions],
   );
+
+  const [form, setForm] = useState<{
+    title: string;
+    description: string;
+    agent: string | null;
+    skill: string | null;
+    playbook: string;
+  }>(() => {
+    const initialSkill = hasSkillOption(normalizedSkillOptions, initialTask?.skill)
+      ? initialTask?.skill
+      : skillOptions.length === 0
+        ? "pm"
+        : null;
+    const fallbackAgent = initialSkill
+      ? AGENTS.find((agent) => agent[1] === initialSkill)?.[0] ?? null
+      : null;
+
+    return {
+      title: initialTask?.title ?? "",
+      description: initialTask?.description ?? "",
+      agent:
+        initialTask?.agent ??
+        fallbackAgent ??
+        (skillOptions.length === 0 ? "PM" : null),
+      skill: initialSkill,
+      playbook: initialTask?.playbook ?? "",
+    };
+  });
 
   return (
     <div
@@ -294,14 +315,15 @@ export function AddTaskModal({
             disabled={!form.title.trim()}
             onClick={() => {
               if (!form.title.trim()) return;
+              const hasValidSkill = hasSkillOption(normalizedSkillOptions, form.skill);
               onSubmit({
                 instanceId,
                 roleId,
                 stageId,
-                title: form.title,
+                title: form.title.trim(),
                 description: form.description,
-                agent: form.agent,
-                skill: form.skill,
+                agent: hasValidSkill ? form.agent : null,
+                skill: hasValidSkill ? form.skill : null,
                 playbook: form.playbook,
               });
             }}

--- a/products/dashboard/components/workflows/header-actions-menu.tsx
+++ b/products/dashboard/components/workflows/header-actions-menu.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
+import { Ellipsis, Pencil, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { TextInputModal } from "@/components/ui/text-input-modal";
+
+interface HeaderActionsMenuProps {
+  entityLabel: string;
+  entityType: "template" | "instance";
+  onRename: (nextLabel: string) => Promise<void>;
+  onDelete: () => Promise<void>;
+  onDeletedHref?: string;
+  deleteDescription?: ReactNode;
+  requireDeleteLabelMatch?: boolean;
+}
+
+export function HeaderActionsMenu({
+  entityLabel,
+  entityType,
+  onRename,
+  onDelete,
+  onDeletedHref = "/",
+  deleteDescription,
+  requireDeleteLabelMatch = false,
+}: HeaderActionsMenuProps) {
+  const router = useRouter();
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+  const entityName = entityType === "template" ? "workflow template" : "workflow instance";
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <div ref={rootRef} className="relative">
+        <button
+          type="button"
+          aria-label={`Open ${entityName} actions`}
+          aria-expanded={open}
+          onClick={() => setOpen((current) => !current)}
+          className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-md border border-border-hi bg-bg-3 text-t2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition hover:border-border-hi hover:bg-bg-4 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent aria-expanded:border-accent aria-expanded:bg-primary-bg aria-expanded:text-accent"
+        >
+          <Ellipsis className="h-[15px] w-[15px]" strokeWidth={2.4} />
+        </button>
+        {open ? (
+          <div className="absolute right-0 top-[calc(100%+8px)] z-30 min-w-[168px] rounded-xl border border-border-hi bg-bg-2 p-1.5 shadow-[var(--shadow-canvas)]">
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                setRenameOpen(true);
+              }}
+              className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left text-[12.5px] text-t1 transition hover:bg-bg-3"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              Rename
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                setDeleteOpen(true);
+              }}
+              className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left text-[12.5px] text-[#f87171] transition hover:bg-linear-to-b hover:from-[#ef4444] hover:to-[#dc2626] hover:text-[#fff7f7]"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      {renameOpen ? (
+        <TextInputModal
+          title={`Rename ${entityName}`}
+          description={`Choose a new name for this ${entityName}.`}
+          label="Name"
+          initialValue={entityLabel}
+          submitLabel="Save"
+          onClose={() => {
+            if (!pending) setRenameOpen(false);
+          }}
+          onSubmit={async (nextLabel) => {
+            setPending(true);
+            try {
+              await onRename(nextLabel);
+              setRenameOpen(false);
+            } finally {
+              setPending(false);
+            }
+          }}
+        />
+      ) : null}
+
+      {deleteOpen && requireDeleteLabelMatch ? (
+        <TextInputModal
+          title={`Delete "${entityLabel}"?`}
+          description={
+            deleteDescription ??
+            `Type "${entityLabel}" to confirm deleting this ${entityName}.`
+          }
+          label={`Type "${entityLabel}" to confirm`}
+          initialValue=""
+          submitLabel="Delete"
+          isValid={(value) => value.trim() === entityLabel}
+          onClose={() => {
+            if (!pending) setDeleteOpen(false);
+          }}
+          onSubmit={async (value) => {
+            setPending(true);
+            try {
+              await onDelete();
+              setDeleteOpen(false);
+              router.push(onDeletedHref);
+              router.refresh();
+            } finally {
+              setPending(false);
+            }
+          }}
+        />
+      ) : null}
+
+      {deleteOpen && !requireDeleteLabelMatch ? (
+        <ConfirmModal
+          title={`Delete "${entityLabel}"?`}
+          description={
+            deleteDescription ?? `This ${entityName} will be permanently removed.`
+          }
+          confirmLabel="Delete"
+          onCancel={() => {
+            if (!pending) setDeleteOpen(false);
+          }}
+          onConfirm={async () => {
+            setPending(true);
+            try {
+              await onDelete();
+              setDeleteOpen(false);
+              router.push(onDeletedHref);
+              router.refresh();
+            } finally {
+              setPending(false);
+            }
+          }}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -131,7 +131,7 @@ export function ProcessMatrix({
     });
 
     return () => setConfig(null);
-  }, [instance.label, setConfig, template?.label]);
+  }, [instance.id, instance.label, setConfig, template?.label]);
 
   const runMutation = useCallback(
     async (

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -5,10 +5,13 @@ import { ChevronsLeftRight, Plus } from "lucide-react";
 
 import {
   createTaskAction,
+  deleteInstanceAction,
   deleteTaskAction,
   moveTaskAction,
+  renameInstanceAction,
   updateTaskDetailsAction,
 } from "@/app/(dashboard)/workflows/actions";
+import { useDashboardTopBar } from "@/components/dashboard-topbar-context";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { captureError } from "@/lib/monitoring";
 import { cn } from "@/lib/utils";
@@ -25,6 +28,7 @@ import type {
 
 import { AddTaskModal } from "./add-task-modal";
 import { AgentRunPanel } from "./agent-run-panel";
+import { HeaderActionsMenu } from "./header-actions-menu";
 import { TaskCard } from "./task-card";
 import { TaskDrawer } from "./task-drawer";
 
@@ -43,6 +47,7 @@ export function ProcessMatrix({
   skillOptions = [],
   playbookOptions = [],
 }: Props) {
+  const { setConfig } = useDashboardTopBar();
   const [collapsed, setCollapsed] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [dragTaskId, setDragTaskId] = useState<string | null>(null);
@@ -106,6 +111,27 @@ export function ProcessMatrix({
     : null;
 
   const isEmpty = stages.length === 0 || roles.length === 0;
+
+  useEffect(() => {
+    setConfig({
+      mode: "workflow-instance",
+      crumbs: ["Workflows", template?.label ?? "Workflow", instance.label],
+      actions: (
+        <HeaderActionsMenu
+          entityLabel={instance.label}
+          entityType="instance"
+          onRename={async (nextLabel) => {
+            await renameInstanceAction(instance.id, nextLabel);
+          }}
+          onDelete={async () => {
+            await deleteInstanceAction(instance.id);
+          }}
+        />
+      ),
+    });
+
+    return () => setConfig(null);
+  }, [instance.label, setConfig, template?.label]);
 
   const runMutation = useCallback(
     async (

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
-import { ChevronsLeftRight } from "lucide-react";
+import { ChevronsLeftRight, Plus } from "lucide-react";
 
 import {
   createTaskAction,
@@ -340,6 +340,7 @@ export function ProcessMatrix({
                             editMode={editMode}
                             draggable
                             onClick={() => setSelectedTaskId(task.id)}
+                            onEdit={editMode ? () => setSelectedTaskId(task.id) : undefined}
                             onRemove={
                               editMode ? () => setConfirmDeleteTask(task) : undefined
                             }
@@ -378,7 +379,7 @@ export function ProcessMatrix({
                               data-testid={`matrix-add-task-${role.id}-${stage.id}`}
                               aria-label={`Add task for ${role.label} in ${stage.label}`}
                             >
-                              +
+                              <Plus className="h-3.5 w-3.5" />
                             </button>
                           </div>
                         ) : null}
@@ -422,7 +423,7 @@ export function ProcessMatrix({
           skillOptions={skillOptions}
           playbookOptions={playbookOptions}
           onClose={() => setAddTaskFor(null)}
-          onCreate={(input) => {
+          onSubmit={(input) => {
             setAddTaskFor(null);
             runMutation(
               (tasks) => tasks,

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -7,6 +7,7 @@ import {
   createTaskAction,
   deleteTaskAction,
   moveTaskAction,
+  updateTaskDetailsAction,
 } from "@/app/(dashboard)/workflows/actions";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { captureError } from "@/lib/monitoring";
@@ -47,10 +48,19 @@ export function ProcessMatrix({
   const [dragTaskId, setDragTaskId] = useState<string | null>(null);
   const [dragOverCell, setDragOverCell] = useState<string | null>(null);
   const [addTaskFor, setAddTaskFor] = useState<{
+    mode: "create" | "edit";
+    taskId?: string;
     roleId: string;
     roleName: string;
     stageId: string;
     stageName: string;
+    initialTask?: {
+      title: string;
+      description?: string;
+      agent?: string | null;
+      skill?: string | null;
+      playbook?: string | null;
+    };
   } | null>(null);
   const [confirmDeleteTask, setConfirmDeleteTask] = useState<WorkflowTask | null>(
     null,
@@ -340,7 +350,26 @@ export function ProcessMatrix({
                             editMode={editMode}
                             draggable
                             onClick={() => setSelectedTaskId(task.id)}
-                            onEdit={editMode ? () => setSelectedTaskId(task.id) : undefined}
+                            onEdit={
+                              editMode
+                                ? () =>
+                                    setAddTaskFor({
+                                      mode: "edit",
+                                      taskId: task.id,
+                                      roleId: role.id,
+                                      roleName: role.label,
+                                      stageId: stage.id,
+                                      stageName: stage.label,
+                                      initialTask: {
+                                        title: task.title,
+                                        description: task.description,
+                                        agent: task.agent ?? null,
+                                        skill: task.skill ?? null,
+                                        playbook: task.playbook ?? null,
+                                      },
+                                    })
+                                : undefined
+                            }
                             onRemove={
                               editMode ? () => setConfirmDeleteTask(task) : undefined
                             }
@@ -366,6 +395,7 @@ export function ProcessMatrix({
                             className="mx-empty-cell"
                             onClick={() =>
                               setAddTaskFor({
+                                mode: "create",
                                 roleId: role.id,
                                 roleName: role.label,
                                 stageId: stage.id,
@@ -415,16 +445,48 @@ export function ProcessMatrix({
 
       {addTaskFor ? (
         <AddTaskModal
+          mode={addTaskFor.mode}
           instanceId={instance.id}
           roleId={addTaskFor.roleId}
           roleName={addTaskFor.roleName}
           stageId={addTaskFor.stageId}
           stageName={addTaskFor.stageName}
+          initialTask={addTaskFor.initialTask}
           skillOptions={skillOptions}
           playbookOptions={playbookOptions}
           onClose={() => setAddTaskFor(null)}
           onSubmit={(input) => {
             setAddTaskFor(null);
+            if (addTaskFor.mode === "edit" && addTaskFor.taskId) {
+              runMutation(
+                (tasks) =>
+                  tasks.map((task) =>
+                    task.id === addTaskFor.taskId
+                      ? {
+                          ...task,
+                          title: input.title.trim(),
+                          description: input.description?.trim() ?? "",
+                          agent: input.agent ?? null,
+                          skill: input.skill ?? null,
+                          playbook: input.playbook ?? null,
+                        }
+                      : task,
+                  ),
+                async () => {
+                  const result = await updateTaskDetailsAction({
+                    taskId: addTaskFor.taskId!,
+                    title: input.title,
+                    description: input.description,
+                    agent: input.agent,
+                    skill: input.skill,
+                    playbook: input.playbook,
+                  });
+                  return result.task;
+                },
+              );
+              return;
+            }
+
             runMutation(
               (tasks) => tasks,
               async () => {

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, X } from "lucide-react";
+import { AlertTriangle, Pencil, Trash2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import type { TaskBarState } from "@/lib/workflows/matrix";
@@ -53,6 +53,7 @@ export interface TaskCardProps {
   /** Opens the Task Drawer for this card. */
   onClick?: () => void;
   editMode?: boolean;
+  onEdit?: () => void;
   onRemove?: () => void;
   draggable?: boolean;
   onDragStart?: React.DragEventHandler<HTMLDivElement>;
@@ -66,6 +67,7 @@ export function TaskCard({
   barState,
   onClick,
   editMode = false,
+  onEdit,
   onRemove,
   draggable = false,
   onDragStart,
@@ -74,6 +76,7 @@ export function TaskCard({
 }: TaskCardProps) {
   const statusClass = STATUS_PILL_CLASS[task.status];
   const statusLabel = STATUS_LABEL[task.status];
+  const showTaskActions = editMode && (Boolean(onEdit) || Boolean(onRemove));
 
   return (
     <div
@@ -106,19 +109,6 @@ export function TaskCard({
       }
       aria-label={onClick ? `Open task: ${task.title}` : undefined}
     >
-      {editMode ? (
-        <button
-          type="button"
-          className="tc-remove"
-          aria-label={`Remove task: ${task.title}`}
-          onClick={(event) => {
-            event.stopPropagation();
-            onRemove?.();
-          }}
-        >
-          <X aria-hidden size={11} strokeWidth={2.2} />
-        </button>
-      ) : null}
       <div className="tc-top">
         <div className="tc-title">{task.title}</div>
         {task.checkpoint && (
@@ -147,7 +137,40 @@ export function TaskCard({
             <div className="s-text">{statusLabel}</div>
           </div>
         )}
-        {task.agent ? <div className="tc-agent">{task.agent}</div> : null}
+        {showTaskActions ? (
+          <div className="tc-actions mx-entity-actions mx-entity-actions-group">
+            {onEdit ? (
+              <button
+                type="button"
+                className="mx-entity-action"
+                aria-label={`Edit task: ${task.title}`}
+                title={`Edit ${task.title}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onEdit();
+                }}
+              >
+                <Pencil aria-hidden size={11} strokeWidth={2.1} />
+              </button>
+            ) : null}
+            {onRemove ? (
+              <button
+                type="button"
+                className="mx-entity-action mx-entity-action-danger"
+                aria-label={`Remove task: ${task.title}`}
+                title={`Delete ${task.title}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onRemove();
+                }}
+              >
+                <Trash2 aria-hidden size={11} strokeWidth={2.1} />
+              </button>
+            ) : null}
+          </div>
+        ) : task.agent ? (
+          <div className="tc-agent">{task.agent}</div>
+        ) : null}
       </div>
     </div>
   );

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -57,6 +57,7 @@ export interface TaskCardProps {
   draggable?: boolean;
   onDragStart?: React.DragEventHandler<HTMLDivElement>;
   onDragEnd?: React.DragEventHandler<HTMLDivElement>;
+  showDefaultPill?: boolean;
 }
 
 export function TaskCard({
@@ -69,6 +70,7 @@ export function TaskCard({
   draggable = false,
   onDragStart,
   onDragEnd,
+  showDefaultPill = false,
 }: TaskCardProps) {
   const statusClass = STATUS_PILL_CLASS[task.status];
   const statusLabel = STATUS_LABEL[task.status];
@@ -78,7 +80,13 @@ export function TaskCard({
       data-testid={`task-card-${task.id}`}
       data-bar={barState}
       data-status={task.status}
-      className={cn("task-card", statusClass, barState, onClick && "cursor-pointer")}
+      className={cn(
+        "task-card",
+        statusClass,
+        barState,
+        showDefaultPill && "task-card-default",
+        onClick && "cursor-pointer",
+      )}
       style={{ "--role-color": roleColor } as React.CSSProperties}
       draggable={editMode && draggable}
       onDragStart={onDragStart}
@@ -128,10 +136,17 @@ export function TaskCard({
         <div className="tc-desc">{task.description}</div>
       ) : null}
       <div className="tc-footer">
-        <div className={cn("s-pill", statusClass)}>
-          <div className="s-dot" aria-hidden />
-          <div className="s-text">{statusLabel}</div>
-        </div>
+        {showDefaultPill ? (
+          <div className="s-pill rounded-full bg-bg-3">
+            <div className="s-dot bg-t3" aria-hidden />
+            <div className="s-text italic text-t2">default</div>
+          </div>
+        ) : (
+          <div className={cn("s-pill", statusClass)}>
+            <div className="s-dot" aria-hidden />
+            <div className="s-text">{statusLabel}</div>
+          </div>
+        )}
         {task.agent ? <div className="tc-agent">{task.agent}</div> : null}
       </div>
     </div>

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -25,6 +25,10 @@ import { cn } from "@/lib/utils";
 
 import { TaskCard } from "./task-card";
 
+const ROLE_COLUMN_WIDTH = 172;
+const STAGE_COLUMN_WIDTH = 192;
+const STAGE_INSERT_WIDTH = 6;
+
 interface TemplateEditorScreenProps {
   template: WorkflowTemplate;
   skillOptions: FrameworkItem[];
@@ -149,15 +153,29 @@ export function TemplateEditorScreen({
     null,
   );
   const [addTaskFor, setAddTaskFor] = useState<{
+    mode: "create" | "edit";
+    taskId?: string;
     roleId: string;
     roleName: string;
     stageId: string;
     stageName: string;
+    initialTask?: {
+      title: string;
+      description?: string;
+      agent?: string | null;
+      skill?: string | null;
+      playbook?: string | null;
+    };
   } | null>(null);
   const [pending, startTransition] = useTransition();
   const [saveError, setSaveError] = useState<string | null>(null);
 
   const isDirty = JSON.stringify(draft) !== JSON.stringify(template);
+  const rowInsertWidth = `${
+    ROLE_COLUMN_WIDTH +
+    draft.stages.length * STAGE_COLUMN_WIDTH +
+    Math.max(draft.stages.length - 1, 0) * STAGE_INSERT_WIDTH
+  }px`;
 
   useEffect(() => {
     draftRef.current = draft;
@@ -264,14 +282,14 @@ export function TemplateEditorScreen({
             {draft.stages.map((stage, index) => (
               <div key={stage.id} className="contents">
                 <div className="mx-stage-hd" role="columnheader">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
+                  <div className="mx-entity-content">
+                    <div className="min-w-0">
                       <div className="mx-stage-name">{stage.label}</div>
                       <div className="mx-stage-sub mx-stage-sub-plain">
                         {stage.sub?.trim() || "No description"}
                       </div>
                     </div>
-                    <div className="mx-entity-actions">
+                    <div className="mx-entity-actions mx-entity-actions-group">
                       <button
                         type="button"
                         aria-label={`Edit stage ${stage.label}`}
@@ -354,52 +372,54 @@ export function TemplateEditorScreen({
                       }))
                     }
                   />
-                  <div className="min-w-0 flex-1">
-                    <div className="mx-role-name">{role.label}</div>
-                    <div className="mx-role-owner mx-role-owner-plain">
-                      {role.owner?.trim() || "No owner"}
+                  <div className="mx-entity-content">
+                    <div className="min-w-0">
+                      <div className="mx-role-name">{role.label}</div>
+                      <div className="mx-role-owner mx-role-owner-plain">
+                        {role.owner?.trim() || "No owner"}
+                      </div>
                     </div>
-                  </div>
-                  <div className="mx-entity-actions">
-                    <button
-                      type="button"
-                      className="mx-entity-action"
-                      aria-label={`Edit role ${role.label}`}
-                      onClick={() =>
-                        setRoleModalState({
-                          mode: "edit",
-                          index: roleIndex,
-                          roleId: role.id,
-                          initialRole: { label: role.label, owner: role.owner },
-                        })
-                      }
-                    >
-                      <Pencil className="h-3.5 w-3.5" />
-                    </button>
-                    <button
-                      type="button"
-                      className="mx-entity-action mx-entity-action-danger"
-                      aria-label={`Remove role ${role.label}`}
-                      onClick={() =>
-                        setConfirmState({
-                          title: `Remove role "${role.label}"?`,
-                          description:
-                            "All tasks assigned to this role in this template will be removed.",
-                          onConfirm: () => {
-                            setDraft((current) => ({
-                              ...current,
-                              roles: current.roles.filter((item) => item.id !== role.id),
-                              taskTemplates: current.taskTemplates.filter(
-                                (task) => task.role !== role.id,
-                              ),
-                            }));
-                            setConfirmState(null);
-                          },
-                        })
-                      }
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </button>
+                    <div className="mx-entity-actions mx-entity-actions-group">
+                      <button
+                        type="button"
+                        className="mx-entity-action"
+                        aria-label={`Edit role ${role.label}`}
+                        onClick={() =>
+                          setRoleModalState({
+                            mode: "edit",
+                            index: roleIndex,
+                            roleId: role.id,
+                            initialRole: { label: role.label, owner: role.owner },
+                          })
+                        }
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        className="mx-entity-action mx-entity-action-danger"
+                        aria-label={`Remove role ${role.label}`}
+                        onClick={() =>
+                          setConfirmState({
+                            title: `Remove role "${role.label}"?`,
+                            description:
+                              "All tasks assigned to this role in this template will be removed.",
+                            onConfirm: () => {
+                              setDraft((current) => ({
+                                ...current,
+                                roles: current.roles.filter((item) => item.id !== role.id),
+                                taskTemplates: current.taskTemplates.filter(
+                                  (task) => task.role !== role.id,
+                                ),
+                              }));
+                              setConfirmState(null);
+                            },
+                          })
+                        }
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
                   </div>
                 </div>
 
@@ -420,13 +440,38 @@ export function TemplateEditorScreen({
                             barState="bar-ready"
                             editMode
                             showDefaultPill
+                            onEdit={() =>
+                              setAddTaskFor({
+                                mode: "edit",
+                                taskId: templateTask?.id,
+                                roleId: role.id,
+                                roleName: role.label,
+                                stageId: stage.id,
+                                stageName: stage.label,
+                                initialTask: {
+                                  title: templateTask?.title ?? "",
+                                  description: templateTask?.desc ?? "",
+                                  agent: templateTask?.agent ?? null,
+                                  skill: templateTask?.skill ?? null,
+                                  playbook: templateTask?.playbook ?? null,
+                                },
+                              })
+                            }
                             onRemove={() =>
-                              setDraft((current) => ({
-                                ...current,
-                                taskTemplates: current.taskTemplates.filter(
-                                  (item) => item.id !== templateTask?.id,
-                                ),
-                              }))
+                              setConfirmState({
+                                title: `Delete "${task.title}"?`,
+                                description:
+                                  "This task and its default configuration will be removed from the template.",
+                                onConfirm: () => {
+                                  setDraft((current) => ({
+                                    ...current,
+                                    taskTemplates: current.taskTemplates.filter(
+                                      (item) => item.id !== templateTask?.id,
+                                    ),
+                                  }));
+                                  setConfirmState(null);
+                                },
+                              })
                             }
                           />
                         ) : (
@@ -435,6 +480,7 @@ export function TemplateEditorScreen({
                             data-testid={`matrix-add-task-${role.id}-${stage.id}`}
                             onClick={() =>
                               setAddTaskFor({
+                                mode: "create",
                                 roleId: role.id,
                                 roleName: role.label,
                                 stageId: stage.id,
@@ -443,7 +489,7 @@ export function TemplateEditorScreen({
                             }
                             className="mx-empty-cell w-full"
                           >
-                            <span className="mx-add-btn opacity-100">
+                            <span className="mx-add-btn">
                               <Plus className="h-3.5 w-3.5" />
                             </span>
                           </button>
@@ -475,6 +521,8 @@ export function TemplateEditorScreen({
               <button
                 type="button"
                 className="mx-row-insert"
+                data-testid={`matrix-insert-role-${roleIndex + 1}`}
+                style={{ width: rowInsertWidth }}
                 onClick={() =>
                   setRoleModalState({
                     mode: "create",
@@ -492,6 +540,8 @@ export function TemplateEditorScreen({
           <button
             type="button"
             className="mx-row-insert"
+            data-testid="matrix-insert-role-end"
+            style={{ width: rowInsertWidth }}
             onClick={() =>
               setRoleModalState({
                 mode: "create",
@@ -538,34 +588,56 @@ export function TemplateEditorScreen({
 
       {addTaskFor ? (
         <AddTaskModal
+          mode={addTaskFor.mode}
           instanceId={`template:${draft.id}`}
           roleId={addTaskFor.roleId}
           roleName={addTaskFor.roleName}
           stageId={addTaskFor.stageId}
           stageName={addTaskFor.stageName}
+          initialTask={addTaskFor.initialTask}
           skillOptions={skillOptions}
           playbookOptions={playbookOptions}
           onClose={() => setAddTaskFor(null)}
-          onCreate={(input) => {
-            setDraft((current) => ({
-              ...current,
-              taskTemplates: [
-                ...current.taskTemplates,
-                {
-                  id: createId("task"),
-                  role: input.roleId,
-                  stage: input.stageId,
-                  title: input.title.trim(),
-                  desc: input.description?.trim(),
-                  checkpoint: Boolean(input.checkpoint),
-                  triggers: input.triggers ?? [],
-                  gates: input.gates ?? [],
-                  agent: input.agent ?? undefined,
-                  skill: input.skill ?? undefined,
-                  playbook: input.playbook ?? undefined,
-                },
-              ],
-            }));
+          onSubmit={(input) => {
+            setDraft((current) => {
+              if (addTaskFor.mode === "edit" && addTaskFor.taskId) {
+                return {
+                  ...current,
+                  taskTemplates: current.taskTemplates.map((item) =>
+                    item.id === addTaskFor.taskId
+                      ? {
+                          ...item,
+                          title: input.title.trim(),
+                          desc: input.description?.trim(),
+                          agent: input.agent ?? undefined,
+                          skill: input.skill ?? undefined,
+                          playbook: input.playbook ?? undefined,
+                        }
+                      : item,
+                  ),
+                };
+              }
+
+              return {
+                ...current,
+                taskTemplates: [
+                  ...current.taskTemplates,
+                  {
+                    id: createId("task"),
+                    role: input.roleId,
+                    stage: input.stageId,
+                    title: input.title.trim(),
+                    desc: input.description?.trim(),
+                    checkpoint: Boolean(input.checkpoint),
+                    triggers: input.triggers ?? [],
+                    gates: input.gates ?? [],
+                    agent: input.agent ?? undefined,
+                    skill: input.skill ?? undefined,
+                    playbook: input.playbook ?? undefined,
+                  },
+                ],
+              };
+            });
             setAddTaskFor(null);
           }}
         />

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -100,19 +100,52 @@ function ColorDot({
   color: string;
   onChange: (color: string) => void;
 }) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
   const [open, setOpen] = useState(false);
 
+  useEffect(() => {
+    if (!open) return;
+
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
   return (
-    <div className="relative shrink-0">
+    <div
+      ref={rootRef}
+      data-role-color-open={open ? "true" : "false"}
+      className={cn("relative shrink-0", open && "z-30")}
+    >
       <button
         type="button"
         aria-label="Change role color"
         onClick={() => setOpen((current) => !current)}
-        className="h-3 w-3 rounded-full transition-transform hover:scale-110"
-        style={{ backgroundColor: color, boxShadow: `0 0 0 2px ${color}30` }}
+        className="flex h-5 w-5 items-center justify-center rounded-full border border-border bg-bg-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition hover:border-border-hi hover:bg-bg-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+      />
+      <span
+        aria-hidden
+        className="pointer-events-none absolute left-1/2 top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full transition-transform duration-150"
+        style={{ backgroundColor: color, boxShadow: `0 0 0 2px ${color}28` }}
       />
       {open ? (
-        <div className="absolute left-0 top-[calc(100%+6px)] z-20 grid w-[100px] grid-cols-4 gap-1 rounded-lg border border-border-hi bg-bg-3 p-2 shadow-[var(--shadow-canvas)]">
+        <div className="absolute left-0 top-[calc(100%+8px)] z-40 grid w-[100px] grid-cols-4 gap-1 rounded-lg border border-border-hi bg-bg-3 p-2 shadow-[var(--shadow-canvas)]">
           {ROLE_COLORS.map((swatch) => (
             <button
               key={swatch}
@@ -303,7 +336,7 @@ export function TemplateEditorScreen({
                           })
                         }
                       >
-                        <Pencil className="h-3.5 w-3.5" />
+                        <Pencil className="h-[11px] w-[11px]" />
                       </button>
                       <button
                         type="button"
@@ -326,7 +359,7 @@ export function TemplateEditorScreen({
                           })
                         }
                       >
-                        <Trash2 className="h-3.5 w-3.5" />
+                        <Trash2 className="h-[11px] w-[11px]" />
                       </button>
                     </div>
                   </div>
@@ -393,7 +426,7 @@ export function TemplateEditorScreen({
                           })
                         }
                       >
-                        <Pencil className="h-3.5 w-3.5" />
+                        <Pencil className="h-[11px] w-[11px]" />
                       </button>
                       <button
                         type="button"
@@ -417,7 +450,7 @@ export function TemplateEditorScreen({
                           })
                         }
                       >
-                        <Trash2 className="h-3.5 w-3.5" />
+                        <Trash2 className="h-[11px] w-[11px]" />
                       </button>
                     </div>
                   </div>

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -183,6 +183,7 @@ export function TemplateEditorScreen({
   const { setConfig } = useDashboardTopBar();
   const { capture } = useAnalytics();
   const draftRef = useRef(template);
+  const [lastSaved, setLastSaved] = useState<WorkflowTemplate>(template);
   const [draft, setDraft] = useState<WorkflowTemplate>(template);
   const [confirmState, setConfirmState] = useState<ConfirmState>(null);
   const [roleModalState, setRoleModalState] = useState<RoleModalState>(null);
@@ -208,7 +209,7 @@ export function TemplateEditorScreen({
   const [pending, startTransition] = useTransition();
   const [saveError, setSaveError] = useState<string | null>(null);
 
-  const isDirty = JSON.stringify(draft) !== JSON.stringify(template);
+  const isDirty = JSON.stringify(draft) !== JSON.stringify(lastSaved);
   const rowInsertWidth = `${
     ROLE_COLUMN_WIDTH +
     draft.stages.length * STAGE_COLUMN_WIDTH +
@@ -218,6 +219,11 @@ export function TemplateEditorScreen({
   useEffect(() => {
     draftRef.current = draft;
   }, [draft]);
+
+  useEffect(() => {
+    setDraft(template);
+    setLastSaved(template);
+  }, [template]);
 
   function addRole(role: Pick<WorkflowRole, "label" | "owner">, index: number) {
     setDraft((current) => ({
@@ -266,6 +272,7 @@ export function TemplateEditorScreen({
       try {
         const result = await updateTemplateAction(draftRef.current.id, draftRef.current);
         setDraft(result.template);
+        setLastSaved(result.template);
         emitEvent("workflow.template_edited", {
           template_id: result.template.id,
           edited_by: "founder",
@@ -299,7 +306,8 @@ export function TemplateEditorScreen({
           entityType="template"
           onRename={async (nextLabel) => {
             const result = await renameTemplateAction(draft.id, nextLabel);
-            setDraft(result.template);
+            setDraft((current) => ({ ...current, label: result.template.label }));
+            setLastSaved((current) => ({ ...current, label: result.template.label }));
           }}
           onDelete={async () => {
             await deleteTemplateAction(draft.id);
@@ -367,6 +375,46 @@ export function TemplateEditorScreen({
             <div className="mx-corner" role="columnheader">
               <span className="flex-1">Roles</span>
             </div>
+
+            {draft.stages.length === 0 ? (
+              <button
+                type="button"
+                className="mx-col-insert mx-col-insert-empty"
+                onClick={() =>
+                  setStageModalState({
+                    mode: "create",
+                    index: 0,
+                  })
+                }
+              >
+                <span className="mx-col-insert-icon">
+                  <Plus className="h-3.5 w-3.5" />
+                </span>
+                <span className="mx-col-insert-label-text">Add first stage</span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                className={cn(
+                  "mx-col-insert",
+                  hoveredStageInsertIndex === 0 && "mx-col-insert-active",
+                )}
+                onMouseEnter={() => setHoveredStageInsertIndex(0)}
+                onMouseLeave={() =>
+                  setHoveredStageInsertIndex((current) => (current === 0 ? null : current))
+                }
+                onClick={() =>
+                  setStageModalState({
+                    mode: "create",
+                    index: 0,
+                  })
+                }
+              >
+                <span className="mx-col-insert-icon">
+                  <Plus className="h-3.5 w-3.5" />
+                </span>
+              </button>
+            )}
 
             {draft.stages.map((stage, index) => (
               <div key={stage.id} className="contents">
@@ -688,6 +736,11 @@ export function TemplateEditorScreen({
           playbookOptions={playbookOptions}
           onClose={() => setAddTaskFor(null)}
           onSubmit={(input) => {
+            const safeSkill =
+              input.skill && skillOptions.some((item) => item.id === input.skill)
+                ? input.skill
+                : undefined;
+            const safeAgent = safeSkill ? input.agent ?? undefined : undefined;
             setDraft((current) => {
               if (addTaskFor.mode === "edit" && addTaskFor.taskId) {
                 return {
@@ -698,8 +751,8 @@ export function TemplateEditorScreen({
                           ...item,
                           title: input.title.trim(),
                           desc: input.description?.trim(),
-                          agent: input.agent ?? undefined,
-                          skill: input.skill ?? undefined,
+                          agent: safeAgent,
+                          skill: safeSkill,
                           playbook: input.playbook ?? undefined,
                         }
                       : item,
@@ -720,8 +773,8 @@ export function TemplateEditorScreen({
                     checkpoint: Boolean(input.checkpoint),
                     triggers: input.triggers ?? [],
                     gates: input.gates ?? [],
-                    agent: input.agent ?? undefined,
-                    skill: input.skill ?? undefined,
+                    agent: safeAgent,
+                    skill: safeSkill,
                     playbook: input.playbook ?? undefined,
                   },
                 ],

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { useEffect, useRef, useState, useTransition } from "react";
-import { Pencil, Plus, Trash2 } from "lucide-react";
+import { CircleAlert, Pencil, Plus, Trash2 } from "lucide-react";
 
-import { updateTemplateAction } from "@/app/(dashboard)/workflows/actions";
+import {
+  deleteTemplateAction,
+  renameTemplateAction,
+  updateTemplateAction,
+} from "@/app/(dashboard)/workflows/actions";
 import { useDashboardTopBar } from "@/components/dashboard-topbar-context";
 import { AddRoleModal } from "@/components/workflows/add-role-modal";
 import { AddStageModal } from "@/components/workflows/add-stage-modal";
 import { AddTaskModal } from "@/components/workflows/add-task-modal";
+import { HeaderActionsMenu } from "@/components/workflows/header-actions-menu";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { useAnalytics } from "@/lib/analytics/events";
 import { emitEvent } from "@/lib/events";
@@ -30,6 +35,7 @@ const STAGE_INSERT_WIDTH = 6;
 
 interface TemplateEditorScreenProps {
   template: WorkflowTemplate;
+  instanceCount: number;
   skillOptions: FrameworkItem[];
   playbookOptions: FrameworkItem[];
 }
@@ -170,6 +176,7 @@ function ColorDot({
 
 export function TemplateEditorScreen({
   template,
+  instanceCount,
   skillOptions,
   playbookOptions,
 }: TemplateEditorScreenProps) {
@@ -280,11 +287,37 @@ export function TemplateEditorScreen({
   useEffect(() => {
     setConfig({
       mode: "template-editor",
+      crumbs: ["Workflows", draft.label],
       label: draft.label,
       onLabelChange: (value) =>
         setDraft((current) => ({ ...current, label: value })),
       onSave: saveTemplate,
       saveDisabled: !isDirty || pending,
+      actions: (
+        <HeaderActionsMenu
+          entityLabel={draft.label}
+          entityType="template"
+          onRename={async (nextLabel) => {
+            const result = await renameTemplateAction(draft.id, nextLabel);
+            setDraft(result.template);
+          }}
+          onDelete={async () => {
+            await deleteTemplateAction(draft.id);
+          }}
+          requireDeleteLabelMatch
+          deleteDescription={
+            <>
+              This will permanently delete the workflow template.
+              <strong className="font-semibold text-t1">
+                {" "}
+                It will also delete all {instanceCount} associated{" "}
+                {instanceCount === 1 ? "instance" : "instances"}.
+              </strong>{" "}
+              Type "{draft.label}" to confirm.
+            </>
+          }
+        />
+      ),
     });
 
     return () => setConfig(null);
@@ -292,10 +325,36 @@ export function TemplateEditorScreen({
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <div className="shrink-0 border-b border-border px-5 py-3">
-        <div className="rounded-lg border border-[rgba(245,158,11,0.28)] bg-[rgba(245,158,11,0.08)] px-3 py-2.5 text-[12px] text-[#fbbf24]">
-          Modifying this workflow updates defaults for new instances. Existing
-          instances keep their current tasks.
+      <div className="shrink-0 border-b border-border bg-bg px-6 py-4">
+        <div className="min-w-0">
+            <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+              Workflow template
+            </p>
+            <div className="mt-1 flex items-center gap-2">
+              <h1 className="truncate text-[20px] font-bold tracking-tight text-t1">{draft.label}</h1>
+              <div className="group relative">
+                <button
+                  type="button"
+                  aria-label="Template editing information"
+                  className="flex h-5 w-5 items-center justify-center rounded-full text-[#fbbf24] transition hover:bg-[rgba(245,158,11,0.08)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#fbbf24]"
+                >
+                  <CircleAlert className="h-3.5 w-3.5" />
+                </button>
+                <div
+                  role="tooltip"
+                  className="pointer-events-none absolute left-[calc(100%+8px)] top-1/2 z-30 hidden w-[280px] -translate-y-1/2 rounded-lg border border-[rgba(245,158,11,0.28)] bg-bg-2 px-3 py-2 text-[12px] leading-5 text-[#fbbf24] shadow-[var(--shadow-canvas)] group-hover:block group-focus-within:block"
+                >
+                  Modifying this workflow updates defaults for new instances. Existing
+                  instances keep their current tasks.
+                </div>
+              </div>
+            </div>
+            <p className="mt-1 text-[13px] text-t2">
+              {draft.taskTemplates.length}{" "}
+              {draft.taskTemplates.length === 1 ? "task" : "tasks"} ·{" "}
+              {draft.roles.length} {draft.roles.length === 1 ? "role" : "roles"} ·{" "}
+              {draft.stages.length} {draft.stages.length === 1 ? "stage" : "stages"}
+            </p>
         </div>
         {saveError ? (
           <div className="mt-2 text-[11.5px] text-(color:--pill-blocked-t)">{saveError}</div>

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -1,0 +1,584 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Pencil, Plus, Trash2 } from "lucide-react";
+
+import { updateTemplateAction } from "@/app/(dashboard)/workflows/actions";
+import { useDashboardTopBar } from "@/components/dashboard-topbar-context";
+import { AddRoleModal } from "@/components/workflows/add-role-modal";
+import { AddStageModal } from "@/components/workflows/add-stage-modal";
+import { AddTaskModal } from "@/components/workflows/add-task-modal";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { useAnalytics } from "@/lib/analytics/events";
+import { emitEvent } from "@/lib/events";
+import { ROLE_COLORS, getRoleColor } from "@/lib/workflows/role-colors";
+import type {
+  FrameworkItem,
+  WorkflowRole,
+  WorkflowStage,
+  WorkflowTask,
+  WorkflowTaskTemplate,
+  WorkflowTemplate,
+} from "@/lib/workflows/types";
+import { cn } from "@/lib/utils";
+
+import { TaskCard } from "./task-card";
+
+interface TemplateEditorScreenProps {
+  template: WorkflowTemplate;
+  skillOptions: FrameworkItem[];
+  playbookOptions: FrameworkItem[];
+}
+
+type ConfirmState =
+  | null
+  | {
+      title: string;
+      description: string;
+      onConfirm: () => void;
+    };
+
+type RoleModalState =
+  | null
+  | {
+      mode: "create" | "edit";
+      index: number;
+      roleId?: string;
+      initialRole?: Pick<WorkflowRole, "label" | "owner">;
+    };
+
+type StageModalState =
+  | null
+  | {
+      mode: "create" | "edit";
+      index: number;
+      stageId?: string;
+      initialStage?: Pick<WorkflowStage, "label" | "sub">;
+    };
+
+function createId(prefix: string): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function templateTaskToCard(task: WorkflowTaskTemplate): WorkflowTask {
+  return {
+    id: task.id ?? createId("task"),
+    instanceId: "template-editor",
+    roleId: task.role,
+    stageId: task.stage,
+    title: task.title,
+    description: task.desc ?? "",
+    status: "not_started",
+    substatus: "",
+    checkpoint: Boolean(task.checkpoint),
+    triggers: task.triggers ?? [],
+    gates: task.gates ?? [],
+    agent: task.agent ?? null,
+    skill: task.skill ?? null,
+    playbook: task.playbook ?? null,
+    createdAt: "",
+    updatedAt: "",
+  };
+}
+
+function insertAt<T>(items: T[], index: number, value: T): T[] {
+  return [...items.slice(0, index), value, ...items.slice(index)];
+}
+
+function ColorDot({
+  color,
+  onChange,
+}: {
+  color: string;
+  onChange: (color: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative shrink-0">
+      <button
+        type="button"
+        aria-label="Change role color"
+        onClick={() => setOpen((current) => !current)}
+        className="h-3 w-3 rounded-full transition-transform hover:scale-110"
+        style={{ backgroundColor: color, boxShadow: `0 0 0 2px ${color}30` }}
+      />
+      {open ? (
+        <div className="absolute left-0 top-[calc(100%+6px)] z-20 grid w-[100px] grid-cols-4 gap-1 rounded-lg border border-border-hi bg-bg-3 p-2 shadow-[var(--shadow-canvas)]">
+          {ROLE_COLORS.map((swatch) => (
+            <button
+              key={swatch}
+              type="button"
+              aria-label={`Use ${swatch}`}
+              onClick={() => {
+                onChange(swatch);
+                setOpen(false);
+              }}
+              className="h-4 w-4 rounded-full"
+              style={{
+                backgroundColor: swatch,
+                outline: swatch === color ? `2px solid ${swatch}` : undefined,
+                outlineOffset: 2,
+              }}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function TemplateEditorScreen({
+  template,
+  skillOptions,
+  playbookOptions,
+}: TemplateEditorScreenProps) {
+  const router = useRouter();
+  const { setConfig } = useDashboardTopBar();
+  const { capture } = useAnalytics();
+  const draftRef = useRef(template);
+  const [draft, setDraft] = useState<WorkflowTemplate>(template);
+  const [confirmState, setConfirmState] = useState<ConfirmState>(null);
+  const [roleModalState, setRoleModalState] = useState<RoleModalState>(null);
+  const [stageModalState, setStageModalState] = useState<StageModalState>(null);
+  const [hoveredStageInsertIndex, setHoveredStageInsertIndex] = useState<number | null>(
+    null,
+  );
+  const [addTaskFor, setAddTaskFor] = useState<{
+    roleId: string;
+    roleName: string;
+    stageId: string;
+    stageName: string;
+  } | null>(null);
+  const [pending, startTransition] = useTransition();
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const isDirty = JSON.stringify(draft) !== JSON.stringify(template);
+
+  useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
+
+  function addRole(role: Pick<WorkflowRole, "label" | "owner">, index: number) {
+    setDraft((current) => ({
+      ...current,
+      roles: insertAt(current.roles, index, {
+        id: createId("role"),
+        label: role.label,
+        owner: role.owner,
+        color: ROLE_COLORS[index % ROLE_COLORS.length],
+      }),
+    }));
+  }
+
+  function updateRole(roleId: string, nextRole: Pick<WorkflowRole, "label" | "owner">) {
+    setDraft((current) => ({
+      ...current,
+      roles: current.roles.map((role) =>
+        role.id === roleId ? { ...role, label: nextRole.label, owner: nextRole.owner } : role,
+      ),
+    }));
+  }
+
+  function addStage(stage: Pick<WorkflowStage, "label" | "sub">, index: number) {
+    setDraft((current) => ({
+      ...current,
+      stages: insertAt(current.stages, index, {
+        id: createId("stage"),
+        label: stage.label,
+        sub: stage.sub,
+      }),
+    }));
+  }
+
+  function updateStage(stageId: string, nextStage: Pick<WorkflowStage, "label" | "sub">) {
+    setDraft((current) => ({
+      ...current,
+      stages: current.stages.map((stage) =>
+        stage.id === stageId ? { ...stage, label: nextStage.label, sub: nextStage.sub } : stage,
+      ),
+    }));
+  }
+
+  function saveTemplate() {
+    setSaveError(null);
+    startTransition(async () => {
+      try {
+        const result = await updateTemplateAction(draftRef.current.id, draftRef.current);
+        setDraft(result.template);
+        emitEvent("workflow.template_edited", {
+          template_id: result.template.id,
+          edited_by: "founder",
+        });
+        capture("workflow.template_edited", {
+          template_id: result.template.id,
+          edited_by: "founder",
+        });
+        router.push("/");
+      } catch (error) {
+        setSaveError(
+          error instanceof Error && error.message
+            ? error.message
+            : "Could not save the workflow template.",
+        );
+      }
+    });
+  }
+
+  useEffect(() => {
+    setConfig({
+      mode: "template-editor",
+      label: draft.label,
+      onLabelChange: (value) =>
+        setDraft((current) => ({ ...current, label: value })),
+      onSave: saveTemplate,
+      saveDisabled: !isDirty || pending,
+    });
+
+    return () => setConfig(null);
+  }, [draft.label, isDirty, pending, setConfig]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="shrink-0 border-b border-border px-5 py-3">
+        <div className="rounded-lg border border-[rgba(245,158,11,0.28)] bg-[rgba(245,158,11,0.08)] px-3 py-2.5 text-[12px] text-[#fbbf24]">
+          Modifying this workflow updates defaults for new instances. Existing
+          instances keep their current tasks.
+        </div>
+        {saveError ? (
+          <div className="mt-2 text-[11.5px] text-(color:--pill-blocked-t)">{saveError}</div>
+        ) : null}
+      </div>
+
+      <div className="matrix-wrap flex-1 overflow-auto">
+        <div className="matrix inline-block min-w-full">
+          <div className="matrix-head-row" role="row">
+            <div className="mx-corner" role="columnheader">
+              <span className="flex-1">Roles</span>
+            </div>
+
+            {draft.stages.map((stage, index) => (
+              <div key={stage.id} className="contents">
+                <div className="mx-stage-hd" role="columnheader">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="mx-stage-name">{stage.label}</div>
+                      <div className="mx-stage-sub mx-stage-sub-plain">
+                        {stage.sub?.trim() || "No description"}
+                      </div>
+                    </div>
+                    <div className="mx-entity-actions">
+                      <button
+                        type="button"
+                        aria-label={`Edit stage ${stage.label}`}
+                        className="mx-entity-action"
+                        onClick={() =>
+                          setStageModalState({
+                            mode: "edit",
+                            index,
+                            stageId: stage.id,
+                            initialStage: { label: stage.label, sub: stage.sub },
+                          })
+                        }
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        aria-label={`Remove stage ${stage.label}`}
+                        className="mx-entity-action mx-entity-action-danger"
+                        onClick={() =>
+                          setConfirmState({
+                            title: `Remove stage "${stage.label}"?`,
+                            description: "All tasks in this stage will be removed.",
+                            onConfirm: () => {
+                              setDraft((current) => ({
+                                ...current,
+                                stages: current.stages.filter((item) => item.id !== stage.id),
+                                taskTemplates: current.taskTemplates.filter(
+                                  (task) => task.stage !== stage.id,
+                                ),
+                              }));
+                              setConfirmState(null);
+                            },
+                          })
+                        }
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <button
+                  type="button"
+                  className={cn(
+                    "mx-col-insert",
+                    hoveredStageInsertIndex === index + 1 && "mx-col-insert-active",
+                  )}
+                  onMouseEnter={() => setHoveredStageInsertIndex(index + 1)}
+                  onMouseLeave={() => setHoveredStageInsertIndex((current) =>
+                    current === index + 1 ? null : current,
+                  )}
+                  onClick={() =>
+                    setStageModalState({
+                      mode: "create",
+                      index: index + 1,
+                    })
+                  }
+                >
+                  <span className="mx-col-insert-icon">
+                    <Plus className="h-3.5 w-3.5" />
+                  </span>
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {draft.roles.map((role, roleIndex) => (
+            <div key={role.id} className="contents">
+              <div className="mx-body-row" role="row">
+                <div className="mx-role-cell" role="rowheader">
+                  <ColorDot
+                    color={role.color || getRoleColor(role.id, draft.roles)}
+                    onChange={(color) =>
+                      setDraft((current) => ({
+                        ...current,
+                        roles: current.roles.map((item) =>
+                          item.id === role.id ? { ...item, color } : item,
+                        ),
+                      }))
+                    }
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="mx-role-name">{role.label}</div>
+                    <div className="mx-role-owner mx-role-owner-plain">
+                      {role.owner?.trim() || "No owner"}
+                    </div>
+                  </div>
+                  <div className="mx-entity-actions">
+                    <button
+                      type="button"
+                      className="mx-entity-action"
+                      aria-label={`Edit role ${role.label}`}
+                      onClick={() =>
+                        setRoleModalState({
+                          mode: "edit",
+                          index: roleIndex,
+                          roleId: role.id,
+                          initialRole: { label: role.label, owner: role.owner },
+                        })
+                      }
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      className="mx-entity-action mx-entity-action-danger"
+                      aria-label={`Remove role ${role.label}`}
+                      onClick={() =>
+                        setConfirmState({
+                          title: `Remove role "${role.label}"?`,
+                          description:
+                            "All tasks assigned to this role in this template will be removed.",
+                          onConfirm: () => {
+                            setDraft((current) => ({
+                              ...current,
+                              roles: current.roles.filter((item) => item.id !== role.id),
+                              taskTemplates: current.taskTemplates.filter(
+                                (task) => task.role !== role.id,
+                              ),
+                            }));
+                            setConfirmState(null);
+                          },
+                        })
+                      }
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+
+                {draft.stages.map((stage) => {
+                  const templateTask = draft.taskTemplates.find(
+                    (task) => task.role === role.id && task.stage === stage.id,
+                  );
+                  const task = templateTask ? templateTaskToCard(templateTask) : null;
+                  const insertIndex = draft.stages.findIndex((item) => item.id === stage.id) + 1;
+
+                  return (
+                    <div key={`${role.id}-${stage.id}`} className="contents">
+                      <div className="mx-task-cell">
+                        {task ? (
+                          <TaskCard
+                            task={task}
+                            roleColor={role.color || getRoleColor(role.id, draft.roles)}
+                            barState="bar-ready"
+                            editMode
+                            showDefaultPill
+                            onRemove={() =>
+                              setDraft((current) => ({
+                                ...current,
+                                taskTemplates: current.taskTemplates.filter(
+                                  (item) => item.id !== templateTask?.id,
+                                ),
+                              }))
+                            }
+                          />
+                        ) : (
+                          <button
+                            type="button"
+                            data-testid={`matrix-add-task-${role.id}-${stage.id}`}
+                            onClick={() =>
+                              setAddTaskFor({
+                                roleId: role.id,
+                                roleName: role.label,
+                                stageId: stage.id,
+                                stageName: stage.label,
+                              })
+                            }
+                            className="mx-empty-cell w-full"
+                          >
+                            <span className="mx-add-btn opacity-100">
+                              <Plus className="h-3.5 w-3.5" />
+                            </span>
+                          </button>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        aria-label={`Insert stage after ${stage.label}`}
+                        className={cn(
+                          "mx-col-insert-body",
+                          hoveredStageInsertIndex === insertIndex && "mx-col-insert-active",
+                        )}
+                        onMouseEnter={() => setHoveredStageInsertIndex(insertIndex)}
+                        onMouseLeave={() => setHoveredStageInsertIndex((current) =>
+                          current === insertIndex ? null : current,
+                        )}
+                        onClick={() =>
+                          setStageModalState({
+                            mode: "create",
+                            index: insertIndex,
+                          })
+                        }
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+
+              <button
+                type="button"
+                className="mx-row-insert"
+                onClick={() =>
+                  setRoleModalState({
+                    mode: "create",
+                    index: roleIndex + 1,
+                  })
+                }
+              >
+                <span className="mx-row-insert-label">
+                  <Plus className="h-3 w-3" /> Insert role
+                </span>
+              </button>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            className="mx-row-insert"
+            onClick={() =>
+              setRoleModalState({
+                mode: "create",
+                index: draft.roles.length,
+              })
+            }
+          >
+            <span className="mx-row-insert-label">
+              <Plus className="h-3 w-3" /> Insert role
+            </span>
+          </button>
+        </div>
+      </div>
+
+      {roleModalState ? (
+        <AddRoleModal
+          mode={roleModalState.mode}
+          initialRole={roleModalState.initialRole}
+          onClose={() => setRoleModalState(null)}
+          onSubmit={(role) => {
+            if (roleModalState.mode === "edit" && roleModalState.roleId) {
+              updateRole(roleModalState.roleId, role);
+              return;
+            }
+            addRole(role, roleModalState.index);
+          }}
+        />
+      ) : null}
+
+      {stageModalState ? (
+        <AddStageModal
+          mode={stageModalState.mode}
+          initialStage={stageModalState.initialStage}
+          onClose={() => setStageModalState(null)}
+          onSubmit={(stage) => {
+            if (stageModalState.mode === "edit" && stageModalState.stageId) {
+              updateStage(stageModalState.stageId, stage);
+              return;
+            }
+            addStage(stage, stageModalState.index);
+          }}
+        />
+      ) : null}
+
+      {addTaskFor ? (
+        <AddTaskModal
+          instanceId={`template:${draft.id}`}
+          roleId={addTaskFor.roleId}
+          roleName={addTaskFor.roleName}
+          stageId={addTaskFor.stageId}
+          stageName={addTaskFor.stageName}
+          skillOptions={skillOptions}
+          playbookOptions={playbookOptions}
+          onClose={() => setAddTaskFor(null)}
+          onCreate={(input) => {
+            setDraft((current) => ({
+              ...current,
+              taskTemplates: [
+                ...current.taskTemplates,
+                {
+                  id: createId("task"),
+                  role: input.roleId,
+                  stage: input.stageId,
+                  title: input.title.trim(),
+                  desc: input.description?.trim(),
+                  checkpoint: Boolean(input.checkpoint),
+                  triggers: input.triggers ?? [],
+                  gates: input.gates ?? [],
+                  agent: input.agent ?? undefined,
+                  skill: input.skill ?? undefined,
+                  playbook: input.playbook ?? undefined,
+                },
+              ],
+            }));
+            setAddTaskFor(null);
+          }}
+        />
+      ) : null}
+
+      {confirmState ? (
+        <ConfirmModal
+          title={confirmState.title}
+          description={confirmState.description}
+          onCancel={() => setConfirmState(null)}
+          onConfirm={confirmState.onConfirm}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -531,7 +531,7 @@ export function TemplateEditorScreen({
                 }
               >
                 <span className="mx-row-insert-label">
-                  <Plus className="h-3 w-3" /> Insert role
+                  <Plus className="h-3 w-3" />
                 </span>
               </button>
             </div>
@@ -550,7 +550,7 @@ export function TemplateEditorScreen({
             }
           >
             <span className="mx-row-insert-label">
-              <Plus className="h-3 w-3" /> Insert role
+              <Plus className="h-3 w-3" />
             </span>
           </button>
         </div>

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef, useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
 import { Pencil, Plus, Trash2 } from "lucide-react";
 
 import { updateTemplateAction } from "@/app/(dashboard)/workflows/actions";
@@ -174,7 +173,6 @@ export function TemplateEditorScreen({
   skillOptions,
   playbookOptions,
 }: TemplateEditorScreenProps) {
-  const router = useRouter();
   const { setConfig } = useDashboardTopBar();
   const { capture } = useAnalytics();
   const draftRef = useRef(template);
@@ -269,7 +267,6 @@ export function TemplateEditorScreen({
           template_id: result.template.id,
           edited_by: "founder",
         });
-        router.push("/");
       } catch (error) {
         setSaveError(
           error instanceof Error && error.message

--- a/products/dashboard/components/workflows/workflow-instance-header.tsx
+++ b/products/dashboard/components/workflows/workflow-instance-header.tsx
@@ -1,0 +1,31 @@
+interface WorkflowInstanceHeaderProps {
+  instanceLabel: string;
+  taskCount: number;
+  roleCount: number;
+  stageCount: number;
+}
+
+export function WorkflowInstanceHeader({
+  instanceLabel,
+  taskCount,
+  roleCount,
+  stageCount,
+}: WorkflowInstanceHeaderProps) {
+  return (
+    <header className="flex flex-shrink-0 items-start border-b border-border bg-bg px-6 py-4">
+      <div className="min-w-0">
+        <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+          Workflow instance
+        </p>
+        <h1 className="mt-1 text-[20px] font-bold tracking-tight text-t1">
+          {instanceLabel}
+        </h1>
+        <p className="mt-1 text-[13px] text-t2">
+          {taskCount} {taskCount === 1 ? "task" : "tasks"} · {roleCount}{" "}
+          {roleCount === 1 ? "role" : "roles"} · {stageCount}{" "}
+          {stageCount === 1 ? "stage" : "stages"}
+        </p>
+      </div>
+    </header>
+  );
+}

--- a/products/dashboard/e2e/workflows.spec.ts
+++ b/products/dashboard/e2e/workflows.spec.ts
@@ -234,3 +234,40 @@ test.describe("workflows — matrix edit mode (AEL-52)", () => {
     await expect(page.getByText("E2E created task")).toBeVisible();
   });
 });
+
+test.describe("workflows — template editor (AEL-55)", () => {
+  test("opens the template editor, renames a stage, saves, and sees the change on next visit", async ({
+    page,
+  }) => {
+    test.skip(
+      !hasSupabaseRuntime,
+      "Supabase runtime credentials required for the template-editor happy path",
+    );
+
+    await authenticateWithBypass(page);
+    await page.goto("/");
+
+    const editTemplate = page
+      .locator('[data-testid^="workflow-template-count-"]')
+      .first();
+    await expect(editTemplate).toBeVisible();
+    await editTemplate.click();
+
+    await expect(page).toHaveURL(/\/workflows\/templates\/[^/]+\/edit$/);
+
+    const firstStage = page.locator(".mx-stage-name").first();
+    await firstStage.click();
+
+    const uniqueLabel = `Discovery ${Date.now()}`;
+    const editor = page.locator('input[value="Pre-Sales"]').or(page.locator(".mx-stage-hd input").first());
+    await editor.fill(uniqueLabel);
+    await editor.press("Enter");
+
+    await page.getByRole("button", { name: /save workflow/i }).click();
+    await expect(page).toHaveURL("/");
+
+    await editTemplate.click();
+    await expect(page).toHaveURL(/\/workflows\/templates\/[^/]+\/edit$/);
+    await expect(page.getByText(uniqueLabel)).toBeVisible();
+  });
+});

--- a/products/dashboard/e2e/workflows.spec.ts
+++ b/products/dashboard/e2e/workflows.spec.ts
@@ -259,7 +259,9 @@ test.describe("workflows — template editor (AEL-55)", () => {
     await firstStage.click();
 
     const uniqueLabel = `Discovery ${Date.now()}`;
-    const editor = page.locator('input[value="Pre-Sales"]').or(page.locator(".mx-stage-hd input").first());
+    const preferredEditor = page.locator('input[value="Pre-Sales"]').first();
+    const fallbackEditor = page.locator(".mx-stage-hd input").first();
+    const editor = (await preferredEditor.count()) > 0 ? preferredEditor : fallbackEditor;
     await editor.fill(uniqueLabel);
     await editor.press("Enter");
 

--- a/products/dashboard/lib/analytics/events.ts
+++ b/products/dashboard/lib/analytics/events.ts
@@ -50,6 +50,10 @@ export type AnalyticsEvent =
       event: "workflow.instance_created";
       properties: { instance_id: string; template_id: string };
     }
+  | {
+      event: "workflow.template_edited";
+      properties: { template_id: string; edited_by: string };
+    }
   // ── Agent run panel ───────────────────────────────────────────────────────
   | { event: "dashboard.agent_run_opened"; properties: { task_id: string } }
   // ── My Tasks panel ────────────────────────────────────────────────────────

--- a/products/dashboard/lib/events.ts
+++ b/products/dashboard/lib/events.ts
@@ -34,6 +34,11 @@ type WorkflowTaskInstancePayload = {
   instance_id: string;
 };
 
+type WorkflowTemplateEditedPayload = {
+  template_id: string;
+  edited_by: string;
+};
+
 /**
  * Discriminated map — enforces name/payload pairing at compile time.
  * Adding a new event requires updating this map; TypeScript will catch mismatches.
@@ -49,6 +54,7 @@ type EventMap = {
   "workflow.task_started": WorkflowTaskInstancePayload;
   "workflow.run_cancelled": WorkflowTaskInstancePayload;
   "workflow.run_retried": WorkflowTaskInstancePayload;
+  "workflow.template_edited": WorkflowTemplateEditedPayload;
   "dashboard.agent_run_opened": { task_id: string };
   "dashboard.my_tasks_opened": Record<string, never>;
 };

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -15,6 +15,7 @@ import type {
   WorkflowTaskPatch,
   WorkflowTaskStatus,
   WorkflowTaskTemplate,
+  WorkflowTemplatePatch,
   WorkflowTemplate,
 } from "./types";
 
@@ -94,6 +95,16 @@ function toJsonObject(value: unknown): Record<string, unknown> {
 }
 
 function mapTemplate(row: WorkflowTemplateRow): WorkflowTemplate {
+  const taskTemplates = toJsonArray<WorkflowTaskTemplate>(row.task_templates).map(
+    (task, index) => ({
+      ...task,
+      id:
+        typeof task.id === "string" && task.id.trim()
+          ? task.id
+          : `${row.id}::${task.role}::${task.stage}::${index}`,
+    }),
+  );
+
   return {
     id: row.id,
     label: row.label,
@@ -101,7 +112,7 @@ function mapTemplate(row: WorkflowTemplateRow): WorkflowTemplate {
     multiInstance: row.multi_instance,
     stages: toJsonArray(row.stages),
     roles: toJsonArray(row.roles),
-    taskTemplates: toJsonArray(row.task_templates),
+    taskTemplates,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -179,6 +190,17 @@ function patchToRow(patch: WorkflowTaskPatch): Record<string, unknown> {
   if (patch.agent !== undefined) row.agent = patch.agent;
   if (patch.skill !== undefined) row.skill = patch.skill;
   if (patch.playbook !== undefined) row.playbook = patch.playbook;
+  return row;
+}
+
+function templatePatchToRow(
+  patch: WorkflowTemplatePatch,
+): Record<string, unknown> {
+  const row: Record<string, unknown> = {};
+  if (patch.label !== undefined) row.label = patch.label;
+  if (patch.stages !== undefined) row.stages = patch.stages;
+  if (patch.roles !== undefined) row.roles = patch.roles;
+  if (patch.taskTemplates !== undefined) row.task_templates = patch.taskTemplates;
   return row;
 }
 
@@ -526,6 +548,27 @@ export function createWorkflowRepository(
       if (error) {
         throw new WorkflowRepositoryError("deleteTask failed", error);
       }
+    },
+
+    async updateTemplate(
+      templateId: string,
+      patch: WorkflowTemplatePatch,
+    ): Promise<WorkflowTemplate> {
+      const row = templatePatchToRow(patch);
+      if (Object.keys(row).length === 0) {
+        throw new WorkflowRepositoryError("updateTemplate called with empty patch");
+      }
+
+      const { data, error } = await client
+        .from("workflow_templates")
+        .update(row)
+        .eq("id", templateId)
+        .select("*")
+        .single();
+
+      return mapTemplate(
+        unwrap("updateTemplate", data, error) as WorkflowTemplateRow,
+      );
     },
 
     async addEvent(taskId: string, event: WorkflowEventInput): Promise<WorkflowEvent> {

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -472,6 +472,27 @@ export function createWorkflowRepository(
       return { ...instance, tasks, events: [] };
     },
 
+    async updateInstance(
+      instanceId: string,
+      patch: Pick<WorkflowInstance, "label" | "status">,
+    ): Promise<WorkflowInstance> {
+      const row: Record<string, unknown> = {};
+      if (patch.label !== undefined) row.label = patch.label;
+      if (patch.status !== undefined) row.status = patch.status;
+      if (Object.keys(row).length === 0) {
+        throw new WorkflowRepositoryError("updateInstance called with empty patch");
+      }
+
+      const { data, error } = await client
+        .from("workflow_instances")
+        .update(row)
+        .eq("id", instanceId)
+        .select("*")
+        .single();
+
+      return mapInstance(unwrap("updateInstance", data, error) as WorkflowInstanceRow);
+    },
+
     async createTask(input: WorkflowTaskCreateInput): Promise<WorkflowTask> {
       const { data, error } = await client
         .from("workflow_tasks")
@@ -550,6 +571,17 @@ export function createWorkflowRepository(
       }
     },
 
+    async deleteInstance(instanceId: string): Promise<void> {
+      const { error } = await client
+        .from("workflow_instances")
+        .delete()
+        .eq("id", instanceId);
+
+      if (error) {
+        throw new WorkflowRepositoryError("deleteInstance failed", error);
+      }
+    },
+
     async updateTemplate(
       templateId: string,
       patch: WorkflowTemplatePatch,
@@ -569,6 +601,29 @@ export function createWorkflowRepository(
       return mapTemplate(
         unwrap("updateTemplate", data, error) as WorkflowTemplateRow,
       );
+    },
+
+    async deleteTemplate(templateId: string): Promise<void> {
+      const { error: deleteInstancesError } = await client
+        .from("workflow_instances")
+        .delete()
+        .eq("template_id", templateId);
+
+      if (deleteInstancesError) {
+        throw new WorkflowRepositoryError(
+          "deleteTemplate instances cleanup failed",
+          deleteInstancesError,
+        );
+      }
+
+      const { error } = await client
+        .from("workflow_templates")
+        .delete()
+        .eq("id", templateId);
+
+      if (error) {
+        throw new WorkflowRepositoryError("deleteTemplate failed", error);
+      }
     },
 
     async addEvent(taskId: string, event: WorkflowEventInput): Promise<WorkflowEvent> {

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -474,7 +474,7 @@ export function createWorkflowRepository(
 
     async updateInstance(
       instanceId: string,
-      patch: Pick<WorkflowInstance, "label" | "status">,
+      patch: Partial<Pick<WorkflowInstance, "label" | "status">>,
     ): Promise<WorkflowInstance> {
       const row: Record<string, unknown> = {};
       if (patch.label !== undefined) row.label = patch.label;

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -561,24 +561,34 @@ export function createWorkflowRepository(
     },
 
     async deleteTask(taskId: string): Promise<void> {
-      const { error } = await client
+      const { data, error } = await client
         .from("workflow_tasks")
         .delete()
-        .eq("id", taskId);
+        .eq("id", taskId)
+        .select("*")
+        .maybeSingle();
 
       if (error) {
         throw new WorkflowRepositoryError("deleteTask failed", error);
       }
+      if (!data) {
+        throw new WorkflowRepositoryError("deleteTask returned no row");
+      }
     },
 
     async deleteInstance(instanceId: string): Promise<void> {
-      const { error } = await client
+      const { data, error } = await client
         .from("workflow_instances")
         .delete()
-        .eq("id", instanceId);
+        .eq("id", instanceId)
+        .select("*")
+        .maybeSingle();
 
       if (error) {
         throw new WorkflowRepositoryError("deleteInstance failed", error);
+      }
+      if (!data) {
+        throw new WorkflowRepositoryError("deleteInstance returned no row");
       }
     },
 

--- a/products/dashboard/lib/workflows/role-colors.ts
+++ b/products/dashboard/lib/workflows/role-colors.ts
@@ -36,5 +36,5 @@ export function getRoleColor(roleId: string, roles: WorkflowRole[]): string {
   if (idx < 0) {
     return ROLE_COLORS[0];
   }
-  return ROLE_COLORS[idx % ROLE_COLORS.length];
+  return roles[idx]?.color || ROLE_COLORS[idx % ROLE_COLORS.length];
 }

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -246,7 +246,7 @@ export interface WorkflowRepository {
   createInstance(templateId: string, label: string): Promise<WorkflowInstanceDetail>;
   updateInstance(
     instanceId: string,
-    patch: Pick<WorkflowInstance, "label" | "status">,
+    patch: Partial<Pick<WorkflowInstance, "label" | "status">>,
   ): Promise<WorkflowInstance>;
   deleteInstance(instanceId: string): Promise<void>;
   createTask(input: WorkflowTaskCreateInput): Promise<WorkflowTask>;

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -41,6 +41,7 @@ export interface WorkflowRole {
   id: string;
   label: string;
   owner?: string;
+  color?: string;
 }
 
 export interface WorkflowTrigger {
@@ -57,6 +58,7 @@ export interface WorkflowGate {
 }
 
 export interface WorkflowTaskTemplate {
+  id?: string;
   role: string;
   stage: string;
   title: string;
@@ -165,6 +167,13 @@ export interface WorkflowTaskPatch {
   playbook?: string | null;
 }
 
+export interface WorkflowTemplatePatch {
+  label?: string;
+  stages?: WorkflowStage[];
+  roles?: WorkflowRole[];
+  taskTemplates?: WorkflowTaskTemplate[];
+}
+
 export interface WorkflowEventInput {
   name: string;
   description?: string;
@@ -238,6 +247,10 @@ export interface WorkflowRepository {
   createTask(input: WorkflowTaskCreateInput): Promise<WorkflowTask>;
   updateTask(taskId: string, patch: WorkflowTaskPatch): Promise<WorkflowTask>;
   deleteTask(taskId: string): Promise<void>;
+  updateTemplate(
+    templateId: string,
+    patch: WorkflowTemplatePatch,
+  ): Promise<WorkflowTemplate>;
   addEvent(taskId: string, event: WorkflowEventInput): Promise<WorkflowEvent>;
   addInstanceEvent(
     instanceId: string,

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -244,6 +244,11 @@ export interface WorkflowRepository {
    */
   listRecentEvents(limit: number): Promise<WorkflowEvent[]>;
   createInstance(templateId: string, label: string): Promise<WorkflowInstanceDetail>;
+  updateInstance(
+    instanceId: string,
+    patch: Pick<WorkflowInstance, "label" | "status">,
+  ): Promise<WorkflowInstance>;
+  deleteInstance(instanceId: string): Promise<void>;
   createTask(input: WorkflowTaskCreateInput): Promise<WorkflowTask>;
   updateTask(taskId: string, patch: WorkflowTaskPatch): Promise<WorkflowTask>;
   deleteTask(taskId: string): Promise<void>;
@@ -251,6 +256,7 @@ export interface WorkflowRepository {
     templateId: string,
     patch: WorkflowTemplatePatch,
   ): Promise<WorkflowTemplate>;
+  deleteTemplate(templateId: string): Promise<void>;
   addEvent(taskId: string, event: WorkflowEventInput): Promise<WorkflowEvent>;
   addInstanceEvent(
     instanceId: string,


### PR DESCRIPTION
## Summary

- add the checkpoint template editor slice and workflow header actions
- polish workflow editor controls, insert flows, details, and save behavior
- compact the agent bundle docs while restoring the PR-loop guidance

## Validation

- [x] `npm run validate`

## Notes

- This branch was cut from local `staging` after the pending commits were created there by mistake.
- Following repo policy, this PR targets `staging` so the normal integration checks and review loop can run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app workflow template editor: create/edit/rename/delete templates, stages, roles, and task defaults; inline task editing and instance rename/delete flows.
  * Dashboard top bar: edit/save controls and contextual header for workflow instances.
  * New accessible modals for text input, adding stages/roles/tasks, and header actions.
  * Analytics & event support for template edits.

* **Documentation**
  * Streamlined framework docs and playbooks with a simplified reading order and concise guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->