### PR TITLE
feat(dashboard): polish workflow template editor matrix interactions

### DIFF
--- a/products/dashboard/__tests__/app/workflows/actions.test.ts
+++ b/products/dashboard/__tests__/app/workflows/actions.test.ts
@@ -366,6 +366,7 @@ describe("workflow matrix edit actions", () => {
     const result = await updateTemplateAction(" client-delivery ", {
       ...updatedTemplate,
       label: "  Client Project Delivery  ",
+      color: "  #14b8a6  ",
       stages: [{ id: " stage-1 ", label: " Planning ", sub: " Scope " }],
       roles: [{ id: " role-1 ", label: " Product ", owner: " Andres ", color: "#6366f1" }],
       taskTemplates: [
@@ -384,6 +385,7 @@ describe("workflow matrix edit actions", () => {
 
     expect(updateTemplate).toHaveBeenCalledWith("client-delivery", {
       label: "Client Project Delivery",
+      color: "#14b8a6",
       stages: [{ id: "stage-1", label: "Planning", sub: "Scope" }],
       roles: [{ id: "role-1", label: "Product", owner: "Andres", color: "#6366f1" }],
       taskTemplates: [

--- a/products/dashboard/__tests__/app/workflows/actions.test.ts
+++ b/products/dashboard/__tests__/app/workflows/actions.test.ts
@@ -411,6 +411,26 @@ describe("workflow matrix edit actions", () => {
     expect(result.template.id).toBe("client-delivery");
   });
 
+  it("updateTemplateAction rejects blank template colors", async () => {
+    mockGetRepo.mockResolvedValue({
+      updateTemplate: vi.fn(),
+    } satisfies Partial<WorkflowRepository>);
+
+    await expect(
+      updateTemplateAction("client-delivery", {
+        id: "client-delivery",
+        label: "Client Project Delivery",
+        color: "   ",
+        multiInstance: true,
+        stages: [],
+        roles: [],
+        taskTemplates: [],
+        createdAt: "2026-04-19T12:00:00Z",
+        updatedAt: "2026-04-19T12:00:00Z",
+      }),
+    ).rejects.toThrow("updateTemplateAction: template color is required");
+  });
+
   it("startTaskAction uses the atomic status transition and records an event", async () => {
     const started = makeTask({ id: "task-start", status: "active", checkpoint: false });
     const updateTaskIfStatus = vi.fn().mockResolvedValue(started);

--- a/products/dashboard/__tests__/components/workflows/template-editor-screen.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/template-editor-screen.test.tsx
@@ -49,7 +49,7 @@ const TEMPLATE: WorkflowTemplate = {
 };
 
 describe("TemplateEditorScreen", () => {
-  it("matches the instance matrix chrome without header add buttons", () => {
+  it("renders insert affordances between and after existing headers", () => {
     render(
       <TemplateEditorScreen
         template={TEMPLATE}
@@ -58,19 +58,22 @@ describe("TemplateEditorScreen", () => {
       />,
     );
 
-    expect(screen.queryByLabelText("Add role")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("matrix-add-stage-header")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Add stage after Pre-Sales")).toBeInTheDocument();
+    expect(screen.getByLabelText("Add stage after Validation")).toBeInTheDocument();
+    expect(screen.getByLabelText("Add role after Sales")).toBeInTheDocument();
+    expect(screen.getByLabelText("Add role after Product")).toBeInTheDocument();
   });
 
-  it("does not show a header add-stage button when stages are empty", () => {
+  it("renders empty-state affordances when stages or roles are missing", () => {
     render(
       <TemplateEditorScreen
-        template={{ ...TEMPLATE, stages: [] }}
+        template={{ ...TEMPLATE, stages: [], roles: [] }}
         skillOptions={[]}
         playbookOptions={[]}
       />,
     );
 
-    expect(screen.queryByText("Add first stage")).not.toBeInTheDocument();
+    expect(screen.getByText("Add first stage")).toBeInTheDocument();
+    expect(screen.getByText("Add first role")).toBeInTheDocument();
   });
 });

--- a/products/dashboard/__tests__/components/workflows/template-editor-screen.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/template-editor-screen.test.tsx
@@ -62,6 +62,11 @@ describe("TemplateEditorScreen", () => {
     expect(screen.getByLabelText("Add stage after Validation")).toBeInTheDocument();
     expect(screen.getByLabelText("Add role after Sales")).toBeInTheDocument();
     expect(screen.getByLabelText("Add role after Product")).toBeInTheDocument();
+    expect(screen.getByLabelText("Template editing information")).toHaveAttribute(
+      "aria-describedby",
+      "template-editor-help",
+    );
+    expect(screen.getByRole("tooltip")).toHaveAttribute("id", "template-editor-help");
   });
 
   it("renders empty-state affordances when stages or roles are missing", () => {

--- a/products/dashboard/__tests__/components/workflows/template-editor-screen.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/template-editor-screen.test.tsx
@@ -49,7 +49,7 @@ const TEMPLATE: WorkflowTemplate = {
 };
 
 describe("TemplateEditorScreen", () => {
-  it("sizes insert-role rows to the role and stage columns only", () => {
+  it("matches the instance matrix chrome without header add buttons", () => {
     render(
       <TemplateEditorScreen
         template={TEMPLATE}
@@ -58,11 +58,19 @@ describe("TemplateEditorScreen", () => {
       />,
     );
 
-    expect(screen.getByTestId("matrix-insert-role-1")).toHaveStyle({
-      width: "562px",
-    });
-    expect(screen.getByTestId("matrix-insert-role-end")).toHaveStyle({
-      width: "562px",
-    });
+    expect(screen.queryByLabelText("Add role")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("matrix-add-stage-header")).not.toBeInTheDocument();
+  });
+
+  it("does not show a header add-stage button when stages are empty", () => {
+    render(
+      <TemplateEditorScreen
+        template={{ ...TEMPLATE, stages: [] }}
+        skillOptions={[]}
+        playbookOptions={[]}
+      />,
+    );
+
+    expect(screen.queryByText("Add first stage")).not.toBeInTheDocument();
   });
 });

--- a/products/dashboard/__tests__/lib/workflows/repository.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/repository.test.ts
@@ -369,11 +369,12 @@ describe("workflow repository", () => {
   });
 
   describe("updateTemplate", () => {
-    it("updates template label, stages, roles, and task templates", async () => {
+    it("updates template label, color, stages, roles, and task templates", async () => {
       const repo = createWorkflowRepository(makeFakeClient(store));
 
       const updated = await repo.updateTemplate("client-delivery", {
         label: "Client Delivery v2",
+        color: "#14b8a6",
         stages: [
           { id: "pre-sales", label: "Pre-Sales", sub: "Qualification" },
           { id: "delivery", label: "Delivery", sub: "Execution" },
@@ -397,6 +398,7 @@ describe("workflow repository", () => {
       });
 
       expect(updated.label).toBe("Client Delivery v2");
+      expect(updated.color).toBe("#14b8a6");
       expect(updated.stages[1]).toMatchObject({
         id: "delivery",
         label: "Delivery",

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -704,6 +704,10 @@ function trimTemplateLabel(value: string): string {
   return value.trim().slice(0, MAX_LABEL_LENGTH);
 }
 
+function normalizeTemplateColor(value: string): string {
+  return value.trim();
+}
+
 function normalizeTemplateStages(
   stages: WorkflowTemplate["stages"],
 ): WorkflowTemplate["stages"] {
@@ -769,6 +773,7 @@ export async function updateTemplateAction(
   const repo = await getServerWorkflowRepository();
   const updatedTemplate = await repo.updateTemplate(trimmedTemplateId, {
     label: trimTemplateLabel(template.label),
+    color: normalizeTemplateColor(template.color),
     stages: normalizeTemplateStages(template.stages),
     roles: normalizeTemplateRoles(template.roles),
     taskTemplates: normalizeTemplateTaskTemplates(template.taskTemplates),

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -705,7 +705,11 @@ function trimTemplateLabel(value: string): string {
 }
 
 function normalizeTemplateColor(value: string): string {
-  return value.trim();
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error("updateTemplateAction: template color is required");
+  }
+  return normalized;
 }
 
 function normalizeTemplateStages(

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -439,6 +439,33 @@ body {
 .mx-header-insert-row .mx-header-insert:focus-visible {
   transform: translate(-50%, -50%) scale(1);
 }
+.mx-empty-state-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px dashed var(--border-hi);
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  transition:
+    border-color 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    background 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    color 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.mx-empty-state-btn:hover {
+  border-color: color-mix(in srgb, var(--accent) 46%, var(--border-hi));
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg));
+}
+.mx-empty-state-btn:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 76%, white 24%);
+  outline-offset: 2px;
+}
 .mx-header-insert:focus-visible {
   outline: none;
 }
@@ -788,10 +815,21 @@ body {
 }
 @media (pointer: coarse) {
   .mx-add-btn,
-  .mx-header-insert,
   .mx-col-insert-icon {
     opacity: 1;
     transform: translateY(0) scale(1);
+  }
+
+  .mx-header-insert {
+    opacity: 1;
+  }
+
+  .mx-header-insert-column .mx-header-insert {
+    transform: translateY(0) scale(1);
+  }
+
+  .mx-header-insert-row .mx-header-insert {
+    transform: translate(-50%, -50%) scale(1);
   }
 
   .mx-col-insert,

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -317,20 +317,15 @@ body {
 .mx-stage-hd:last-child {
   border-right: none;
 }
-.mx-header-insert {
+.mx-header-insert-zone {
   position: absolute;
   z-index: 12;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  cursor: pointer;
   overflow: visible;
-  -webkit-tap-highlight-color: transparent;
 }
-.mx-header-insert::before {
+.mx-header-insert-zone::before {
   content: "";
   position: absolute;
   border-radius: 9999px;
@@ -355,34 +350,34 @@ body {
   background: color-mix(in srgb, var(--border-hi) 70%, transparent);
 }
 .mx-header-insert-row {
-  left: 50%;
+  left: 0;
+  right: 0;
   bottom: -17px;
-  width: 34px;
+  width: 100%;
   height: 34px;
-  transform: translateX(-50%);
 }
 .mx-header-insert-row::before {
-  left: 16px;
-  right: 16px;
+  left: 50%;
   top: 50%;
   height: 1px;
-  transform: translateY(-50%) scaleX(0.72);
+  width: 1px;
+  transform: translate(-50%, -50%) scaleY(0.72);
   background: color-mix(in srgb, var(--border-hi) 74%, transparent);
 }
-.mx-header-insert:hover::before,
-.mx-header-insert:focus-visible::before {
+.mx-header-insert-zone:hover::before,
+.mx-header-insert-zone:focus-within::before {
   opacity: 1;
   background: color-mix(in srgb, var(--accent) 26%, transparent);
 }
 .mx-header-insert-column:hover::before,
-.mx-header-insert-column:focus-visible::before {
+.mx-header-insert-column:focus-within::before {
   transform: translateX(-50%) scaleY(1);
 }
 .mx-header-insert-row:hover::before,
-.mx-header-insert-row:focus-visible::before {
-  transform: translateY(-50%) scaleX(1);
+.mx-header-insert-row:focus-within::before {
+  transform: translate(-50%, -50%) scaleY(1);
 }
-.mx-header-insert-icon {
+.mx-header-insert {
   position: relative;
   z-index: 1;
   display: inline-flex;
@@ -390,14 +385,14 @@ body {
   justify-content: center;
   width: 26px;
   height: 26px;
+  padding: 0;
   border-radius: 9999px;
-  border: 1px solid color-mix(in srgb, var(--border-hi) 72%, transparent);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--bg-4) 96%, white 4%), var(--bg-3));
-  color: color-mix(in srgb, var(--accent) 72%, var(--t2));
-  box-shadow:
-    0 10px 22px rgba(15, 23, 42, 0.08),
-    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  border: 1px solid transparent;
+  background: rgba(129, 140, 248, 0.04);
+  color: var(--t3);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  box-shadow: none;
   opacity: 0;
   transition:
     opacity 0.24s cubic-bezier(0.16, 1, 0.3, 1),
@@ -409,40 +404,45 @@ body {
   transform: scale(0.84);
   backdrop-filter: blur(10px);
 }
-.mx-header-insert-column .mx-header-insert-icon {
+.mx-header-insert-column .mx-header-insert {
   transform: translateY(4px) scale(0.84);
 }
-.mx-header-insert-row .mx-header-insert-icon {
-  transform: translateY(-4px) scale(0.84);
+.mx-header-insert-row .mx-header-insert {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, calc(-50% - 4px)) scale(0.84);
 }
-.mx-header-insert:hover .mx-header-insert-icon,
-.mx-header-insert:focus-visible .mx-header-insert-icon {
+.mx-header-insert-zone:hover .mx-header-insert,
+.mx-header-insert-zone:focus-within .mx-header-insert {
+  opacity: 1;
+}
+.mx-header-insert:hover,
+.mx-header-insert:focus-visible {
   opacity: 1;
   color: var(--accent);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--primary-bg) 88%, white 12%),
-      color-mix(in srgb, var(--primary-bg) 96%, var(--bg-3))
-    );
-  border-color: color-mix(in srgb, var(--accent) 22%, var(--border-hi));
+  background: rgba(129, 140, 248, 0.1);
+  border-color: rgba(129, 140, 248, 0.16);
   box-shadow:
-    0 14px 28px rgba(99, 102, 241, 0.12),
     0 0 0 1px rgba(129, 140, 248, 0.08),
-    inset 0 1px 0 rgba(255, 255, 255, 0.24);
+    0 8px 18px rgba(99, 102, 241, 0.08);
 }
-.mx-header-insert-column:hover .mx-header-insert-icon,
-.mx-header-insert-column:focus-visible .mx-header-insert-icon {
+.mx-header-insert-column:hover .mx-header-insert,
+.mx-header-insert-column:focus-within .mx-header-insert {
   transform: translateY(0) scale(1);
 }
-.mx-header-insert-row:hover .mx-header-insert-icon,
-.mx-header-insert-row:focus-visible .mx-header-insert-icon {
-  transform: translateY(0) scale(1);
+.mx-header-insert-row:hover .mx-header-insert,
+.mx-header-insert-row:focus-within .mx-header-insert {
+  transform: translate(-50%, -50%) scale(1);
+}
+.mx-header-insert-row .mx-header-insert:hover,
+.mx-header-insert-row .mx-header-insert:focus-visible {
+  transform: translate(-50%, -50%) scale(1);
 }
 .mx-header-insert:focus-visible {
   outline: none;
 }
-.mx-header-insert:focus-visible .mx-header-insert-icon {
+.mx-header-insert:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent) 76%, white 24%);
   outline-offset: 2px;
 }
@@ -788,7 +788,7 @@ body {
 }
 @media (pointer: coarse) {
   .mx-add-btn,
-  .mx-header-insert-icon,
+  .mx-header-insert,
   .mx-col-insert-icon {
     opacity: 1;
     transform: translateY(0) scale(1);

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -677,18 +677,44 @@ body {
   border: none;
   cursor: pointer;
   background: transparent;
-  position: relative;
-  z-index: 2;
+  position: sticky;
+  left: 0;
+  z-index: 6;
   transition:
     height 0.18s cubic-bezier(0.16, 1, 0.3, 1),
     margin 0.18s cubic-bezier(0.16, 1, 0.3, 1),
     background 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.mx-row-insert::before {
+  content: "";
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  top: 50%;
+  height: 1px;
+  background: color-mix(in srgb, var(--border-hi) 72%, transparent);
+  transform: translateY(-50%);
+  transition:
+    opacity 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    background 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.mx-row-insert-empty {
+  height: 40px;
+  margin-top: 0;
+  margin-bottom: 0;
+  justify-content: center;
+  gap: 8px;
+  background: var(--primary-bg);
 }
 .mx-row-insert:hover {
   height: 24px;
   margin-top: 0;
   margin-bottom: 0;
   background: var(--primary-bg);
+}
+.mx-row-insert:hover::before,
+.mx-row-insert:focus-visible::before {
+  opacity: 0;
 }
 .mx-row-insert-label {
   display: inline-flex;
@@ -741,6 +767,24 @@ body {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
   transform: translateY(-50%) scale(1);
+}
+.mx-row-insert-empty::before {
+  display: none;
+}
+.mx-row-insert-empty .mx-row-insert-label,
+.mx-row-insert-empty:hover .mx-row-insert-label,
+.mx-row-insert-empty:focus-visible .mx-row-insert-label {
+  position: static;
+  opacity: 1;
+  transform: none;
+  background: rgba(129, 140, 248, 0.1);
+  border-color: rgba(129, 140, 248, 0.16);
+  color: var(--accent);
+  box-shadow: none;
+}
+.mx-row-insert-empty:focus-visible .mx-row-insert-label {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* ── Task card ── */

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -317,6 +317,135 @@ body {
 .mx-stage-hd:last-child {
   border-right: none;
 }
+.mx-header-insert {
+  position: absolute;
+  z-index: 12;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  overflow: visible;
+  -webkit-tap-highlight-color: transparent;
+}
+.mx-header-insert::before {
+  content: "";
+  position: absolute;
+  border-radius: 9999px;
+  opacity: 0;
+  transition:
+    opacity 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    background 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.mx-header-insert-column {
+  top: 8px;
+  right: -17px;
+  bottom: 8px;
+  width: 34px;
+}
+.mx-header-insert-column::before {
+  top: 10px;
+  bottom: 10px;
+  left: 50%;
+  width: 1px;
+  transform: translateX(-50%) scaleY(0.7);
+  background: color-mix(in srgb, var(--border-hi) 70%, transparent);
+}
+.mx-header-insert-row {
+  left: 50%;
+  bottom: -17px;
+  width: 34px;
+  height: 34px;
+  transform: translateX(-50%);
+}
+.mx-header-insert-row::before {
+  left: 16px;
+  right: 16px;
+  top: 50%;
+  height: 1px;
+  transform: translateY(-50%) scaleX(0.72);
+  background: color-mix(in srgb, var(--border-hi) 74%, transparent);
+}
+.mx-header-insert:hover::before,
+.mx-header-insert:focus-visible::before {
+  opacity: 1;
+  background: color-mix(in srgb, var(--accent) 26%, transparent);
+}
+.mx-header-insert-column:hover::before,
+.mx-header-insert-column:focus-visible::before {
+  transform: translateX(-50%) scaleY(1);
+}
+.mx-header-insert-row:hover::before,
+.mx-header-insert-row:focus-visible::before {
+  transform: translateY(-50%) scaleX(1);
+}
+.mx-header-insert-icon {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 9999px;
+  border: 1px solid color-mix(in srgb, var(--border-hi) 72%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--bg-4) 96%, white 4%), var(--bg-3));
+  color: color-mix(in srgb, var(--accent) 72%, var(--t2));
+  box-shadow:
+    0 10px 22px rgba(15, 23, 42, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  opacity: 0;
+  transition:
+    opacity 0.24s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.24s cubic-bezier(0.16, 1, 0.3, 1),
+    background 0.24s cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 0.24s cubic-bezier(0.16, 1, 0.3, 1),
+    color 0.24s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.24s cubic-bezier(0.16, 1, 0.3, 1);
+  transform: scale(0.84);
+  backdrop-filter: blur(10px);
+}
+.mx-header-insert-column .mx-header-insert-icon {
+  transform: translateY(4px) scale(0.84);
+}
+.mx-header-insert-row .mx-header-insert-icon {
+  transform: translateY(-4px) scale(0.84);
+}
+.mx-header-insert:hover .mx-header-insert-icon,
+.mx-header-insert:focus-visible .mx-header-insert-icon {
+  opacity: 1;
+  color: var(--accent);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--primary-bg) 88%, white 12%),
+      color-mix(in srgb, var(--primary-bg) 96%, var(--bg-3))
+    );
+  border-color: color-mix(in srgb, var(--accent) 22%, var(--border-hi));
+  box-shadow:
+    0 14px 28px rgba(99, 102, 241, 0.12),
+    0 0 0 1px rgba(129, 140, 248, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.24);
+}
+.mx-header-insert-column:hover .mx-header-insert-icon,
+.mx-header-insert-column:focus-visible .mx-header-insert-icon {
+  transform: translateY(0) scale(1);
+}
+.mx-header-insert-row:hover .mx-header-insert-icon,
+.mx-header-insert-row:focus-visible .mx-header-insert-icon {
+  transform: translateY(0) scale(1);
+}
+.mx-header-insert:focus-visible {
+  outline: none;
+}
+.mx-header-insert:focus-visible .mx-header-insert-icon {
+  outline: 2px solid color-mix(in srgb, var(--accent) 76%, white 24%);
+  outline-offset: 2px;
+}
 .mx-stage-name {
   font-size: 12px;
   font-weight: 600;
@@ -367,7 +496,12 @@ body {
   align-items: center;
   gap: 7px;
   min-height: 106px;
+  overflow: visible;
   transition: width 0.2s;
+}
+.mx-role-cell:hover,
+.mx-role-cell:focus-within {
+  z-index: 14;
 }
 .mx-role-cell:has([data-role-color-open="true"]) {
   z-index: 25;
@@ -654,6 +788,7 @@ body {
 }
 @media (pointer: coarse) {
   .mx-add-btn,
+  .mx-header-insert-icon,
   .mx-col-insert-icon {
     opacity: 1;
     transform: translateY(0) scale(1);

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -357,11 +357,11 @@ body {
   height: 34px;
 }
 .mx-header-insert-row::before {
-  left: 50%;
+  left: 8px;
+  right: 8px;
   top: 50%;
   height: 1px;
-  width: 1px;
-  transform: translate(-50%, -50%) scaleY(0.72);
+  transform: translateY(-50%) scaleX(0.72);
   background: color-mix(in srgb, var(--border-hi) 74%, transparent);
 }
 .mx-header-insert-zone:hover::before,
@@ -375,7 +375,7 @@ body {
 }
 .mx-header-insert-row:hover::before,
 .mx-header-insert-row:focus-within::before {
-  transform: translate(-50%, -50%) scaleY(1);
+  transform: translateY(-50%) scaleX(1);
 }
 .mx-header-insert {
   position: relative;

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -152,13 +152,12 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
                   : "border border-[#10b981] bg-[#10b981] text-white shadow-[0_0_0_1px_rgba(16,185,129,0.16),0_8px_22px_rgba(16,185,129,0.24)] hover:bg-[#22c55e]",
               )}
             >
-              <span
-                aria-hidden
-                className={cn(
-                  "h-1.5 w-1.5 rounded-full",
-                  config.saveDisabled ? "bg-t3" : "bg-white shadow-[0_0_10px_rgba(255,255,255,0.7)]",
-                )}
-              />
+              {!config.saveDisabled ? (
+                <span
+                  aria-hidden
+                  className="h-1.5 w-1.5 rounded-full bg-white shadow-[0_0_10px_rgba(255,255,255,0.7)]"
+                />
+              ) : null}
               Save
             </button>
           ) : null}

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Bell, Pencil } from "lucide-react";
 
@@ -138,7 +138,13 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
         </nav>
 
         <div className="flex shrink-0 items-center gap-1.5">
-          {config?.actions ?? null}
+          {config?.mode === "template-editor" ? (
+            <>
+              {config.actions ?? null}
+            </>
+          ) : (
+            config?.actions ?? null
+          )}
 
           {config?.mode === "template-editor" ? (
             <button

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -363,11 +363,13 @@ export function TemplateEditorScreen({
                 <button
                   type="button"
                   aria-label="Template editing information"
+                  aria-describedby="template-editor-help"
                   className="inline-flex h-3.5 w-3.5 cursor-help items-center justify-center text-[#fbbf24] transition hover:text-[#fcd34d] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#fbbf24]"
                 >
                   <CircleAlert className="h-3 w-3" />
                 </button>
                 <div
+                  id="template-editor-help"
                   role="tooltip"
                   className="pointer-events-none absolute left-0 top-[calc(100%+8px)] z-30 hidden w-[280px] rounded-lg border border-[rgba(245,158,11,0.28)] bg-bg-2 px-3 py-2 text-[12px] leading-5 text-[#fbbf24] shadow-[var(--shadow-canvas)] group-hover:block group-focus-within:block"
                 >

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -174,6 +174,32 @@ function ColorDot({
   );
 }
 
+function MatrixHeaderInsertButton({
+  axis,
+  ariaLabel,
+  onClick,
+}: {
+  axis: "column" | "row";
+  ariaLabel: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      className={cn(
+        "mx-header-insert",
+        axis === "column" ? "mx-header-insert-column" : "mx-header-insert-row",
+      )}
+      onClick={onClick}
+    >
+      <span className="mx-header-insert-icon">
+        <Plus className="h-3 w-3" />
+      </span>
+    </button>
+  );
+}
+
 export function TemplateEditorScreen({
   template,
   instanceCount,
@@ -427,6 +453,18 @@ export function TemplateEditorScreen({
                     </button>
                   </div>
                 </div>
+                {index < draft.stages.length - 1 ? (
+                  <MatrixHeaderInsertButton
+                    axis="column"
+                    ariaLabel={`Add stage after ${stage.label}`}
+                    onClick={() =>
+                      setStageModalState({
+                        mode: "create",
+                        index: index + 1,
+                      })
+                    }
+                  />
+                ) : null}
               </div>
             ))}
           </div>
@@ -494,6 +532,18 @@ export function TemplateEditorScreen({
                     </button>
                   </div>
                 </div>
+                {roleIndex < draft.roles.length - 1 ? (
+                  <MatrixHeaderInsertButton
+                    axis="row"
+                    ariaLabel={`Add role after ${role.label}`}
+                    onClick={() =>
+                      setRoleModalState({
+                        mode: "create",
+                        index: roleIndex + 1,
+                      })
+                    }
+                  />
+                ) : null}
               </div>
 
               {draft.stages.map((stage) => {

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -101,9 +101,11 @@ function insertAt<T>(items: T[], index: number, value: T): T[] {
 function ColorDot({
   color,
   onChange,
+  ariaLabel = "Change role color",
 }: {
   color: string;
   onChange: (color: string) => void;
+  ariaLabel?: string;
 }) {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [open, setOpen] = useState(false);
@@ -140,7 +142,7 @@ function ColorDot({
     >
       <button
         type="button"
-        aria-label="Change role color"
+        aria-label={ariaLabel}
         onClick={() => setOpen((current) => !current)}
         className="flex h-5 w-5 cursor-pointer items-center justify-center rounded-full border border-border bg-bg-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition hover:border-border-hi hover:bg-bg-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
       />
@@ -335,27 +337,36 @@ export function TemplateEditorScreen({
     <div className="flex h-full flex-col overflow-hidden">
       <div className="shrink-0 border-b border-border bg-bg px-6 py-4">
         <div className="min-w-0">
-            <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
-              Workflow template
-            </p>
-            <div className="mt-1 flex items-center gap-2">
-              <h1 className="truncate text-[20px] font-bold tracking-tight text-t1">{draft.label}</h1>
-              <div className="group relative">
+            <div className="flex items-center gap-1.5 leading-none">
+              <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+                Workflow template
+              </p>
+              <div className="group relative inline-flex items-center">
                 <button
                   type="button"
                   aria-label="Template editing information"
-                  className="flex h-5 w-5 items-center justify-center rounded-full text-[#fbbf24] transition hover:bg-[rgba(245,158,11,0.08)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#fbbf24]"
+                  className="inline-flex h-3.5 w-3.5 cursor-help items-center justify-center text-[#fbbf24] transition hover:text-[#fcd34d] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#fbbf24]"
                 >
-                  <CircleAlert className="h-3.5 w-3.5" />
+                  <CircleAlert className="h-3 w-3" />
                 </button>
                 <div
                   role="tooltip"
-                  className="pointer-events-none absolute left-[calc(100%+8px)] top-1/2 z-30 hidden w-[280px] -translate-y-1/2 rounded-lg border border-[rgba(245,158,11,0.28)] bg-bg-2 px-3 py-2 text-[12px] leading-5 text-[#fbbf24] shadow-[var(--shadow-canvas)] group-hover:block group-focus-within:block"
+                  className="pointer-events-none absolute left-0 top-[calc(100%+8px)] z-30 hidden w-[280px] rounded-lg border border-[rgba(245,158,11,0.28)] bg-bg-2 px-3 py-2 text-[12px] leading-5 text-[#fbbf24] shadow-[var(--shadow-canvas)] group-hover:block group-focus-within:block"
                 >
                   Modifying this workflow updates defaults for new instances. Existing
                   instances keep their current tasks.
                 </div>
               </div>
+            </div>
+            <div className="mt-1 flex items-center gap-2">
+              <h1 className="truncate text-[20px] font-bold tracking-tight text-t1">{draft.label}</h1>
+              <ColorDot
+                color={draft.color}
+                ariaLabel="Change workflow template color"
+                onChange={(color) =>
+                  setDraft((current) => ({ ...current, color }))
+                }
+              />
             </div>
             <p className="mt-1 text-[13px] text-t2">
               {draft.taskTemplates.length}{" "}

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -184,19 +184,21 @@ function MatrixHeaderInsertButton({
   onClick: () => void;
 }) {
   return (
-    <button
-      type="button"
-      aria-label={ariaLabel}
+    <div
       className={cn(
-        "mx-header-insert",
+        "mx-header-insert-zone",
         axis === "column" ? "mx-header-insert-column" : "mx-header-insert-row",
       )}
-      onClick={onClick}
     >
-      <span className="mx-header-insert-icon">
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        className="mx-header-insert"
+        onClick={onClick}
+      >
         <Plus className="h-3 w-3" />
-      </span>
-    </button>
+      </button>
+    </div>
   );
 }
 

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -30,8 +30,6 @@ import { cn } from "@/lib/utils";
 import { TaskCard } from "./task-card";
 
 const ROLE_COLUMN_WIDTH = 172;
-const STAGE_COLUMN_WIDTH = 192;
-const STAGE_INSERT_WIDTH = 6;
 
 interface TemplateEditorScreenProps {
   template: WorkflowTemplate;
@@ -190,9 +188,6 @@ export function TemplateEditorScreen({
   const [confirmState, setConfirmState] = useState<ConfirmState>(null);
   const [roleModalState, setRoleModalState] = useState<RoleModalState>(null);
   const [stageModalState, setStageModalState] = useState<StageModalState>(null);
-  const [hoveredStageInsertIndex, setHoveredStageInsertIndex] = useState<number | null>(
-    null,
-  );
   const [addTaskFor, setAddTaskFor] = useState<{
     mode: "create" | "edit";
     taskId?: string;
@@ -212,11 +207,6 @@ export function TemplateEditorScreen({
   const [saveError, setSaveError] = useState<string | null>(null);
 
   const isDirty = JSON.stringify(draft) !== JSON.stringify(lastSaved);
-  const rowInsertWidth = `${
-    ROLE_COLUMN_WIDTH +
-    draft.stages.length * STAGE_COLUMN_WIDTH +
-    Math.max(draft.stages.length - 1, 0) * STAGE_INSERT_WIDTH
-  }px`;
 
   useEffect(() => {
     draftRef.current = draft;
@@ -387,320 +377,199 @@ export function TemplateEditorScreen({
               <span className="flex-1">Roles</span>
             </div>
 
-            {draft.stages.length === 0 ? (
-              <button
-                type="button"
-                className="mx-col-insert mx-col-insert-empty"
-                onClick={() =>
-                  setStageModalState({
-                    mode: "create",
-                    index: 0,
-                  })
-                }
-              >
-                <span className="mx-col-insert-icon">
-                  <Plus className="h-3.5 w-3.5" />
-                </span>
-                <span className="mx-col-insert-label-text">Add first stage</span>
-              </button>
-            ) : (
-              <button
-                type="button"
-                className={cn(
-                  "mx-col-insert",
-                  hoveredStageInsertIndex === 0 && "mx-col-insert-active",
-                )}
-                onMouseEnter={() => setHoveredStageInsertIndex(0)}
-                onMouseLeave={() =>
-                  setHoveredStageInsertIndex((current) => (current === 0 ? null : current))
-                }
-                onClick={() =>
-                  setStageModalState({
-                    mode: "create",
-                    index: 0,
-                  })
-                }
-              >
-                <span className="mx-col-insert-icon">
-                  <Plus className="h-3.5 w-3.5" />
-                </span>
-              </button>
-            )}
-
             {draft.stages.map((stage, index) => (
-              <div key={stage.id} className="contents">
-                <div className="mx-stage-hd" role="columnheader">
-                  <div className="mx-entity-content">
-                    <div className="min-w-0">
-                      <div className="mx-stage-name">{stage.label}</div>
-                      <div className="mx-stage-sub mx-stage-sub-plain">
-                        {stage.sub?.trim() || "No description"}
-                      </div>
-                    </div>
-                    <div className="mx-entity-actions mx-entity-actions-group">
-                      <button
-                        type="button"
-                        aria-label={`Edit stage ${stage.label}`}
-                        className="mx-entity-action"
-                        onClick={() =>
-                          setStageModalState({
-                            mode: "edit",
-                            index,
-                            stageId: stage.id,
-                            initialStage: { label: stage.label, sub: stage.sub },
-                          })
-                        }
-                      >
-                        <Pencil className="h-[11px] w-[11px]" />
-                      </button>
-                      <button
-                        type="button"
-                        aria-label={`Remove stage ${stage.label}`}
-                        className="mx-entity-action mx-entity-action-danger"
-                        onClick={() =>
-                          setConfirmState({
-                            title: `Remove stage "${stage.label}"?`,
-                            description: "All tasks in this stage will be removed.",
-                            onConfirm: () => {
-                              setDraft((current) => ({
-                                ...current,
-                                stages: current.stages.filter((item) => item.id !== stage.id),
-                                taskTemplates: current.taskTemplates.filter(
-                                  (task) => task.stage !== stage.id,
-                                ),
-                              }));
-                              setConfirmState(null);
-                            },
-                          })
-                        }
-                      >
-                        <Trash2 className="h-[11px] w-[11px]" />
-                      </button>
+              <div key={stage.id} className="mx-stage-hd" role="columnheader">
+                <div className="mx-entity-content">
+                  <div className="min-w-0">
+                    <div className="mx-stage-name">{stage.label}</div>
+                    <div className="mx-stage-sub mx-stage-sub-plain">
+                      {stage.sub?.trim() || "No description"}
                     </div>
                   </div>
+                  <div className="mx-entity-actions mx-entity-actions-group">
+                    <button
+                      type="button"
+                      aria-label={`Edit stage ${stage.label}`}
+                      className="mx-entity-action"
+                      onClick={() =>
+                        setStageModalState({
+                          mode: "edit",
+                          index,
+                          stageId: stage.id,
+                          initialStage: { label: stage.label, sub: stage.sub },
+                        })
+                      }
+                    >
+                      <Pencil className="h-[11px] w-[11px]" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Remove stage ${stage.label}`}
+                      className="mx-entity-action mx-entity-action-danger"
+                      onClick={() =>
+                        setConfirmState({
+                          title: `Remove stage "${stage.label}"?`,
+                          description: "All tasks in this stage will be removed.",
+                          onConfirm: () => {
+                            setDraft((current) => ({
+                              ...current,
+                              stages: current.stages.filter((item) => item.id !== stage.id),
+                              taskTemplates: current.taskTemplates.filter(
+                                (task) => task.stage !== stage.id,
+                              ),
+                            }));
+                            setConfirmState(null);
+                          },
+                        })
+                      }
+                    >
+                      <Trash2 className="h-[11px] w-[11px]" />
+                    </button>
+                  </div>
                 </div>
-
-                <button
-                  type="button"
-                  className={cn(
-                    "mx-col-insert",
-                    hoveredStageInsertIndex === index + 1 && "mx-col-insert-active",
-                  )}
-                  onMouseEnter={() => setHoveredStageInsertIndex(index + 1)}
-                  onMouseLeave={() => setHoveredStageInsertIndex((current) =>
-                    current === index + 1 ? null : current,
-                  )}
-                  onClick={() =>
-                    setStageModalState({
-                      mode: "create",
-                      index: index + 1,
-                    })
-                  }
-                >
-                  <span className="mx-col-insert-icon">
-                    <Plus className="h-3.5 w-3.5" />
-                  </span>
-                </button>
               </div>
             ))}
           </div>
 
           {draft.roles.map((role, roleIndex) => (
-            <div key={role.id} className="contents">
-              <div className="mx-body-row" role="row">
-                <div className="mx-role-cell" role="rowheader">
-                  <ColorDot
-                    color={role.color || getRoleColor(role.id, draft.roles)}
-                    onChange={(color) =>
-                      setDraft((current) => ({
-                        ...current,
-                        roles: current.roles.map((item) =>
-                          item.id === role.id ? { ...item, color } : item,
-                        ),
-                      }))
-                    }
-                  />
-                  <div className="mx-entity-content">
-                    <div className="min-w-0">
-                      <div className="mx-role-name">{role.label}</div>
-                      <div className="mx-role-owner mx-role-owner-plain">
-                        {role.owner?.trim() || "No owner"}
-                      </div>
+            <div key={role.id} className="mx-body-row" role="row">
+              <div className="mx-role-cell" role="rowheader">
+                <ColorDot
+                  color={role.color || getRoleColor(role.id, draft.roles)}
+                  onChange={(color) =>
+                    setDraft((current) => ({
+                      ...current,
+                      roles: current.roles.map((item) =>
+                        item.id === role.id ? { ...item, color } : item,
+                      ),
+                    }))
+                  }
+                />
+                <div className="mx-entity-content">
+                  <div className="min-w-0">
+                    <div className="mx-role-name">{role.label}</div>
+                    <div className="mx-role-owner mx-role-owner-plain">
+                      {role.owner?.trim() || "No owner"}
                     </div>
-                    <div className="mx-entity-actions mx-entity-actions-group">
-                      <button
-                        type="button"
-                        className="mx-entity-action"
-                        aria-label={`Edit role ${role.label}`}
-                        onClick={() =>
-                          setRoleModalState({
+                  </div>
+                  <div className="mx-entity-actions mx-entity-actions-group">
+                    <button
+                      type="button"
+                      className="mx-entity-action"
+                      aria-label={`Edit role ${role.label}`}
+                      onClick={() =>
+                        setRoleModalState({
+                          mode: "edit",
+                          index: roleIndex,
+                          roleId: role.id,
+                          initialRole: { label: role.label, owner: role.owner },
+                        })
+                      }
+                    >
+                      <Pencil className="h-[11px] w-[11px]" />
+                    </button>
+                    <button
+                      type="button"
+                      className="mx-entity-action mx-entity-action-danger"
+                      aria-label={`Remove role ${role.label}`}
+                      onClick={() =>
+                        setConfirmState({
+                          title: `Remove role "${role.label}"?`,
+                          description:
+                            "All tasks assigned to this role in this template will be removed.",
+                          onConfirm: () => {
+                            setDraft((current) => ({
+                              ...current,
+                              roles: current.roles.filter((item) => item.id !== role.id),
+                              taskTemplates: current.taskTemplates.filter(
+                                (task) => task.role !== role.id,
+                              ),
+                            }));
+                            setConfirmState(null);
+                          },
+                        })
+                      }
+                    >
+                      <Trash2 className="h-[11px] w-[11px]" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              {draft.stages.map((stage) => {
+                const templateTask = draft.taskTemplates.find(
+                  (task) => task.role === role.id && task.stage === stage.id,
+                );
+                const task = templateTask ? templateTaskToCard(templateTask) : null;
+
+                return (
+                  <div key={`${role.id}-${stage.id}`} className="mx-task-cell">
+                    {task ? (
+                      <TaskCard
+                        task={task}
+                        roleColor={role.color || getRoleColor(role.id, draft.roles)}
+                        barState="bar-ready"
+                        editMode
+                        showDefaultPill
+                        onEdit={() =>
+                          setAddTaskFor({
                             mode: "edit",
-                            index: roleIndex,
+                            taskId: templateTask?.id,
                             roleId: role.id,
-                            initialRole: { label: role.label, owner: role.owner },
+                            roleName: role.label,
+                            stageId: stage.id,
+                            stageName: stage.label,
+                            initialTask: {
+                              title: templateTask?.title ?? "",
+                              description: templateTask?.desc ?? "",
+                              agent: templateTask?.agent ?? null,
+                              skill: templateTask?.skill ?? null,
+                              playbook: templateTask?.playbook ?? null,
+                            },
                           })
                         }
-                      >
-                        <Pencil className="h-[11px] w-[11px]" />
-                      </button>
-                      <button
-                        type="button"
-                        className="mx-entity-action mx-entity-action-danger"
-                        aria-label={`Remove role ${role.label}`}
-                        onClick={() =>
+                        onRemove={() =>
                           setConfirmState({
-                            title: `Remove role "${role.label}"?`,
+                            title: `Delete "${task.title}"?`,
                             description:
-                              "All tasks assigned to this role in this template will be removed.",
+                              "This task and its default configuration will be removed from the template.",
                             onConfirm: () => {
                               setDraft((current) => ({
                                 ...current,
-                                roles: current.roles.filter((item) => item.id !== role.id),
                                 taskTemplates: current.taskTemplates.filter(
-                                  (task) => task.role !== role.id,
+                                  (item) => item.id !== templateTask?.id,
                                 ),
                               }));
                               setConfirmState(null);
                             },
                           })
                         }
-                      >
-                        <Trash2 className="h-[11px] w-[11px]" />
-                      </button>
-                    </div>
-                  </div>
-                </div>
-
-                {draft.stages.map((stage) => {
-                  const templateTask = draft.taskTemplates.find(
-                    (task) => task.role === role.id && task.stage === stage.id,
-                  );
-                  const task = templateTask ? templateTaskToCard(templateTask) : null;
-                  const insertIndex = draft.stages.findIndex((item) => item.id === stage.id) + 1;
-
-                  return (
-                    <div key={`${role.id}-${stage.id}`} className="contents">
-                      <div className="mx-task-cell">
-                        {task ? (
-                          <TaskCard
-                            task={task}
-                            roleColor={role.color || getRoleColor(role.id, draft.roles)}
-                            barState="bar-ready"
-                            editMode
-                            showDefaultPill
-                            onEdit={() =>
-                              setAddTaskFor({
-                                mode: "edit",
-                                taskId: templateTask?.id,
-                                roleId: role.id,
-                                roleName: role.label,
-                                stageId: stage.id,
-                                stageName: stage.label,
-                                initialTask: {
-                                  title: templateTask?.title ?? "",
-                                  description: templateTask?.desc ?? "",
-                                  agent: templateTask?.agent ?? null,
-                                  skill: templateTask?.skill ?? null,
-                                  playbook: templateTask?.playbook ?? null,
-                                },
-                              })
-                            }
-                            onRemove={() =>
-                              setConfirmState({
-                                title: `Delete "${task.title}"?`,
-                                description:
-                                  "This task and its default configuration will be removed from the template.",
-                                onConfirm: () => {
-                                  setDraft((current) => ({
-                                    ...current,
-                                    taskTemplates: current.taskTemplates.filter(
-                                      (item) => item.id !== templateTask?.id,
-                                    ),
-                                  }));
-                                  setConfirmState(null);
-                                },
-                              })
-                            }
-                          />
-                        ) : (
-                          <button
-                            type="button"
-                            data-testid={`matrix-add-task-${role.id}-${stage.id}`}
-                            onClick={() =>
-                              setAddTaskFor({
-                                mode: "create",
-                                roleId: role.id,
-                                roleName: role.label,
-                                stageId: stage.id,
-                                stageName: stage.label,
-                              })
-                            }
-                            className="mx-empty-cell w-full"
-                          >
-                            <span className="mx-add-btn">
-                              <Plus className="h-3.5 w-3.5" />
-                            </span>
-                          </button>
-                        )}
-                      </div>
+                      />
+                    ) : (
                       <button
                         type="button"
-                        aria-label={`Insert stage after ${stage.label}`}
-                        className={cn(
-                          "mx-col-insert-body",
-                          hoveredStageInsertIndex === insertIndex && "mx-col-insert-active",
-                        )}
-                        onMouseEnter={() => setHoveredStageInsertIndex(insertIndex)}
-                        onMouseLeave={() => setHoveredStageInsertIndex((current) =>
-                          current === insertIndex ? null : current,
-                        )}
+                        data-testid={`matrix-add-task-${role.id}-${stage.id}`}
                         onClick={() =>
-                          setStageModalState({
+                          setAddTaskFor({
                             mode: "create",
-                            index: insertIndex,
+                            roleId: role.id,
+                            roleName: role.label,
+                            stageId: stage.id,
+                            stageName: stage.label,
                           })
                         }
-                      />
-                    </div>
-                  );
-                })}
-              </div>
-
-              <button
-                type="button"
-                className="mx-row-insert"
-                data-testid={`matrix-insert-role-${roleIndex + 1}`}
-                style={{ width: rowInsertWidth }}
-                onClick={() =>
-                  setRoleModalState({
-                    mode: "create",
-                    index: roleIndex + 1,
-                  })
-                }
-              >
-                <span className="mx-row-insert-label">
-                  <Plus className="h-3 w-3" />
-                </span>
-              </button>
+                        className="mx-empty-cell w-full"
+                      >
+                        <span className="mx-add-btn">
+                          <Plus className="h-3.5 w-3.5" />
+                        </span>
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           ))}
-
-          <button
-            type="button"
-            className="mx-row-insert"
-            data-testid="matrix-insert-role-end"
-            style={{ width: rowInsertWidth }}
-            onClick={() =>
-              setRoleModalState({
-                mode: "create",
-                index: draft.roles.length,
-              })
-            }
-          >
-            <span className="mx-row-insert-label">
-              <Plus className="h-3 w-3" />
-            </span>
-          </button>
         </div>
       </div>
 

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -405,6 +405,22 @@ export function TemplateEditorScreen({
               <span className="flex-1">Roles</span>
             </div>
 
+            {draft.stages.length === 0 ? (
+              <div className="mx-stage-hd" role="columnheader">
+                <button
+                  type="button"
+                  className="mx-empty-state-btn"
+                  onClick={() =>
+                    setStageModalState({
+                      mode: "create",
+                      index: 0,
+                    })
+                  }
+                >
+                  Add first stage
+                </button>
+              </div>
+            ) : null}
             {draft.stages.map((stage, index) => (
               <div key={stage.id} className="mx-stage-hd" role="columnheader">
                 <div className="mx-entity-content">
@@ -467,10 +483,43 @@ export function TemplateEditorScreen({
                     }
                   />
                 ) : null}
+                {index === draft.stages.length - 1 ? (
+                  <MatrixHeaderInsertButton
+                    axis="column"
+                    ariaLabel={`Add stage after ${stage.label}`}
+                    onClick={() =>
+                      setStageModalState({
+                        mode: "create",
+                        index: draft.stages.length,
+                      })
+                    }
+                  />
+                ) : null}
               </div>
             ))}
           </div>
 
+          {draft.roles.length === 0 ? (
+            <div className="mx-body-row" role="row">
+              <div className="mx-role-cell" role="rowheader">
+                <button
+                  type="button"
+                  className="mx-empty-state-btn"
+                  onClick={() =>
+                    setRoleModalState({
+                      mode: "create",
+                      index: 0,
+                    })
+                  }
+                >
+                  Add first role
+                </button>
+              </div>
+              {draft.stages.map((stage) => (
+                <div key={`empty-role-${stage.id}`} className="mx-task-cell" />
+              ))}
+            </div>
+          ) : null}
           {draft.roles.map((role, roleIndex) => (
             <div key={role.id} className="mx-body-row" role="row">
               <div className="mx-role-cell" role="rowheader">
@@ -542,6 +591,18 @@ export function TemplateEditorScreen({
                       setRoleModalState({
                         mode: "create",
                         index: roleIndex + 1,
+                      })
+                    }
+                  />
+                ) : null}
+                {roleIndex === draft.roles.length - 1 ? (
+                  <MatrixHeaderInsertButton
+                    axis="row"
+                    ariaLabel={`Add role after ${role.label}`}
+                    onClick={() =>
+                      setRoleModalState({
+                        mode: "create",
+                        index: draft.roles.length,
                       })
                     }
                   />

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -142,7 +142,7 @@ function ColorDot({
         type="button"
         aria-label="Change role color"
         onClick={() => setOpen((current) => !current)}
-        className="flex h-5 w-5 items-center justify-center rounded-full border border-border bg-bg-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition hover:border-border-hi hover:bg-bg-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+        className="flex h-5 w-5 cursor-pointer items-center justify-center rounded-full border border-border bg-bg-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition hover:border-border-hi hover:bg-bg-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
       />
       <span
         aria-hidden
@@ -160,7 +160,7 @@ function ColorDot({
                 onChange(swatch);
                 setOpen(false);
               }}
-              className="h-4 w-4 rounded-full"
+              className="h-4 w-4 cursor-pointer rounded-full"
               style={{
                 backgroundColor: swatch,
                 outline: swatch === color ? `2px solid ${swatch}` : undefined,

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -198,6 +198,7 @@ function templatePatchToRow(
 ): Record<string, unknown> {
   const row: Record<string, unknown> = {};
   if (patch.label !== undefined) row.label = patch.label;
+  if (patch.color !== undefined) row.color = patch.color;
   if (patch.stages !== undefined) row.stages = patch.stages;
   if (patch.roles !== undefined) row.roles = patch.roles;
   if (patch.taskTemplates !== undefined) row.task_templates = patch.taskTemplates;

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -169,6 +169,7 @@ export interface WorkflowTaskPatch {
 
 export interface WorkflowTemplatePatch {
   label?: string;
+  color?: string;
   stages?: WorkflowStage[];
   roles?: WorkflowRole[];
   taskTemplates?: WorkflowTaskTemplate[];


### PR DESCRIPTION
## Summary
- align the template editor matrix chrome with the instance matrix by removing header add controls and introducing between-header insert affordances
- improve role/stage insert interaction hit areas and hover/focus behavior so add controls are discoverable without shifting layout
- refine template editor header controls: move info tooltip next to the workflow template label, scope tooltip trigger to icon-only, and add template color picker next to the title while keeping top-bar actions/save behavior

## Test plan
- [x] npm test -- process-matrix.test.tsx
- [x] npm test -- top-bar.test.tsx template-editor-screen.test.tsx
- [x] npm test -- template-editor-screen.test.tsx

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates can store/edit a custom color; editor UI simplified with new header insert controls and improved empty-state add buttons.

* **Bug Fixes**
  * Color input is trimmed and validated; blank/whitespace colors are rejected.
  * Save indicator hidden when saving is disabled.

* **Style**
  * Redesigned matrix header/row insert visuals, focus outlines, and mobile/coarse-pointer visibility.

* **Tests**
  * Added/updated tests for color trimming/validation and editor insert/empty-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->