### PR TITLE
feat(dashboard): refine framework skills UI and editor workflows

### DIFF
--- a/products/dashboard/__tests__/components/framework/framework-screen.test.tsx
+++ b/products/dashboard/__tests__/components/framework/framework-screen.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { FrameworkScreen } from "@/components/framework/framework-screen";
+import type { FrameworkItem } from "@/lib/workflows/types";
+
+vi.mock("@/app/(dashboard)/framework/actions", () => ({
+  deleteFrameworkItemAction: vi.fn(),
+  upsertFrameworkItemAction: vi.fn(),
+}));
+
+vi.mock("@/components/dashboard-topbar-context", () => ({
+  useDashboardTopBar: () => ({
+    setConfig: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/analytics/events", () => ({
+  useAnalytics: () => ({
+    capture: vi.fn(),
+  }),
+}));
+
+const ITEMS: FrameworkItem[] = [
+  {
+    id: "sk-developer",
+    type: "skill",
+    name: "Developer",
+    description: "Implements the smallest coherent change.",
+    icon: "🛠️",
+    content: "# Developer\n\n- Implements code\n- Validates changes",
+  },
+];
+
+describe("FrameworkScreen", () => {
+  it("shows rendered markdown by default and editable plain text on toggle", async () => {
+    const user = userEvent.setup();
+
+    render(<FrameworkScreen initialItems={ITEMS} type="skill" />);
+
+    await user.click(screen.getByTestId("framework-card-sk-developer"));
+
+    const preview = screen.getByTestId("framework-markdown-preview-skill");
+    expect(preview).toBeInTheDocument();
+    expect(within(preview).getByRole("heading", { name: "Developer" })).toBeInTheDocument();
+    expect(preview).toHaveTextContent("Implements code");
+    expect(preview).toHaveTextContent("Validates changes");
+
+    await user.click(screen.getByRole("tab", { name: "Edit" }));
+
+    const editor = screen.getByTestId("framework-editor-skill");
+    expect(screen.queryByTestId("framework-markdown-preview-skill")).not.toBeInTheDocument();
+    expect(editor).toBeInTheDocument();
+    expect(editor).toHaveValue("# Developer\n\n- Implements code\n- Validates changes");
+
+    await user.click(screen.getByRole("tab", { name: "View" }));
+
+    expect(screen.getByTestId("framework-markdown-preview-skill")).toBeInTheDocument();
+  });
+});

--- a/products/dashboard/__tests__/components/framework/framework-screen.test.tsx
+++ b/products/dashboard/__tests__/components/framework/framework-screen.test.tsx
@@ -58,4 +58,25 @@ describe("FrameworkScreen", () => {
 
     expect(screen.getByTestId("framework-markdown-preview-skill")).toBeInTheDocument();
   });
+
+  it("applies markdown formatting from the editor toolbar", async () => {
+    const user = userEvent.setup();
+
+    render(<FrameworkScreen initialItems={ITEMS} type="skill" />);
+
+    await user.click(screen.getByTestId("framework-card-sk-developer"));
+    await user.click(screen.getByRole("tab", { name: "Edit" }));
+
+    const editor = screen.getByTestId("framework-editor-skill") as HTMLTextAreaElement;
+    const selectedText = "Implements code";
+    const start = editor.value.indexOf(selectedText);
+    const end = start + selectedText.length;
+
+    editor.focus();
+    editor.setSelectionRange(start, end);
+
+    await user.click(screen.getByRole("button", { name: "Bold" }));
+
+    expect(editor).toHaveValue("# Developer\n\n- **Implements code**\n- Validates changes");
+  });
 });

--- a/products/dashboard/__tests__/components/framework/framework-screen.test.tsx
+++ b/products/dashboard/__tests__/components/framework/framework-screen.test.tsx
@@ -79,4 +79,22 @@ describe("FrameworkScreen", () => {
 
     expect(editor).toHaveValue("# Developer\n\n- **Implements code**\n- Validates changes");
   });
+
+  it("imports markdown from an uploaded file and replaces the current draft", async () => {
+    const user = userEvent.setup();
+
+    render(<FrameworkScreen initialItems={ITEMS} type="skill" />);
+
+    await user.click(screen.getByTestId("framework-card-sk-developer"));
+
+    const input = screen.getByLabelText("Upload markdown file") as HTMLInputElement;
+    const file = new File(["# Imported Skill\n\n1. First step"], "imported-skill.md", {
+      type: "text/markdown",
+    });
+
+    await user.upload(input, file);
+
+    const editor = screen.getByTestId("framework-editor-skill");
+    expect(editor).toHaveValue("# Imported Skill\n\n1. First step");
+  });
 });

--- a/products/dashboard/__tests__/components/framework/framework-screen.test.tsx
+++ b/products/dashboard/__tests__/components/framework/framework-screen.test.tsx
@@ -94,7 +94,7 @@ describe("FrameworkScreen", () => {
 
     await user.upload(input, file);
 
-    const editor = screen.getByTestId("framework-editor-skill");
+    const editor = await screen.findByTestId("framework-editor-skill");
     expect(editor).toHaveValue("# Imported Skill\n\n1. First step");
   });
 });

--- a/products/dashboard/__tests__/components/top-bar.test.tsx
+++ b/products/dashboard/__tests__/components/top-bar.test.tsx
@@ -109,7 +109,7 @@ describe("TopBar", () => {
       React.useEffect(() => {
         setConfig({
           mode: "template-editor",
-          crumbs: ["Workflows", "Client Project Delivery"],
+          crumbs: [{ label: "Workflows" }, { label: "Client Project Delivery" }],
           label: "Client Project Delivery",
           onLabelChange: vi.fn(),
           onSave: vi.fn(),
@@ -143,7 +143,11 @@ describe("TopBar", () => {
       React.useEffect(() => {
         setConfig({
           mode: "workflow-instance",
-          crumbs: ["Workflows", "Client Project Delivery", "Acme rollout"],
+          crumbs: [
+            { label: "Workflows" },
+            { label: "Client Project Delivery" },
+            { label: "Acme rollout" },
+          ],
         });
         return () => setConfig(null);
       }, [setConfig]);
@@ -160,5 +164,34 @@ describe("TopBar", () => {
     expect(screen.getByText("Workflows")).toBeInTheDocument();
     expect(screen.getByText("Client Project Delivery")).toBeInTheDocument();
     expect(screen.getByText("Acme rollout")).toBeInTheDocument();
+  });
+
+  it("renders the page save pill when a page config provides save handlers", () => {
+    vi.mocked(usePathname).mockReturnValue("/framework/skills");
+
+    function Harness() {
+      const { setConfig } = useDashboardTopBar();
+      React.useEffect(() => {
+        setConfig({
+          mode: "page",
+          crumbs: [{ label: "Skills" }, { label: "Developer" }],
+          onSave: vi.fn(),
+          saveDisabled: false,
+        });
+        return () => setConfig(null);
+      }, [setConfig]);
+
+      return <TopBar />;
+    }
+
+    render(
+      <DashboardTopBarProvider>
+        <Harness />
+      </DashboardTopBarProvider>,
+    );
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(saveButton).toBeInTheDocument();
+    expect(saveButton.querySelector("span")).not.toBeNull();
   });
 });

--- a/products/dashboard/__tests__/components/top-bar.test.tsx
+++ b/products/dashboard/__tests__/components/top-bar.test.tsx
@@ -5,7 +5,7 @@
  * Covers:
  *   - The breadcrumb is derived from the active route (Overview / Skills /
  *     Playbooks / Event Feed / Settings).
- *   - The header landmark and the placeholder "My Tasks" pill render.
+ *   - The header landmark renders.
  *   - Unknown routes still produce a sensible humanised fallback so a new
  *     route added before the table is updated does not blank the chrome.
  */
@@ -68,18 +68,6 @@ describe("TopBar", () => {
     expect(screen.getByTestId("topbar-header")).toBeInTheDocument();
   });
 
-  it("renders the My Tasks pill and it toggles expanded state when clicked", async () => {
-    vi.mocked(usePathname).mockReturnValue("/");
-    const user = userEvent.setup();
-    renderWithTopBarProvider(<TopBar />);
-    const pill = screen.getByTestId("topbar-my-tasks-btn");
-    expect(pill).toBeInTheDocument();
-    expect(pill).toHaveAttribute("aria-expanded", "false");
-
-    await user.click(pill);
-    expect(pill).toHaveAttribute("aria-expanded", "true");
-  });
-
   it("renders the workflow edit pill and toggles the edit query param", async () => {
     vi.mocked(usePathname).mockReturnValue("/workflows/123");
     vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams());
@@ -132,7 +120,6 @@ describe("TopBar", () => {
     ).toHaveValue("Client Project Delivery");
     expect(screen.getByText("Workflows")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument();
-    expect(screen.queryByTestId("topbar-my-tasks-btn")).not.toBeInTheDocument();
   });
 
   it("renders configured workflow-instance breadcrumbs", () => {

--- a/products/dashboard/__tests__/lib/workflows/repository.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/repository.test.ts
@@ -25,6 +25,7 @@ interface FilterState {
   pendingInsert?: Record<string, unknown>[];
   pendingUpdate?: Record<string, unknown>;
   pendingUpsert?: Record<string, unknown>[];
+  pendingDelete: boolean;
   selecting: boolean;
 }
 
@@ -56,6 +57,10 @@ function makeQueryBuilder(state: FilterState, store: RowMap) {
     },
     upsert(rows: Record<string, unknown> | Record<string, unknown>[]) {
       state.pendingUpsert = Array.isArray(rows) ? rows : [rows];
+      return builder;
+    },
+    delete() {
+      state.pendingDelete = true;
       return builder;
     },
     async maybeSingle() {
@@ -134,6 +139,22 @@ function applyOperation(
     return updated;
   }
 
+  if (state.pendingDelete) {
+    const removed: Record<string, unknown>[] = [];
+    const kept: Record<string, unknown>[] = [];
+
+    for (const row of tableRows) {
+      if (state.filters.every((f) => f(row))) {
+        removed.push(row);
+      } else {
+        kept.push(row);
+      }
+    }
+
+    store[state.table] = kept;
+    return removed;
+  }
+
   // Read path
   let rows = tableRows.filter((row) => state.filters.every((f) => f(row)));
 
@@ -163,6 +184,7 @@ function makeFakeClient(store: RowMap): SupabaseClient {
         rows: [],
         filters: [],
         orderBy: [],
+        pendingDelete: false,
         selecting: false,
       };
       return makeQueryBuilder(state, store);
@@ -618,6 +640,15 @@ describe("workflow repository", () => {
       expect(updated.description).toBe("Updated description");
       expect(updated.content).toBe("# Updated PM Skill");
       expect(store.framework_items).toHaveLength(2);
+    });
+
+    it("deleteFrameworkItem removes the row", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+
+      await repo.deleteFrameworkItem("sk-pm");
+
+      expect(store.framework_items).toHaveLength(1);
+      expect(store.framework_items[0]?.id).toBe("pb-presales");
     });
   });
 });

--- a/products/dashboard/app/(dashboard)/framework/actions.ts
+++ b/products/dashboard/app/(dashboard)/framework/actions.ts
@@ -1,0 +1,70 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
+import type { FrameworkItem, FrameworkItemType } from "@/lib/workflows/types";
+
+const MAX_NAME_LENGTH = 120;
+const MAX_DESCRIPTION_LENGTH = 240;
+
+function normalizeRequiredField(
+  value: string,
+  label: string,
+  maxLength: number,
+): string {
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string`);
+  }
+
+  const normalized = value.trim().slice(0, maxLength);
+  if (!normalized) {
+    throw new Error(`${label} is required`);
+  }
+
+  return normalized;
+}
+
+function normalizeType(type: FrameworkItemType): FrameworkItemType {
+  if (type !== "skill" && type !== "playbook") {
+    throw new Error(`Unsupported framework item type "${type}"`);
+  }
+  return type;
+}
+
+function revalidateFrameworkPaths() {
+  revalidatePath("/", "layout");
+  revalidatePath("/framework/skills");
+  revalidatePath("/framework/playbooks");
+}
+
+export async function upsertFrameworkItemAction(
+  item: FrameworkItem,
+): Promise<{ item: FrameworkItem }> {
+  const repo = await getServerWorkflowRepository();
+  const type = normalizeType(item.type);
+
+  const saved = await repo.upsertFrameworkItem({
+    id: normalizeRequiredField(item.id, "Framework item id", 160),
+    type,
+    name: normalizeRequiredField(item.name, "Framework item name", MAX_NAME_LENGTH),
+    description: normalizeRequiredField(
+      item.description,
+      "Framework item description",
+      MAX_DESCRIPTION_LENGTH,
+    ),
+    icon: item.icon?.trim() ? item.icon.trim().slice(0, 16) : null,
+    content: typeof item.content === "string" ? item.content : "",
+  });
+
+  revalidateFrameworkPaths();
+  return { item: saved };
+}
+
+export async function deleteFrameworkItemAction(itemId: string): Promise<void> {
+  const repo = await getServerWorkflowRepository();
+  const normalizedId = normalizeRequiredField(itemId, "Framework item id", 160);
+
+  await repo.deleteFrameworkItem(normalizedId);
+  revalidateFrameworkPaths();
+}

--- a/products/dashboard/app/(dashboard)/framework/skills/page.tsx
+++ b/products/dashboard/app/(dashboard)/framework/skills/page.tsx
@@ -1,23 +1,15 @@
+import { FrameworkScreen } from "@/components/framework/framework-screen";
 import { ShellEvents } from "@/components/shell-events";
+import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
 
-/**
- * Skills — placeholder.
- *
- * Real Skills library lands in PR 12 (AEL-56). This page exists so the
- * sidebar's Framework → Skills link doesn't 404 and so shell events
- * fire on the route during PR 3.
- */
-export default function SkillsPage() {
+export default async function SkillsPage() {
+  const repo = await getServerWorkflowRepository();
+  const items = await repo.getFrameworkItems("skill");
+
   return (
     <>
       <ShellEvents route="/framework/skills" />
-      <div className="flex h-full flex-col items-center justify-center gap-3 p-10 text-center">
-        <h1 className="text-[16px] font-semibold text-t1">Skills</h1>
-        <p className="max-w-md text-[12.5px] text-t3">
-          The Skills library will live here. Skill authoring, listing, and the
-          Markdown editor land in a follow-up PR.
-        </p>
-      </div>
+      <FrameworkScreen initialItems={items} type="skill" />
     </>
   );
 }

--- a/products/dashboard/app/(dashboard)/framework/skills/page.tsx
+++ b/products/dashboard/app/(dashboard)/framework/skills/page.tsx
@@ -7,9 +7,11 @@ export default async function SkillsPage() {
   const items = await repo.getFrameworkItems("skill");
 
   return (
-    <>
+    <div className="flex h-full min-h-0 flex-col">
       <ShellEvents route="/framework/skills" />
-      <FrameworkScreen initialItems={items} type="skill" />
-    </>
+      <div className="min-h-0 flex-1">
+        <FrameworkScreen initialItems={items} type="skill" />
+      </div>
+    </div>
   );
 }

--- a/products/dashboard/app/(dashboard)/layout.tsx
+++ b/products/dashboard/app/(dashboard)/layout.tsx
@@ -100,7 +100,7 @@ export default async function DashboardLayout({
         />
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
           <TopBar initialPendingCount={pendingCount} />
-          <main className="min-h-0 flex-1 overflow-y-auto bg-bg">{children}</main>
+          <main className="min-h-0 flex-1 overflow-hidden bg-bg">{children}</main>
         </div>
       </DashboardTopBarProvider>
     </>

--- a/products/dashboard/app/(dashboard)/layout.tsx
+++ b/products/dashboard/app/(dashboard)/layout.tsx
@@ -8,7 +8,6 @@ import { AuthIdentitySync } from "@/components/auth-identity-sync";
 import { captureError } from "@/lib/monitoring";
 import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
 import type { WorkflowInstance, WorkflowTemplate } from "@/lib/workflows/types";
-import { pickPendingCheckpoints } from "@/lib/workflows/aggregate";
 
 /**
  * Server-side load of the workflow tree data the sidebar renders.
@@ -21,50 +20,27 @@ import { pickPendingCheckpoints } from "@/lib/workflows/aggregate";
 async function loadSidebarWorkflowTree(): Promise<{
   templates: WorkflowTemplate[];
   instancesByTemplate: Record<string, SidebarInstanceView[]>;
-  pendingCount: number;
 }> {
   const repo = await getServerWorkflowRepository();
-
-  // Sidebar data and badge count are independent — failures in one must not
-  // wipe the other. Run them as separate best-effort fetches.
-  const [sidebarResult, pendingCount] = await Promise.all([
-    (async () => {
-      try {
-        const [templates, instances] = await Promise.all([
-          repo.getTemplates(),
-          repo.listInstances(),
-        ]);
-        const instancesByTemplate: Record<string, SidebarInstanceView[]> = {};
-        for (const instance of instances satisfies WorkflowInstance[]) {
-          const bucket = instancesByTemplate[instance.templateId] ?? [];
-          bucket.push({ ...instance });
-          instancesByTemplate[instance.templateId] = bucket;
-        }
-        return { templates, instancesByTemplate };
-      } catch (error) {
-        captureError(error, { feature: "sidebar.workflow_tree" });
-        return { templates: [] as WorkflowTemplate[], instancesByTemplate: {} as Record<string, SidebarInstanceView[]> };
-      }
-    })(),
-    (async () => {
-      try {
-        const [templates, instances, tasks] = await Promise.all([
-          repo.getTemplates(),
-          repo.listInstances(),
-          repo.listAllTasks(),
-        ]);
-        return pickPendingCheckpoints({ templates, instances, tasks, events: [] }).length;
-      } catch (error) {
-        captureError(error, {
-          feature: "sidebar.pending_count",
-          action: "loadBadgeCount",
-        });
-        return 0;
-      }
-    })(),
-  ]);
-
-  return { ...sidebarResult, pendingCount };
+  try {
+    const [templates, instances] = await Promise.all([
+      repo.getTemplates(),
+      repo.listInstances(),
+    ]);
+    const instancesByTemplate: Record<string, SidebarInstanceView[]> = {};
+    for (const instance of instances satisfies WorkflowInstance[]) {
+      const bucket = instancesByTemplate[instance.templateId] ?? [];
+      bucket.push({ ...instance });
+      instancesByTemplate[instance.templateId] = bucket;
+    }
+    return { templates, instancesByTemplate };
+  } catch (error) {
+    captureError(error, { feature: "sidebar.workflow_tree" });
+    return {
+      templates: [] as WorkflowTemplate[],
+      instancesByTemplate: {} as Record<string, SidebarInstanceView[]>,
+    };
+  }
 }
 
 /**
@@ -87,7 +63,7 @@ export default async function DashboardLayout({
     redirect("/login");
   }
 
-  const { templates, instancesByTemplate, pendingCount } = await loadSidebarWorkflowTree();
+  const { templates, instancesByTemplate } = await loadSidebarWorkflowTree();
 
   return (
     <>
@@ -99,7 +75,7 @@ export default async function DashboardLayout({
           instancesByTemplate={instancesByTemplate}
         />
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <TopBar initialPendingCount={pendingCount} />
+          <TopBar />
           <main className="min-h-0 flex-1 overflow-hidden bg-bg">{children}</main>
         </div>
       </DashboardTopBarProvider>

--- a/products/dashboard/app/globals.css
+++ b/products/dashboard/app/globals.css
@@ -196,6 +196,14 @@ body {
     color 0.2s ease;
 }
 
+button:not(:disabled) {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
 /*
  * Sidebar collapse — driven by `<html data-sidebar="collapsed|expanded">`.
  *

--- a/products/dashboard/components/dashboard-topbar-context.tsx
+++ b/products/dashboard/components/dashboard-topbar-context.tsx
@@ -32,6 +32,8 @@ interface WorkflowInstanceTopBarConfig {
 interface PageTopBarConfig {
   mode: "page";
   crumbs: DashboardTopBarCrumb[];
+  onSave?: () => void;
+  saveDisabled?: boolean;
   actions?: ReactNode;
 }
 

--- a/products/dashboard/components/dashboard-topbar-context.tsx
+++ b/products/dashboard/components/dashboard-topbar-context.tsx
@@ -8,9 +8,14 @@ import {
   type ReactNode,
 } from "react";
 
+export interface DashboardTopBarCrumb {
+  label: string;
+  onClick?: () => void;
+}
+
 interface TemplateEditorTopBarConfig {
   mode: "template-editor";
-  crumbs: string[];
+  crumbs: DashboardTopBarCrumb[];
   label: string;
   onLabelChange: (value: string) => void;
   onSave: () => void;
@@ -20,13 +25,20 @@ interface TemplateEditorTopBarConfig {
 
 interface WorkflowInstanceTopBarConfig {
   mode: "workflow-instance";
-  crumbs: string[];
+  crumbs: DashboardTopBarCrumb[];
+  actions?: ReactNode;
+}
+
+interface PageTopBarConfig {
+  mode: "page";
+  crumbs: DashboardTopBarCrumb[];
   actions?: ReactNode;
 }
 
 type TopBarConfig =
   | TemplateEditorTopBarConfig
   | WorkflowInstanceTopBarConfig
+  | PageTopBarConfig
   | null;
 
 interface DashboardTopBarContextValue {

--- a/products/dashboard/components/framework/framework-header-actions-menu.tsx
+++ b/products/dashboard/components/framework/framework-header-actions-menu.tsx
@@ -47,7 +47,7 @@ export function FrameworkHeaderActionsMenu({
         aria-label={`Open ${entityName} actions`}
         aria-expanded={open}
         onClick={() => setOpen((current) => !current)}
-        className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-md border border-border-hi bg-bg-3 text-t2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition hover:border-border-hi hover:bg-bg-4 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent aria-expanded:border-accent aria-expanded:bg-primary-bg aria-expanded:text-accent"
+        className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-md border border-border bg-bg-2 text-t2 transition hover:border-border-hi hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent aria-expanded:border-accent aria-expanded:bg-primary-bg aria-expanded:text-accent"
       >
         <Ellipsis className="h-[15px] w-[15px]" strokeWidth={2.4} />
       </button>

--- a/products/dashboard/components/framework/framework-header-actions-menu.tsx
+++ b/products/dashboard/components/framework/framework-header-actions-menu.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Ellipsis, Pencil, Trash2 } from "lucide-react";
+
+interface FrameworkHeaderActionsMenuProps {
+  entityName: string;
+  onRename: () => void;
+  onDelete: () => void;
+}
+
+export function FrameworkHeaderActionsMenu({
+  entityName,
+  onRename,
+  onDelete,
+}: FrameworkHeaderActionsMenuProps) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        aria-label={`Open ${entityName} actions`}
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+        className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-md border border-border-hi bg-bg-3 text-t2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition hover:border-border-hi hover:bg-bg-4 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent aria-expanded:border-accent aria-expanded:bg-primary-bg aria-expanded:text-accent"
+      >
+        <Ellipsis className="h-[15px] w-[15px]" strokeWidth={2.4} />
+      </button>
+      {open ? (
+        <div className="absolute right-0 top-[calc(100%+8px)] z-30 min-w-[168px] rounded-xl border border-border-hi bg-bg-2 p-1.5 shadow-[var(--shadow-canvas)]">
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              onRename();
+            }}
+            className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left text-[12.5px] text-t1 transition hover:bg-bg-3"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+            Rename
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              onDelete();
+            }}
+            className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left text-[12.5px] text-[#f87171] transition hover:bg-linear-to-b hover:from-[#ef4444] hover:to-[#dc2626] hover:text-[#fff7f7]"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            Delete
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/products/dashboard/components/framework/framework-item-modal.tsx
+++ b/products/dashboard/components/framework/framework-item-modal.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  );
+}
+
+interface FrameworkItemModalProps {
+  title: string;
+  description?: string;
+  initialName: string;
+  initialDescription: string;
+  submitLabel: string;
+  pending?: boolean;
+  onSubmit: (values: { name: string; description: string }) => void | Promise<void>;
+  onClose: () => void;
+}
+
+export function FrameworkItemModal({
+  title,
+  description,
+  initialName,
+  initialDescription,
+  submitLabel,
+  pending = false,
+  onSubmit,
+  onClose,
+}: FrameworkItemModalProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const nameId = useId();
+  const descriptionFieldId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const [name, setName] = useState(initialName);
+  const [summary, setSummary] = useState(initialDescription);
+  const canSubmit = Boolean(name.trim() && summary.trim()) && !pending;
+
+  useEffect(() => {
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    nameRef.current?.focus();
+    nameRef.current?.select();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && !pending) {
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab" || !dialogRef.current) {
+        return;
+      }
+
+      const focusable = getFocusableElements(dialogRef.current);
+      if (focusable.length === 0) {
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      previousFocusRef.current?.focus();
+    };
+  }, [onClose, pending]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-(--overlay) p-4 backdrop-blur-[3px]"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (!pending && event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        className="w-full max-w-[460px] rounded-[14px] border border-border-hi bg-bg-2 p-7 shadow-[var(--shadow-canvas)]"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={description ? descriptionId : undefined}
+      >
+        <div id={titleId} className="text-[16px] font-bold tracking-tight text-t1">
+          {title}
+        </div>
+        {description ? (
+          <p id={descriptionId} className="mt-1 text-[12.5px] leading-[1.6] text-t3">
+            {description}
+          </p>
+        ) : null}
+
+        <label htmlFor={nameId} className="mb-1.5 mt-4 block text-[11px] font-medium text-t2">
+          Title
+        </label>
+        <input
+          id={nameId}
+          ref={nameRef}
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          className="block w-full rounded-lg border border-border bg-bg-3 px-3 py-2.5 text-[13px] text-t1 placeholder:text-t3 focus:border-primary focus:outline-none"
+          placeholder="Title"
+        />
+
+        <label
+          htmlFor={descriptionFieldId}
+          className="mb-1.5 mt-4 block text-[11px] font-medium text-t2"
+        >
+          Description
+        </label>
+        <textarea
+          id={descriptionFieldId}
+          value={summary}
+          onChange={(event) => setSummary(event.target.value)}
+          rows={3}
+          className="block w-full resize-none rounded-lg border border-border bg-bg-3 px-3 py-2.5 text-[13px] leading-6 text-t1 placeholder:text-t3 focus:border-primary focus:outline-none"
+          placeholder="Short description"
+        />
+
+        <div className="mt-6 flex justify-end gap-2">
+          <button
+            type="button"
+            className="rounded-lg border border-border bg-bg-3 px-4 py-2 text-[13px] font-medium text-t2 transition hover:bg-bg-4 hover:text-t1 disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={onClose}
+            disabled={pending}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (!canSubmit) return;
+              void onSubmit({ name, description: summary });
+            }}
+            disabled={!canSubmit}
+            className="rounded-lg bg-primary px-5 py-2 text-[13px] font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/products/dashboard/components/framework/framework-item-modal.tsx
+++ b/products/dashboard/components/framework/framework-item-modal.tsx
@@ -150,7 +150,7 @@ export function FrameworkItemModal({
             type="button"
             onClick={() => {
               if (!canSubmit) return;
-              void onSubmit({ name, description: summary }).catch(() => {
+              void Promise.resolve(onSubmit({ name, description: summary })).catch(() => {
                 // Parent handlers surface user-facing errors.
               });
             }}

--- a/products/dashboard/components/framework/framework-item-modal.tsx
+++ b/products/dashboard/components/framework/framework-item-modal.tsx
@@ -150,7 +150,9 @@ export function FrameworkItemModal({
             type="button"
             onClick={() => {
               if (!canSubmit) return;
-              void onSubmit({ name, description: summary });
+              void onSubmit({ name, description: summary }).catch(() => {
+                // Parent handlers surface user-facing errors.
+              });
             }}
             disabled={!canSubmit}
             className="rounded-lg bg-primary px-5 py-2 text-[13px] font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"

--- a/products/dashboard/components/framework/framework-item-modal.tsx
+++ b/products/dashboard/components/framework/framework-item-modal.tsx
@@ -40,7 +40,8 @@ export function FrameworkItemModal({
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const [name, setName] = useState(initialName);
   const [summary, setSummary] = useState(initialDescription);
-  const canSubmit = Boolean(name.trim() && summary.trim()) && !pending;
+  const [inFlight, setInFlight] = useState(false);
+  const canSubmit = Boolean(name.trim() && summary.trim()) && !pending && !inFlight;
 
   useEffect(() => {
     previousFocusRef.current =
@@ -48,6 +49,12 @@ export function FrameworkItemModal({
     nameRef.current?.focus();
     nameRef.current?.select();
 
+    return () => {
+      previousFocusRef.current?.focus();
+    };
+  }, []);
+
+  useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape" && !pending) {
         onClose();
@@ -79,7 +86,6 @@ export function FrameworkItemModal({
     window.addEventListener("keydown", handleKeyDown);
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
-      previousFocusRef.current?.focus();
     };
   }, [onClose, pending]);
 
@@ -149,9 +155,12 @@ export function FrameworkItemModal({
           <button
             type="button"
             onClick={() => {
-              if (!canSubmit) return;
+              if (!canSubmit || inFlight) return;
+              setInFlight(true);
               void Promise.resolve(onSubmit({ name, description: summary })).catch(() => {
                 // Parent handlers surface user-facing errors.
+              }).finally(() => {
+                setInFlight(false);
               });
             }}
             disabled={!canSubmit}

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -1,0 +1,542 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { Download, Plus, Sparkles, X } from "lucide-react";
+
+import {
+  deleteFrameworkItemAction,
+  upsertFrameworkItemAction,
+} from "@/app/(dashboard)/framework/actions";
+import { useDashboardTopBar } from "@/components/dashboard-topbar-context";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { useAnalytics } from "@/lib/analytics/events";
+import type { FrameworkItem, FrameworkItemType } from "@/lib/workflows/types";
+import { cn } from "@/lib/utils";
+
+interface FrameworkScreenProps {
+  initialItems: FrameworkItem[];
+  type: FrameworkItemType;
+}
+
+const SKILL_EMOJIS = ["🤖", "🧠", "✨", "🛠️", "🔍", "🧭", "✅", "🗂️"];
+const PLAYBOOK_EMOJIS = ["📄", "📚", "🧪", "🚀", "🧱", "🗺️", "📌", "🔐"];
+
+function createFrameworkItemId(type: FrameworkItemType, name: string): string {
+  const prefix = type === "skill" ? "sk" : "pb";
+  const slug = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `${prefix}-${slug || "item"}-${crypto.randomUUID().slice(0, 8)}`;
+  }
+
+  return `${prefix}-${slug || "item"}-${Date.now().toString(36)}`;
+}
+
+function createDraftItem(type: FrameworkItemType, name: string, description: string): FrameworkItem {
+  return {
+    id: createFrameworkItemId(type, name),
+    type,
+    name: name.trim(),
+    description: description.trim(),
+    icon: type === "skill" ? "🤖" : "📄",
+    content: `# ${name.trim()}\n\n`,
+  };
+}
+
+function sortItems(nextItems: FrameworkItem[]) {
+  return [...nextItems].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function EmojiPicker({
+  value,
+  options,
+  onSelect,
+}: {
+  value: string;
+  options: string[];
+  onSelect: (emoji: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        aria-label="Emoji picker"
+        onClick={() => setOpen((current) => !current)}
+        className="flex h-10 w-10 items-center justify-center rounded-lg border border-border bg-bg text-[18px] transition hover:border-border-hi hover:bg-bg-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+      >
+        {value}
+      </button>
+      {open ? (
+        <div className="absolute left-0 top-[calc(100%+8px)] z-20 grid grid-cols-4 gap-1 rounded-xl border border-border bg-bg-2 p-2 shadow-[var(--shadow-canvas)]">
+          {options.map((emoji) => (
+            <button
+              key={emoji}
+              type="button"
+              onClick={() => {
+                onSelect(emoji);
+                setOpen(false);
+              }}
+              className={cn(
+                "flex h-9 w-9 items-center justify-center rounded-lg text-[18px] transition hover:bg-bg-3",
+                emoji === value ? "bg-bg-3" : "bg-transparent",
+              )}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function FrameworkScreen({
+  initialItems,
+  type,
+}: FrameworkScreenProps) {
+  const { setConfig } = useDashboardTopBar();
+  const { capture } = useAnalytics();
+  const [items, setItems] = useState(initialItems);
+  const [adding, setAdding] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editContent, setEditContent] = useState("");
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editIcon, setEditIcon] = useState("");
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const routeLabel = type === "skill" ? "Skills" : "Playbooks";
+  const routeMetaLabel = type === "skill" ? "Framework library" : "Framework procedures";
+  const routeDescription =
+    type === "skill"
+      ? "A compact library of reusable agent capabilities. Select a skill to edit its markdown source."
+      : "A compact library of reusable execution procedures. Select a playbook to edit its markdown source.";
+  const createLabel = type === "skill" ? "New skill" : "New playbook";
+  const emojiOptions = type === "skill" ? SKILL_EMOJIS : PLAYBOOK_EMOJIS;
+
+  const filteredItems = useMemo(
+    () => items.filter((item) => item.type === type),
+    [items, type],
+  );
+  const editingItem = filteredItems.find((item) => item.id === editingId) ?? null;
+  const deleteTarget = filteredItems.find((item) => item.id === confirmDeleteId) ?? null;
+
+  useEffect(() => {
+    setItems(initialItems);
+  }, [initialItems]);
+
+  useEffect(() => {
+    setConfig({
+      mode: "page",
+      crumbs: editingItem
+        ? [
+            {
+              label: routeLabel,
+              onClick: () => {
+                setEditingId(null);
+                setError(null);
+              },
+            },
+            { label: editingItem.name },
+          ]
+        : [{ label: routeLabel }],
+      actions:
+        editingItem || adding ? null : (
+          <button
+            type="button"
+            onClick={() => {
+              setError(null);
+              setAdding(true);
+            }}
+            className="flex items-center gap-1.5 rounded-md border border-border bg-bg-2 px-2.5 py-1.5 text-[11.5px] font-medium text-t2 transition hover:border-border-hi hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {createLabel}
+          </button>
+        ),
+    });
+
+    return () => setConfig(null);
+  }, [adding, createLabel, editingItem, routeLabel, setConfig]);
+
+  function resetAddForm() {
+    setAdding(false);
+    setName("");
+    setDescription("");
+  }
+
+  function emitEditedEvent(itemId: string) {
+    if (type === "skill") {
+      capture("framework.skill_edited", {
+        item_id: itemId,
+        edited_by: "founder",
+      });
+    }
+  }
+
+  function beginEdit(item: FrameworkItem) {
+    setError(null);
+    setAdding(false);
+    setEditingId(item.id);
+    setEditContent(item.content);
+    setEditName(item.name);
+    setEditDescription(item.description);
+    setEditIcon(item.icon ?? emojiOptions[0]!);
+  }
+
+  function createItem() {
+    const draft = createDraftItem(type, name, description);
+
+    startTransition(async () => {
+      try {
+        const result = await upsertFrameworkItemAction(draft);
+        setItems((current) =>
+          sortItems([
+            ...current.filter((item) => item.id !== result.item.id),
+            result.item,
+          ]),
+        );
+        resetAddForm();
+        emitEditedEvent(result.item.id);
+        setError(null);
+      } catch (actionError) {
+        setError(
+          actionError instanceof Error && actionError.message
+            ? actionError.message
+            : `Could not create the ${type}.`,
+        );
+      }
+    });
+  }
+
+  function saveItem() {
+    if (!editingItem) {
+      return;
+    }
+
+    startTransition(async () => {
+      try {
+        const result = await upsertFrameworkItemAction({
+          ...editingItem,
+          name: editName.trim(),
+          description: editDescription.trim(),
+          icon: editIcon.trim(),
+          content: editContent,
+        });
+        setItems((current) =>
+          sortItems(
+            current.map((item) => (item.id === result.item.id ? result.item : item)),
+          ),
+        );
+        setEditingId(null);
+        setEditContent("");
+        setEditName("");
+        setEditDescription("");
+        setEditIcon("");
+        emitEditedEvent(result.item.id);
+        setError(null);
+      } catch (actionError) {
+        setError(
+          actionError instanceof Error && actionError.message
+            ? actionError.message
+            : `Could not save the ${type}.`,
+        );
+      }
+    });
+  }
+
+  function deleteItem(itemId: string) {
+    startTransition(async () => {
+      try {
+        await deleteFrameworkItemAction(itemId);
+        setItems((current) => current.filter((item) => item.id !== itemId));
+        setConfirmDeleteId(null);
+        if (editingId === itemId) {
+          setEditingId(null);
+          setEditContent("");
+        }
+        setError(null);
+      } catch (actionError) {
+        setError(
+          actionError instanceof Error && actionError.message
+            ? actionError.message
+            : `Could not delete the ${type}.`,
+        );
+      }
+    });
+  }
+
+  function downloadMarkdown() {
+    if (!editingItem) return;
+
+    const slug = (editName || editingItem.name)
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    const blob = new Blob([editContent], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${slug || "framework-item"}.md`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden" data-testid={`framework-screen-${type}`}>
+      <div className="shrink-0 border-b border-border bg-bg px-6 py-4">
+        <div className="min-w-0">
+          <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+            {editingItem ? routeLabel.slice(0, -1) || routeLabel : routeMetaLabel}
+          </p>
+          <h1 className="mt-1 truncate text-[20px] font-bold tracking-tight text-t1">
+            {editingItem ? editName || editingItem.name : routeLabel}
+          </h1>
+          <p className="mt-1 text-[13px] text-t2">
+            {editingItem
+              ? editDescription || editingItem.description
+              : routeDescription}
+          </p>
+        </div>
+        {error ? (
+          <div className="mt-2 text-[11.5px] text-(color:--pill-blocked-t)">{error}</div>
+        ) : null}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden bg-bg-2 p-6">
+        {editingItem ? (
+          <div className="flex h-full min-h-0 flex-col rounded-[16px] border border-border bg-bg-2">
+            <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-5 py-3">
+              <div className="flex min-w-0 items-center gap-3">
+                <EmojiPicker
+                  value={editIcon || emojiOptions[0]!}
+                  options={emojiOptions}
+                  onSelect={setEditIcon}
+                />
+                <div className="min-w-0">
+                  <input
+                    value={editName}
+                    onChange={(event) => setEditName(event.target.value)}
+                    aria-label="Name"
+                    className="w-full min-w-0 bg-transparent text-[14px] font-semibold text-t1 outline-none placeholder:text-t3"
+                    placeholder={`${routeLabel.slice(0, -1)} name`}
+                  />
+                  <input
+                    value={editDescription}
+                    onChange={(event) => setEditDescription(event.target.value)}
+                    aria-label="Description"
+                    className="mt-1 w-full min-w-0 bg-transparent text-[12px] text-t2 outline-none placeholder:text-t3"
+                    placeholder="Short description"
+                  />
+                </div>
+              </div>
+
+              <div className="flex shrink-0 items-center gap-2">
+                <button
+                  type="button"
+                  onClick={downloadMarkdown}
+                  className="flex items-center gap-1.5 rounded-md border border-border bg-bg px-3 py-2 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                >
+                  <Download className="h-3.5 w-3.5" />
+                  Download
+                </button>
+                <button
+                  type="button"
+                  onClick={saveItem}
+                  disabled={pending || !editName.trim() || !editDescription.trim()}
+                  className={cn(
+                    "rounded-md px-3 py-2 text-[12px] font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+                    pending || !editName.trim() || !editDescription.trim()
+                      ? "cursor-not-allowed bg-primary text-white opacity-70"
+                      : "bg-primary text-white hover:opacity-90",
+                  )}
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+
+            <div className="min-h-0 flex-1 p-5">
+              <textarea
+                value={editContent}
+                onChange={(event) => setEditContent(event.target.value)}
+                spellCheck={false}
+                data-testid={`framework-editor-${type}`}
+                className="h-full min-h-[320px] w-full resize-none rounded-xl border border-border bg-bg px-4 py-3 font-mono text-[12.5px] leading-6 text-t1 outline-none transition placeholder:text-t3 focus:border-primary"
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="flex h-full min-h-0 flex-col">
+            {adding ? (
+              <div
+                className="mb-5 shrink-0 rounded-[14px] border border-border bg-bg px-5 py-4"
+                data-testid={`framework-add-form-${type}`}
+              >
+                <div className="grid gap-3 md:grid-cols-[minmax(0,220px)_minmax(0,1fr)_auto] md:items-end">
+                  <div className="min-w-0">
+                    <label className="mb-1.5 block text-[10px] font-semibold uppercase tracking-[0.13em] text-t3">
+                      Name
+                    </label>
+                    <input
+                      value={name}
+                      onChange={(event) => setName(event.target.value)}
+                      placeholder={type === "skill" ? "Skill name" : "Playbook name"}
+                      className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-[12.5px] text-t1 outline-none transition placeholder:text-t3 focus:border-primary"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <label className="mb-1.5 block text-[10px] font-semibold uppercase tracking-[0.13em] text-t3">
+                      Description
+                    </label>
+                    <input
+                      value={description}
+                      onChange={(event) => setDescription(event.target.value)}
+                      placeholder="Short description"
+                      className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-[12.5px] text-t1 outline-none transition placeholder:text-t3 focus:border-primary"
+                    />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={createItem}
+                      disabled={pending || !name.trim() || !description.trim()}
+                      className={cn(
+                        "rounded-md px-3 py-2 text-[12px] font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+                        pending || !name.trim() || !description.trim()
+                          ? "cursor-not-allowed bg-primary text-white opacity-70"
+                          : "bg-primary text-white hover:opacity-90",
+                      )}
+                    >
+                      Create
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        resetAddForm();
+                        setError(null);
+                      }}
+                      disabled={pending}
+                      className="rounded-md border border-border bg-bg px-3 py-2 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
+            <div className="min-h-0 flex-1 overflow-auto px-1 py-2">
+              <div
+                className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]"
+                data-testid={`framework-grid-${type}`}
+              >
+                {filteredItems.map((item) => (
+                  <div
+                    key={item.id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => beginEdit(item)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        beginEdit(item);
+                      }
+                    }}
+                    data-testid={`framework-card-${item.id}`}
+                    className="group relative flex h-[104px] cursor-pointer items-center gap-3 overflow-hidden rounded-[7px] border border-border bg-bg-2 px-4 py-4 text-left transition-all duration-150 hover:border-border-hi hover:bg-bg-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                  >
+                    <span
+                      className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[7px] border border-border bg-bg text-[18px]"
+                      aria-hidden
+                    >
+                      {item.icon || (type === "skill" ? "🤖" : "📄")}
+                    </span>
+                    <span className="min-w-0 flex-1 overflow-hidden pr-8">
+                      <span className="block overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-semibold text-t1">
+                        {item.name}
+                      </span>
+                      <span className="mt-1 block overflow-hidden text-[11.5px] leading-[1.35] text-t2 [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]">
+                        {item.description}
+                      </span>
+                    </span>
+                    <span className="absolute right-3 top-3 flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-[8px] border border-border bg-bg-3 text-t3 opacity-0 transition group-hover:opacity-100">
+                      <button
+                        type="button"
+                        title={`Delete ${item.name}`}
+                        aria-label={`Delete ${item.name}`}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          setConfirmDeleteId(item.id);
+                        }}
+                        className="flex h-full w-full cursor-pointer items-center justify-center rounded-[8px] hover:bg-[linear-gradient(180deg,#ef4444,#dc2626)] hover:text-[#fff7f7] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f87171]"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </button>
+                    </span>
+                  </div>
+                ))}
+
+                {filteredItems.length === 0 ? (
+                  <div className="col-span-full flex min-h-[180px] flex-col items-center justify-center rounded-[14px] border border-dashed border-border-hi bg-bg px-6 text-center">
+                    <Sparkles className="mb-3 h-5 w-5 text-t3" />
+                    <p className="text-[13px] font-medium text-t1">
+                      No {type === "skill" ? "skills" : "playbooks"} yet
+                    </p>
+                    <p className="mt-1 max-w-sm text-[11.5px] leading-5 text-t3">
+                      Create the first {type === "skill" ? "skill" : "playbook"} to populate this library.
+                    </p>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {deleteTarget ? (
+        <ConfirmModal
+          title={`Delete "${deleteTarget.name}"?`}
+          description={`This will permanently remove this ${type}. This cannot be undone.`}
+          onConfirm={() => deleteItem(deleteTarget.id)}
+          onCancel={() => setConfirmDeleteId(null)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -504,82 +504,139 @@ export function FrameworkScreen({
             </div>
 
             <div className="min-h-0 flex-1 overflow-hidden px-6 py-6">
-              <div className="mx-auto flex h-full min-h-0 w-full max-w-[1120px] flex-col">
+              <div className="mx-auto flex h-full min-h-0 w-full max-w-[1180px] flex-col">
                 <div
                   className={cn(
-                    "h-full min-h-0 overflow-auto transition-colors",
+                    "relative h-full min-h-0 overflow-hidden rounded-[22px] border transition-[border-color,box-shadow,background-color]",
                     editorView === "markdown"
-                      ? "bg-bg"
-                      : "rounded-[16px] bg-bg-3/65 ring-1 ring-border",
+                      ? "border-border bg-linear-to-b from-bg to-bg-2/92 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+                      : "border-border-hi bg-linear-to-b from-bg to-bg-3/90 shadow-[0_28px_90px_rgba(15,23,42,0.12)]",
                   )}
                 >
+                  <div className="pointer-events-none absolute inset-x-0 top-0 h-14 bg-linear-to-b from-white/6 to-transparent opacity-70" />
                   {editorView === "markdown" ? (
-                    <div
-                      data-testid={`framework-markdown-preview-${type}`}
-                      className="min-h-full px-8 py-7"
-                    >
-                      <div className="max-w-3xl">
+                    <div className="h-full min-h-0 overflow-auto">
+                      <div
+                        data-testid={`framework-markdown-preview-${type}`}
+                        className="mx-auto min-h-full w-full max-w-[920px] px-6 py-7 md:px-8 md:py-9"
+                      >
+                        <div className="max-w-[70ch]">
                         <ReactMarkdown
                           remarkPlugins={[remarkGfm]}
                           components={{
                             h1: ({ node: _node, ...props }) => (
-                              <h1 className="mb-4 text-[28px] font-bold tracking-tight text-t1" {...props} />
+                              <h1
+                                className="mb-5 text-[30px] font-bold tracking-[-0.03em] text-t1"
+                                {...props}
+                              />
                             ),
                             h2: ({ node: _node, ...props }) => (
-                              <h2 className="mb-3 mt-8 text-[22px] font-semibold tracking-tight text-t1" {...props} />
+                              <h2
+                                className="mb-3 mt-10 border-t border-border pt-6 text-[22px] font-semibold tracking-[-0.02em] text-t1 first:mt-0 first:border-t-0 first:pt-0"
+                                {...props}
+                              />
                             ),
                             h3: ({ node: _node, ...props }) => (
-                              <h3 className="mb-2 mt-6 text-[17px] font-semibold text-t1" {...props} />
+                              <h3 className="mb-2 mt-7 text-[17px] font-semibold text-t1" {...props} />
                             ),
                             p: ({ node: _node, ...props }) => (
-                              <p className="mb-4 text-[14px] leading-7 text-t1" {...props} />
+                              <p className="mb-4 text-[14px] leading-7 text-t1/95" {...props} />
                             ),
                             ul: ({ node: _node, ...props }) => (
-                              <ul className="mb-4 list-disc space-y-2 pl-6" {...props} />
+                              <ul className="mb-5 list-disc space-y-2.5 pl-6 marker:text-t3" {...props} />
                             ),
                             ol: ({ node: _node, ...props }) => (
-                              <ol className="mb-4 list-decimal space-y-2 pl-6" {...props} />
+                              <ol className="mb-5 list-decimal space-y-2.5 pl-6 marker:text-t3" {...props} />
                             ),
                             li: ({ node: _node, ...props }) => (
                               <li className="text-[14px] leading-7 text-t1" {...props} />
                             ),
                             blockquote: ({ node: _node, ...props }) => (
-                              <blockquote className="mb-4 border-l-2 border-border-hi pl-4 italic text-t2" {...props} />
+                              <blockquote
+                                className="mb-5 rounded-r-[14px] border-l-[3px] border-border-hi bg-bg-2/65 px-4 py-3 italic text-t2"
+                                {...props}
+                              />
                             ),
                             code: ({ node: _node, className, ...props }) => (
                               <code
                                 className={cn(
-                                  "rounded bg-bg-2 px-1.5 py-0.5 font-mono text-[12px] text-t1",
+                                  "rounded-md bg-bg-2 px-1.5 py-0.5 font-mono text-[12px] text-t1",
                                   className,
                                 )}
                                 {...props}
                               />
                             ),
                             pre: ({ node: _node, ...props }) => (
-                              <pre className="mb-4 overflow-x-auto rounded-xl border border-border bg-bg-2 p-4 font-mono text-[12px] text-t1" {...props} />
+                              <pre
+                                className="mb-5 overflow-x-auto rounded-[16px] border border-border bg-bg-2 p-4 font-mono text-[12px] text-t1 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
+                                {...props}
+                              />
                             ),
                             a: ({ node: _node, ...props }) => (
-                              <a className="text-accent underline underline-offset-2" {...props} />
+                              <a
+                                className="text-accent underline decoration-accent/35 underline-offset-3 transition hover:decoration-accent"
+                                {...props}
+                              />
                             ),
                           }}
                         >
                           {draftItem.content || "_No content yet._"}
                         </ReactMarkdown>
+                        </div>
                       </div>
                     </div>
                   ) : (
-                    <div className="min-h-full px-5 py-5">
-                      <textarea
-                        value={draftItem.content}
-                        onChange={(event) =>
-                          setDraftItem((current) =>
-                            current ? { ...current, content: event.target.value } : current,
-                          )
-                        }
-                        spellCheck={false}
-                        data-testid={`framework-editor-${type}`}
-                        className="block min-h-full w-full resize-none rounded-[12px] bg-bg px-6 py-6 font-mono text-[13px] leading-7 text-t1 outline-none transition placeholder:text-t3"
-                      />
+                    <div className="h-full min-h-0 overflow-auto">
+                      <div className="flex min-h-full w-full flex-col">
+                        <div className="flex items-center justify-between gap-3 border-b border-white/8 px-5 py-4 md:px-6">
+                          <div className="flex items-center gap-2" aria-hidden>
+                            <span className="h-2.5 w-2.5 rounded-full bg-[#fb7185]/80" />
+                            <span className="h-2.5 w-2.5 rounded-full bg-[#fbbf24]/80" />
+                            <span className="h-2.5 w-2.5 rounded-full bg-[#4ade80]/80" />
+                          </div>
+                          <div className="min-w-0 text-right">
+                            <p className="truncate font-mono text-[11px] uppercase tracking-[0.16em] text-slate-400">
+                              Markdown editor
+                            </p>
+                            <p className="truncate text-[11.5px] text-slate-500">
+                              Plain text source
+                            </p>
+                          </div>
+                        </div>
+
+                        <div className="min-h-0 flex-1 bg-linear-to-b from-[#111c31] to-[#0b1324]">
+                          <div className="flex min-h-full">
+                            <div
+                              className="hidden w-14 shrink-0 select-none border-r border-white/7 bg-white/[0.02] px-2 py-5 text-right font-mono text-[11px] leading-7 text-slate-500 md:block"
+                              aria-hidden
+                            >
+                              {Array.from(
+                                {
+                                  length: Math.max(
+                                    (draftItem.content.match(/\n/g)?.length ?? 0) + 1,
+                                    16,
+                                  ),
+                                },
+                                (_, index) => (
+                                  <div key={index}>{index + 1}</div>
+                                ),
+                              )}
+                            </div>
+
+                            <textarea
+                              value={draftItem.content}
+                              onChange={(event) =>
+                                setDraftItem((current) =>
+                                  current ? { ...current, content: event.target.value } : current,
+                                )
+                              }
+                              spellCheck={false}
+                              data-testid={`framework-editor-${type}`}
+                              className="block min-h-full w-full resize-none bg-transparent px-5 py-5 font-mono text-[13px] leading-7 text-slate-100 outline-none transition placeholder:text-slate-500 md:px-6"
+                            />
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   )}
                 </div>

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -270,6 +270,7 @@ export function FrameworkScreen({
   const [editorView, setEditorView] = useState<EditorViewMode>("markdown");
   const [itemModalState, setItemModalState] = useState<FrameworkItemModalState>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [deletingItemId, setDeletingItemId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
@@ -597,6 +598,9 @@ export function FrameworkScreen({
   }
 
   function deleteItem(itemId: string) {
+    if (deletingItemId === itemId) return;
+
+    setDeletingItemId(itemId);
     startTransition(async () => {
       try {
         await deleteFrameworkItemAction(itemId);
@@ -612,6 +616,8 @@ export function FrameworkScreen({
             ? actionError.message
             : `Could not delete the ${type}.`,
         );
+      } finally {
+        setDeletingItemId((current) => (current === itemId ? null : current));
       }
     });
   }
@@ -1204,6 +1210,7 @@ export function FrameworkScreen({
         <ConfirmModal
           title={`Delete "${deleteTarget.name}"?`}
           description={`This will permanently remove this ${type}. This cannot be undone.`}
+          confirmDisabled={deletingItemId === deleteTarget.id}
           onConfirm={() => deleteItem(deleteTarget.id)}
           onCancel={() => setConfirmDeleteId(null)}
         />

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -1,13 +1,24 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
-import { Download, Plus, Sparkles, X } from "lucide-react";
+import {
+  Download,
+  Eye,
+  Pencil,
+  Plus,
+  Search,
+  Sparkles,
+} from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 import {
   deleteFrameworkItemAction,
   upsertFrameworkItemAction,
 } from "@/app/(dashboard)/framework/actions";
 import { useDashboardTopBar } from "@/components/dashboard-topbar-context";
+import { FrameworkHeaderActionsMenu } from "@/components/framework/framework-header-actions-menu";
+import { FrameworkItemModal } from "@/components/framework/framework-item-modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { useAnalytics } from "@/lib/analytics/events";
 import type { FrameworkItem, FrameworkItemType } from "@/lib/workflows/types";
@@ -18,8 +29,43 @@ interface FrameworkScreenProps {
   type: FrameworkItemType;
 }
 
-const SKILL_EMOJIS = ["🤖", "🧠", "✨", "🛠️", "🔍", "🧭", "✅", "🗂️"];
-const PLAYBOOK_EMOJIS = ["📄", "📚", "🧪", "🚀", "🧱", "🗺️", "📌", "🔐"];
+type EditorViewMode = "markdown" | "plain-text";
+
+type FrameworkItemModalState =
+  | null
+  | {
+      mode: "create" | "rename";
+      initialName: string;
+      initialDescription: string;
+    };
+
+const SKILL_EMOJIS = [
+  { emoji: "🤖", label: "Robot", keywords: ["agent", "ai", "automation"] },
+  { emoji: "🧠", label: "Brain", keywords: ["thinking", "reasoning", "strategy"] },
+  { emoji: "✨", label: "Sparkles", keywords: ["polish", "quality", "magic"] },
+  { emoji: "🛠️", label: "Tools", keywords: ["build", "developer", "implementation"] },
+  { emoji: "🔍", label: "Search", keywords: ["audit", "review", "analysis"] },
+  { emoji: "🧭", label: "Compass", keywords: ["navigation", "direction", "framework"] },
+  { emoji: "✅", label: "Check", keywords: ["quality", "approval", "done"] },
+  { emoji: "🗂️", label: "Folders", keywords: ["organization", "library", "catalog"] },
+  { emoji: "📝", label: "Writing", keywords: ["documentation", "editor", "notes"] },
+  { emoji: "🚀", label: "Rocket", keywords: ["launch", "ship", "release"] },
+  { emoji: "🧪", label: "Experiment", keywords: ["test", "validation", "quality"] },
+  { emoji: "🎯", label: "Target", keywords: ["goal", "focus", "scope"] },
+] as const;
+
+const PLAYBOOK_EMOJIS = [
+  { emoji: "📄", label: "Document", keywords: ["procedure", "guide", "playbook"] },
+  { emoji: "📚", label: "Books", keywords: ["knowledge", "library", "reference"] },
+  { emoji: "🧪", label: "Experiment", keywords: ["test", "validation", "quality"] },
+  { emoji: "🚀", label: "Rocket", keywords: ["launch", "ship", "release"] },
+  { emoji: "🧱", label: "Brick", keywords: ["foundation", "system", "base"] },
+  { emoji: "🗺️", label: "Map", keywords: ["plan", "navigation", "route"] },
+  { emoji: "📌", label: "Pin", keywords: ["important", "reference", "anchor"] },
+  { emoji: "🔐", label: "Lock", keywords: ["security", "policy", "governance"] },
+  { emoji: "🧭", label: "Compass", keywords: ["direction", "operating model", "flow"] },
+  { emoji: "📝", label: "Writing", keywords: ["instructions", "steps", "notes"] },
+] as const;
 
 function createFrameworkItemId(type: FrameworkItemType, name: string): string {
   const prefix = type === "skill" ? "sk" : "pb";
@@ -51,30 +97,46 @@ function sortItems(nextItems: FrameworkItem[]) {
   return [...nextItems].sort((left, right) => left.name.localeCompare(right.name));
 }
 
-function EmojiPicker({
+function areFrameworkItemsEqual(left: FrameworkItem | null, right: FrameworkItem | null) {
+  if (!left || !right) return false;
+  return (
+    left.name === right.name &&
+    left.description === right.description &&
+    (left.icon ?? "") === (right.icon ?? "") &&
+    left.content === right.content
+  );
+}
+
+function CompactEmojiPicker({
   value,
   options,
   onSelect,
 }: {
   value: string;
-  options: string[];
+  options: readonly { emoji: string; label: string; keywords: readonly string[] }[];
   onSelect: (emoji: string) => void;
 }) {
-  const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
 
   useEffect(() => {
     if (!open) return;
 
+    inputRef.current?.focus();
+
     function handlePointerDown(event: MouseEvent) {
       if (!rootRef.current?.contains(event.target as Node)) {
         setOpen(false);
+        setQuery("");
       }
     }
 
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         setOpen(false);
+        setQuery("");
       }
     }
 
@@ -86,34 +148,79 @@ function EmojiPicker({
     };
   }, [open]);
 
+  const normalizedQuery = query.trim().toLowerCase();
+  const filteredOptions =
+    normalizedQuery.length === 0
+      ? options
+      : options.filter((option) =>
+          [option.emoji, option.label, ...option.keywords].some((token) =>
+            token.toLowerCase().includes(normalizedQuery),
+          ),
+        );
+
+  const typedEmoji = query.trim();
+  const hasTypedEmoji = /\p{Extended_Pictographic}/u.test(typedEmoji);
+
   return (
-    <div ref={rootRef} className="relative">
+    <div ref={rootRef} className="relative shrink-0">
       <button
         type="button"
-        aria-label="Emoji picker"
+        aria-label="Change icon"
         onClick={() => setOpen((current) => !current)}
-        className="flex h-10 w-10 items-center justify-center rounded-lg border border-border bg-bg text-[18px] transition hover:border-border-hi hover:bg-bg-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+        className="flex h-8 w-8 items-center justify-center rounded-full border border-border bg-bg text-[16px] transition hover:border-border-hi hover:bg-bg-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
       >
         {value}
       </button>
       {open ? (
-        <div className="absolute left-0 top-[calc(100%+8px)] z-20 grid grid-cols-4 gap-1 rounded-xl border border-border bg-bg-2 p-2 shadow-[var(--shadow-canvas)]">
-          {options.map((emoji) => (
+        <div className="absolute left-0 top-[calc(100%+10px)] z-30 w-[244px] rounded-xl border border-border-hi bg-bg-2 p-3 shadow-[var(--shadow-canvas)]">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-t3" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              aria-label="Search or type emoji"
+              placeholder="Search or type emoji"
+              className="w-full rounded-lg border border-border bg-bg px-9 py-2 text-[12.5px] text-t1 outline-none transition placeholder:text-t3 focus:border-primary"
+            />
+          </div>
+
+          {hasTypedEmoji ? (
             <button
-              key={emoji}
               type="button"
               onClick={() => {
-                onSelect(emoji);
+                onSelect(typedEmoji.slice(0, 8));
                 setOpen(false);
+                setQuery("");
               }}
-              className={cn(
-                "flex h-9 w-9 items-center justify-center rounded-lg text-[18px] transition hover:bg-bg-3",
-                emoji === value ? "bg-bg-3" : "bg-transparent",
-              )}
+              className="mt-2 flex w-full items-center gap-2 rounded-lg border border-border bg-bg px-3 py-2 text-left text-[12.5px] text-t1 transition hover:bg-bg-3"
             >
-              {emoji}
+              <span className="text-[16px]">{typedEmoji}</span>
+              Use typed emoji
             </button>
-          ))}
+          ) : null}
+
+          <div className="mt-2 grid max-h-[180px] grid-cols-5 gap-1 overflow-auto">
+            {filteredOptions.map((option) => (
+              <button
+                key={option.emoji}
+                type="button"
+                aria-label={`Use ${option.label}`}
+                title={option.label}
+                onClick={() => {
+                  onSelect(option.emoji);
+                  setOpen(false);
+                  setQuery("");
+                }}
+                className={cn(
+                  "flex h-9 w-9 items-center justify-center rounded-lg border border-transparent text-[18px] transition hover:border-border hover:bg-bg-3",
+                  option.emoji === value ? "border-border bg-bg-3" : "bg-transparent",
+                )}
+              >
+                {option.emoji}
+              </button>
+            ))}
+          </div>
         </div>
       ) : null}
     </div>
@@ -127,14 +234,11 @@ export function FrameworkScreen({
   const { setConfig } = useDashboardTopBar();
   const { capture } = useAnalytics();
   const [items, setItems] = useState(initialItems);
-  const [adding, setAdding] = useState(false);
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [editContent, setEditContent] = useState("");
-  const [editName, setEditName] = useState("");
-  const [editDescription, setEditDescription] = useState("");
-  const [editIcon, setEditIcon] = useState("");
+  const [draftItem, setDraftItem] = useState<FrameworkItem | null>(null);
+  const [lastSavedItem, setLastSavedItem] = useState<FrameworkItem | null>(null);
+  const [editorView, setEditorView] = useState<EditorViewMode>("markdown");
+  const [itemModalState, setItemModalState] = useState<FrameworkItemModalState>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
@@ -143,61 +247,24 @@ export function FrameworkScreen({
   const routeMetaLabel = type === "skill" ? "Framework library" : "Framework procedures";
   const routeDescription =
     type === "skill"
-      ? "A compact library of reusable agent capabilities. Select a skill to edit its markdown source."
-      : "A compact library of reusable execution procedures. Select a playbook to edit its markdown source.";
+      ? "A compact library of reusable agent capabilities. Select a skill to read or edit its markdown source."
+      : "A compact library of reusable execution procedures. Select a playbook to read or edit its markdown source.";
   const createLabel = type === "skill" ? "New skill" : "New playbook";
   const emojiOptions = type === "skill" ? SKILL_EMOJIS : PLAYBOOK_EMOJIS;
-
   const filteredItems = useMemo(
     () => items.filter((item) => item.type === type),
     [items, type],
   );
-  const editingItem = filteredItems.find((item) => item.id === editingId) ?? null;
-  const deleteTarget = filteredItems.find((item) => item.id === confirmDeleteId) ?? null;
+  const isDirty =
+    draftItem !== null &&
+    (lastSavedItem === null || !areFrameworkItemsEqual(draftItem, lastSavedItem));
+  const deleteTarget =
+    filteredItems.find((item) => item.id === confirmDeleteId) ??
+    (draftItem?.id === confirmDeleteId ? draftItem : null);
 
   useEffect(() => {
     setItems(initialItems);
   }, [initialItems]);
-
-  useEffect(() => {
-    setConfig({
-      mode: "page",
-      crumbs: editingItem
-        ? [
-            {
-              label: routeLabel,
-              onClick: () => {
-                setEditingId(null);
-                setError(null);
-              },
-            },
-            { label: editingItem.name },
-          ]
-        : [{ label: routeLabel }],
-      actions:
-        editingItem || adding ? null : (
-          <button
-            type="button"
-            onClick={() => {
-              setError(null);
-              setAdding(true);
-            }}
-            className="flex items-center gap-1.5 rounded-md border border-border bg-bg-2 px-2.5 py-1.5 text-[11.5px] font-medium text-t2 transition hover:border-border-hi hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-          >
-            <Plus className="h-3.5 w-3.5" />
-            {createLabel}
-          </button>
-        ),
-    });
-
-    return () => setConfig(null);
-  }, [adding, createLabel, editingItem, routeLabel, setConfig]);
-
-  function resetAddForm() {
-    setAdding(false);
-    setName("");
-    setDescription("");
-  }
 
   function emitEditedEvent(itemId: string) {
     if (type === "skill") {
@@ -210,63 +277,37 @@ export function FrameworkScreen({
 
   function beginEdit(item: FrameworkItem) {
     setError(null);
-    setAdding(false);
     setEditingId(item.id);
-    setEditContent(item.content);
-    setEditName(item.name);
-    setEditDescription(item.description);
-    setEditIcon(item.icon ?? emojiOptions[0]!);
+    setDraftItem(item);
+    setLastSavedItem(item);
+    setEditorView("markdown");
   }
 
-  function createItem() {
-    const draft = createDraftItem(type, name, description);
-
-    startTransition(async () => {
-      try {
-        const result = await upsertFrameworkItemAction(draft);
-        setItems((current) =>
-          sortItems([
-            ...current.filter((item) => item.id !== result.item.id),
-            result.item,
-          ]),
-        );
-        resetAddForm();
-        emitEditedEvent(result.item.id);
-        setError(null);
-      } catch (actionError) {
-        setError(
-          actionError instanceof Error && actionError.message
-            ? actionError.message
-            : `Could not create the ${type}.`,
-        );
-      }
-    });
+  function resetEditor() {
+    setEditingId(null);
+    setDraftItem(null);
+    setLastSavedItem(null);
+    setEditorView("markdown");
   }
 
   function saveItem() {
-    if (!editingItem) {
-      return;
-    }
+    if (!draftItem) return;
 
     startTransition(async () => {
       try {
         const result = await upsertFrameworkItemAction({
-          ...editingItem,
-          name: editName.trim(),
-          description: editDescription.trim(),
-          icon: editIcon.trim(),
-          content: editContent,
+          ...draftItem,
+          name: draftItem.name.trim(),
+          description: draftItem.description.trim(),
+          icon: draftItem.icon?.trim() ?? null,
         });
         setItems((current) =>
           sortItems(
             current.map((item) => (item.id === result.item.id ? result.item : item)),
           ),
         );
-        setEditingId(null);
-        setEditContent("");
-        setEditName("");
-        setEditDescription("");
-        setEditIcon("");
+        setDraftItem(result.item);
+        setLastSavedItem(result.item);
         emitEditedEvent(result.item.id);
         setError(null);
       } catch (actionError) {
@@ -286,8 +327,7 @@ export function FrameworkScreen({
         setItems((current) => current.filter((item) => item.id !== itemId));
         setConfirmDeleteId(null);
         if (editingId === itemId) {
-          setEditingId(null);
-          setEditContent("");
+          resetEditor();
         }
         setError(null);
       } catch (actionError) {
@@ -301,14 +341,14 @@ export function FrameworkScreen({
   }
 
   function downloadMarkdown() {
-    if (!editingItem) return;
+    if (!draftItem) return;
 
-    const slug = (editName || editingItem.name)
+    const slug = draftItem.name
       .toLowerCase()
       .trim()
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-+|-+$/g, "");
-    const blob = new Blob([editContent], { type: "text/markdown;charset=utf-8" });
+    const blob = new Blob([draftItem.content], { type: "text/markdown;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement("a");
     anchor.href = url;
@@ -317,150 +357,237 @@ export function FrameworkScreen({
     URL.revokeObjectURL(url);
   }
 
+  useEffect(() => {
+    if (draftItem) {
+      setConfig({
+        mode: "page",
+        crumbs: [
+          {
+            label: routeLabel,
+            onClick: () => {
+              resetEditor();
+              setError(null);
+            },
+          },
+          { label: draftItem.name },
+        ],
+        onSave: saveItem,
+        saveDisabled:
+          pending ||
+          !isDirty ||
+          !draftItem.name.trim() ||
+          !draftItem.description.trim(),
+        actions: (
+          <FrameworkHeaderActionsMenu
+            entityName={type === "skill" ? "skill" : "playbook"}
+            onRename={() =>
+              setItemModalState({
+                mode: "rename",
+                initialName: draftItem.name,
+                initialDescription: draftItem.description,
+              })
+            }
+            onDelete={() => setConfirmDeleteId(draftItem.id)}
+          />
+        ),
+      });
+      return () => setConfig(null);
+    }
+
+    setConfig({
+      mode: "page",
+      crumbs: [{ label: routeLabel }],
+      actions: (
+        <button
+          type="button"
+          onClick={() => {
+            setError(null);
+            setItemModalState({
+              mode: "create",
+              initialName: "",
+              initialDescription: "",
+            });
+          }}
+          className="flex items-center gap-1.5 rounded-md border border-border bg-bg-2 px-2.5 py-1.5 text-[11.5px] font-medium text-t2 transition hover:border-border-hi hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          {createLabel}
+        </button>
+      ),
+    });
+
+    return () => setConfig(null);
+  }, [createLabel, draftItem, isDirty, pending, routeLabel, setConfig, type]);
+
   return (
     <div className="flex h-full flex-col overflow-hidden" data-testid={`framework-screen-${type}`}>
-      <div className="shrink-0 border-b border-border bg-bg px-6 py-4">
+      <div className="shrink-0 border-b border-border bg-bg px-6 py-5">
         <div className="min-w-0">
           <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
-            {editingItem ? routeLabel.slice(0, -1) || routeLabel : routeMetaLabel}
+            {draftItem ? routeLabel.slice(0, -1) || routeLabel : routeMetaLabel}
           </p>
-          <h1 className="mt-1 truncate text-[20px] font-bold tracking-tight text-t1">
-            {editingItem ? editName || editingItem.name : routeLabel}
-          </h1>
-          <p className="mt-1 text-[13px] text-t2">
-            {editingItem
-              ? editDescription || editingItem.description
-              : routeDescription}
-          </p>
+
+          {draftItem ? (
+            <div className="mt-2 flex items-start gap-3">
+              <CompactEmojiPicker
+                value={draftItem.icon || emojiOptions[0]!.emoji}
+                options={emojiOptions}
+                onSelect={(emoji) =>
+                  setDraftItem((current) => (current ? { ...current, icon: emoji } : current))
+                }
+              />
+              <div className="min-w-0">
+                <h1 className="truncate text-[22px] font-bold tracking-tight text-t1">
+                  {draftItem.name}
+                </h1>
+                <p className="mt-1 max-w-3xl text-[13px] leading-6 text-t2">
+                  {draftItem.description}
+                </p>
+              </div>
+            </div>
+          ) : (
+            <>
+              <h1 className="mt-1 truncate text-[20px] font-bold tracking-tight text-t1">
+                {routeLabel}
+              </h1>
+              <p className="mt-1 text-[13px] text-t2">{routeDescription}</p>
+            </>
+          )}
         </div>
         {error ? (
           <div className="mt-2 text-[11.5px] text-(color:--pill-blocked-t)">{error}</div>
         ) : null}
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden bg-bg-2 p-6">
-        {editingItem ? (
-          <div className="flex h-full min-h-0 flex-col rounded-[16px] border border-border bg-bg-2">
-            <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-5 py-3">
-              <div className="flex min-w-0 items-center gap-3">
-                <EmojiPicker
-                  value={editIcon || emojiOptions[0]!}
-                  options={emojiOptions}
-                  onSelect={setEditIcon}
-                />
-                <div className="min-w-0">
-                  <input
-                    value={editName}
-                    onChange={(event) => setEditName(event.target.value)}
-                    aria-label="Name"
-                    className="w-full min-w-0 bg-transparent text-[14px] font-semibold text-t1 outline-none placeholder:text-t3"
-                    placeholder={`${routeLabel.slice(0, -1)} name`}
-                  />
-                  <input
-                    value={editDescription}
-                    onChange={(event) => setEditDescription(event.target.value)}
-                    aria-label="Description"
-                    className="mt-1 w-full min-w-0 bg-transparent text-[12px] text-t2 outline-none placeholder:text-t3"
-                    placeholder="Short description"
-                  />
-                </div>
+      <div className="min-h-0 flex-1 overflow-hidden bg-bg-2">
+        {draftItem ? (
+          <div className="flex h-full min-h-0 flex-col">
+            <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-bg px-6 py-3">
+              <div
+                className="inline-flex w-fit items-center rounded-lg border border-border bg-bg-2 p-1"
+                role="tablist"
+                aria-label="Editor mode"
+              >
+                {(
+                  [
+                    ["markdown", "View", Eye],
+                    ["plain-text", "Edit", Pencil],
+                  ] as const
+                ).map(([mode, label, Icon]) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    role="tab"
+                    aria-selected={editorView === mode}
+                    onClick={() => setEditorView(mode)}
+                    className={cn(
+                      "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12px] font-medium transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+                      editorView === mode
+                        ? "bg-bg text-t1"
+                        : "text-t2 hover:bg-bg hover:text-t1",
+                    )}
+                  >
+                    <Icon className="h-3.5 w-3.5" />
+                    {label}
+                  </button>
+                ))}
               </div>
 
-              <div className="flex shrink-0 items-center gap-2">
-                <button
-                  type="button"
-                  onClick={downloadMarkdown}
-                  className="flex items-center gap-1.5 rounded-md border border-border bg-bg px-3 py-2 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-                >
-                  <Download className="h-3.5 w-3.5" />
-                  Download
-                </button>
-                <button
-                  type="button"
-                  onClick={saveItem}
-                  disabled={pending || !editName.trim() || !editDescription.trim()}
-                  className={cn(
-                    "rounded-md px-3 py-2 text-[12px] font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
-                    pending || !editName.trim() || !editDescription.trim()
-                      ? "cursor-not-allowed bg-primary text-white opacity-70"
-                      : "bg-primary text-white hover:opacity-90",
-                  )}
-                >
-                  Save
-                </button>
-              </div>
+              <button
+                type="button"
+                onClick={downloadMarkdown}
+                className="flex items-center gap-1.5 rounded-md border border-border bg-bg px-3 py-2 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+              >
+                <Download className="h-3.5 w-3.5" />
+                Download
+              </button>
             </div>
 
-            <div className="min-h-0 flex-1 p-5">
-              <textarea
-                value={editContent}
-                onChange={(event) => setEditContent(event.target.value)}
-                spellCheck={false}
-                data-testid={`framework-editor-${type}`}
-                className="h-full min-h-[320px] w-full resize-none rounded-xl border border-border bg-bg px-4 py-3 font-mono text-[12.5px] leading-6 text-t1 outline-none transition placeholder:text-t3 focus:border-primary"
-              />
+            <div className="min-h-0 flex-1 overflow-hidden px-6 py-6">
+              <div className="mx-auto flex h-full min-h-0 w-full max-w-[1120px] flex-col">
+                <div
+                  className={cn(
+                    "h-full min-h-0 overflow-auto transition-colors",
+                    editorView === "markdown"
+                      ? "bg-bg"
+                      : "rounded-[16px] bg-bg-3/65 ring-1 ring-border",
+                  )}
+                >
+                  {editorView === "markdown" ? (
+                    <div
+                      data-testid={`framework-markdown-preview-${type}`}
+                      className="min-h-full px-8 py-7"
+                    >
+                      <div className="max-w-3xl">
+                        <ReactMarkdown
+                          remarkPlugins={[remarkGfm]}
+                          components={{
+                            h1: ({ node: _node, ...props }) => (
+                              <h1 className="mb-4 text-[28px] font-bold tracking-tight text-t1" {...props} />
+                            ),
+                            h2: ({ node: _node, ...props }) => (
+                              <h2 className="mb-3 mt-8 text-[22px] font-semibold tracking-tight text-t1" {...props} />
+                            ),
+                            h3: ({ node: _node, ...props }) => (
+                              <h3 className="mb-2 mt-6 text-[17px] font-semibold text-t1" {...props} />
+                            ),
+                            p: ({ node: _node, ...props }) => (
+                              <p className="mb-4 text-[14px] leading-7 text-t1" {...props} />
+                            ),
+                            ul: ({ node: _node, ...props }) => (
+                              <ul className="mb-4 list-disc space-y-2 pl-6" {...props} />
+                            ),
+                            ol: ({ node: _node, ...props }) => (
+                              <ol className="mb-4 list-decimal space-y-2 pl-6" {...props} />
+                            ),
+                            li: ({ node: _node, ...props }) => (
+                              <li className="text-[14px] leading-7 text-t1" {...props} />
+                            ),
+                            blockquote: ({ node: _node, ...props }) => (
+                              <blockquote className="mb-4 border-l-2 border-border-hi pl-4 italic text-t2" {...props} />
+                            ),
+                            code: ({ node: _node, className, ...props }) => (
+                              <code
+                                className={cn(
+                                  "rounded bg-bg-2 px-1.5 py-0.5 font-mono text-[12px] text-t1",
+                                  className,
+                                )}
+                                {...props}
+                              />
+                            ),
+                            pre: ({ node: _node, ...props }) => (
+                              <pre className="mb-4 overflow-x-auto rounded-xl border border-border bg-bg-2 p-4 font-mono text-[12px] text-t1" {...props} />
+                            ),
+                            a: ({ node: _node, ...props }) => (
+                              <a className="text-accent underline underline-offset-2" {...props} />
+                            ),
+                          }}
+                        >
+                          {draftItem.content || "_No content yet._"}
+                        </ReactMarkdown>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="min-h-full px-5 py-5">
+                      <textarea
+                        value={draftItem.content}
+                        onChange={(event) =>
+                          setDraftItem((current) =>
+                            current ? { ...current, content: event.target.value } : current,
+                          )
+                        }
+                        spellCheck={false}
+                        data-testid={`framework-editor-${type}`}
+                        className="block min-h-full w-full resize-none rounded-[12px] bg-bg px-6 py-6 font-mono text-[13px] leading-7 text-t1 outline-none transition placeholder:text-t3"
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
             </div>
           </div>
         ) : (
-          <div className="flex h-full min-h-0 flex-col">
-            {adding ? (
-              <div
-                className="mb-5 shrink-0 rounded-[14px] border border-border bg-bg px-5 py-4"
-                data-testid={`framework-add-form-${type}`}
-              >
-                <div className="grid gap-3 md:grid-cols-[minmax(0,220px)_minmax(0,1fr)_auto] md:items-end">
-                  <div className="min-w-0">
-                    <label className="mb-1.5 block text-[10px] font-semibold uppercase tracking-[0.13em] text-t3">
-                      Name
-                    </label>
-                    <input
-                      value={name}
-                      onChange={(event) => setName(event.target.value)}
-                      placeholder={type === "skill" ? "Skill name" : "Playbook name"}
-                      className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-[12.5px] text-t1 outline-none transition placeholder:text-t3 focus:border-primary"
-                    />
-                  </div>
-                  <div className="min-w-0">
-                    <label className="mb-1.5 block text-[10px] font-semibold uppercase tracking-[0.13em] text-t3">
-                      Description
-                    </label>
-                    <input
-                      value={description}
-                      onChange={(event) => setDescription(event.target.value)}
-                      placeholder="Short description"
-                      className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-[12.5px] text-t1 outline-none transition placeholder:text-t3 focus:border-primary"
-                    />
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={createItem}
-                      disabled={pending || !name.trim() || !description.trim()}
-                      className={cn(
-                        "rounded-md px-3 py-2 text-[12px] font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
-                        pending || !name.trim() || !description.trim()
-                          ? "cursor-not-allowed bg-primary text-white opacity-70"
-                          : "bg-primary text-white hover:opacity-90",
-                      )}
-                    >
-                      Create
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        resetAddForm();
-                        setError(null);
-                      }}
-                      disabled={pending}
-                      className="rounded-md border border-border bg-bg px-3 py-2 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </div>
-              </div>
-            ) : null}
-
+          <div className="flex h-full min-h-0 flex-col p-6">
             <div className="min-h-0 flex-1 overflow-auto px-1 py-2">
               <div
                 className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]"
@@ -479,35 +606,21 @@ export function FrameworkScreen({
                       }
                     }}
                     data-testid={`framework-card-${item.id}`}
-                    className="group relative flex h-[104px] cursor-pointer items-center gap-3 overflow-hidden rounded-[7px] border border-border bg-bg-2 px-4 py-4 text-left transition-all duration-150 hover:border-border-hi hover:bg-bg-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                    className="group flex h-[104px] cursor-pointer items-center gap-3 overflow-hidden rounded-[10px] border border-border bg-bg px-4 py-4 text-left transition-all duration-150 hover:border-border-hi hover:bg-bg-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
                   >
                     <span
-                      className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[7px] border border-border bg-bg text-[18px]"
+                      className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] border border-border bg-bg-2 text-[18px]"
                       aria-hidden
                     >
                       {item.icon || (type === "skill" ? "🤖" : "📄")}
                     </span>
-                    <span className="min-w-0 flex-1 overflow-hidden pr-8">
+                    <span className="min-w-0 flex-1 overflow-hidden">
                       <span className="block overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-semibold text-t1">
                         {item.name}
                       </span>
                       <span className="mt-1 block overflow-hidden text-[11.5px] leading-[1.35] text-t2 [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]">
                         {item.description}
                       </span>
-                    </span>
-                    <span className="absolute right-3 top-3 flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-[8px] border border-border bg-bg-3 text-t3 opacity-0 transition group-hover:opacity-100">
-                      <button
-                        type="button"
-                        title={`Delete ${item.name}`}
-                        aria-label={`Delete ${item.name}`}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          setConfirmDeleteId(item.id);
-                        }}
-                        className="flex h-full w-full cursor-pointer items-center justify-center rounded-[8px] hover:bg-[linear-gradient(180deg,#ef4444,#dc2626)] hover:text-[#fff7f7] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#f87171]"
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </button>
                     </span>
                   </div>
                 ))}
@@ -528,6 +641,71 @@ export function FrameworkScreen({
           </div>
         )}
       </div>
+
+      {itemModalState ? (
+        <FrameworkItemModal
+          title={
+            itemModalState.mode === "create"
+              ? `Create ${type === "skill" ? "skill" : "playbook"}`
+              : `Rename ${type === "skill" ? "skill" : "playbook"}`
+          }
+          description={
+            itemModalState.mode === "create"
+              ? `Add the ${type === "skill" ? "skill" : "playbook"} title and description first.`
+              : `Update the ${type === "skill" ? "skill" : "playbook"} title and description.`
+          }
+          initialName={itemModalState.initialName}
+          initialDescription={itemModalState.initialDescription}
+          submitLabel={itemModalState.mode === "create" ? "Create" : "Apply"}
+          pending={pending}
+          onClose={() => {
+            if (!pending) {
+              setItemModalState(null);
+            }
+          }}
+          onSubmit={({ name, description }) => {
+            if (itemModalState.mode === "rename") {
+              setDraftItem((current) =>
+                current
+                  ? {
+                      ...current,
+                      name: name.trim(),
+                      description: description.trim(),
+                    }
+                  : current,
+              );
+              setItemModalState(null);
+              return;
+            }
+
+            const draft = createDraftItem(type, name, description);
+            startTransition(async () => {
+              try {
+                const result = await upsertFrameworkItemAction(draft);
+                setItems((current) =>
+                  sortItems([
+                    ...current.filter((item) => item.id !== result.item.id),
+                    result.item,
+                  ]),
+                );
+                setItemModalState(null);
+                setEditingId(result.item.id);
+                setDraftItem(result.item);
+                setLastSavedItem(result.item);
+                setEditorView("markdown");
+                emitEditedEvent(result.item.id);
+                setError(null);
+              } catch (actionError) {
+                setError(
+                  actionError instanceof Error && actionError.message
+                    ? actionError.message
+                    : `Could not create the ${type}.`,
+                );
+              }
+            });
+          }}
+        />
+      ) : null}
 
       {deleteTarget ? (
         <ConfirmModal

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -766,7 +766,7 @@ export function FrameworkScreen({
 
       <div className="flex min-h-0 flex-1 overflow-hidden bg-bg-2">
         {draftItem ? (
-          <div className="flex h-full min-h-0 flex-col">
+          <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
             <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-bg px-6 py-3">
               <div
                 className="inline-flex w-fit items-center rounded-lg border border-border bg-bg-2 p-1"
@@ -1021,19 +1021,19 @@ export function FrameworkScreen({
                       <div className="flex w-full justify-start md:ml-auto md:w-auto md:justify-end">
                         <div
                           className={cn(
-                            "flex items-center overflow-hidden rounded-xl border border-border bg-bg-2 transition-[width,border-color,background-color,box-shadow] duration-200",
+                            "flex items-center overflow-hidden rounded-lg border border-border bg-bg-2 transition-[width,border-color,background-color,box-shadow] duration-200",
                             searchOpen || searchQuery.length > 0
-                              ? "w-full max-w-[360px] border-border-hi bg-bg-3 shadow-[0_12px_30px_rgba(15,23,42,0.08)]"
-                              : "w-12",
+                              ? "w-full max-w-[320px] border-border-hi bg-bg-3 shadow-[0_10px_24px_rgba(15,23,42,0.08)]"
+                              : "w-10",
                           )}
                         >
                           <button
                             type="button"
                             aria-label={`Search ${type === "skill" ? "skills" : "playbooks"}`}
                             onClick={() => setSearchOpen(true)}
-                            className="flex h-12 w-12 shrink-0 items-center justify-center text-t3 transition hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                            className="flex h-10 w-10 shrink-0 items-center justify-center text-t3 transition hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
                           >
-                            <Search className="h-4 w-4" />
+                            <Search className="h-3.5 w-3.5" />
                           </button>
                           <input
                             ref={searchInputRef}
@@ -1047,9 +1047,9 @@ export function FrameworkScreen({
                             }}
                             placeholder={`Search ${type === "skill" ? "skills" : "playbooks"}`}
                             className={cn(
-                              "min-w-0 bg-transparent pr-4 text-[13px] text-t1 outline-none placeholder:text-t3 transition-[opacity,width,padding] duration-200",
+                              "min-w-0 bg-transparent pr-3 text-[12.5px] text-t1 outline-none placeholder:text-t3 transition-[opacity,width,padding] duration-200",
                               searchOpen || searchQuery.length > 0
-                                ? "w-[min(308px,calc(100vw-10rem))] px-0 opacity-100"
+                                ? "w-[min(274px,calc(100vw-10rem))] px-0 opacity-100"
                                 : "w-0 px-0 opacity-0",
                             )}
                           />
@@ -1061,9 +1061,9 @@ export function FrameworkScreen({
                                 setSearchQuery("");
                                 searchInputRef.current?.focus();
                               }}
-                              className="mr-2 flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-t3 transition hover:bg-bg hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                              className="mr-1.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-t3 transition hover:bg-bg hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
                             >
-                              <X className="h-3.5 w-3.5" />
+                              <X className="h-3 w-3" />
                             </button>
                           ) : null}
                         </div>
@@ -1083,24 +1083,24 @@ export function FrameworkScreen({
                           type="button"
                           onClick={() => beginEdit(item)}
                           data-testid={`framework-card-${item.id}`}
-                          className="group flex min-h-[168px] flex-col justify-between rounded-[18px] border border-border bg-bg-2/88 px-5 py-5 text-left transition-[background-color,border-color,transform,box-shadow] duration-150 hover:border-border-hi hover:bg-bg-3/92 hover:shadow-[0_16px_40px_rgba(15,23,42,0.08)] focus-visible:-translate-y-[1px] focus-visible:border-border-hi focus-visible:bg-bg-3/92 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                          className="group flex min-h-[92px] flex-col justify-center rounded-[16px] border border-border bg-bg-2/88 px-4 py-4 text-left transition-[background-color,border-color,transform,box-shadow] duration-150 hover:border-border-hi hover:bg-bg-3/92 hover:shadow-[0_14px_34px_rgba(15,23,42,0.08)] focus-visible:-translate-y-[1px] focus-visible:border-border-hi focus-visible:bg-bg-3/92 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
                         >
-                          <div className="flex items-start justify-between gap-4">
-                            <div className="min-w-0 flex-1">
-                              <h2 className="overflow-hidden text-[18px] leading-[1.15] font-semibold tracking-[-0.02em] text-t1 [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]">
-                                {item.name}
-                              </h2>
-                            </div>
+                          <div className="flex min-w-0 items-center gap-3">
                             <span
-                              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-border bg-bg text-[18px] text-t1 transition-colors group-hover:border-border-hi group-hover:bg-bg-2"
+                              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border bg-bg text-[15px] text-t1 transition-colors group-hover:border-border-hi group-hover:bg-bg-2"
                               aria-hidden
                             >
                               {item.icon || (type === "skill" ? "🤖" : "📄")}
                             </span>
+                            <div className="min-w-0 flex-1">
+                              <h2 className="overflow-hidden whitespace-nowrap text-[16px] leading-[1.15] font-semibold tracking-[-0.02em] text-t1 text-ellipsis">
+                                {item.name}
+                              </h2>
+                            </div>
                           </div>
 
-                          <div className="mt-5 min-w-0">
-                            <p className="overflow-hidden text-[13px] leading-6 text-t2 [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:3]">
+                          <div className="mt-2 min-w-0">
+                            <p className="overflow-hidden whitespace-nowrap text-[12.5px] leading-[1.35rem] text-t2 text-ellipsis">
                               {item.description}
                             </p>
                           </div>

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -16,6 +16,7 @@ import {
   Search,
   Sparkles,
   TextQuote,
+  Upload,
   WrapText,
   Italic,
 } from "lucide-react";
@@ -263,6 +264,7 @@ export function FrameworkScreen({
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
   const editorTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const importInputRef = useRef<HTMLInputElement | null>(null);
   const pendingSelectionRef = useRef<EditorSelection | null>(null);
   const pendingViewportRef = useRef<EditorViewport | null>(null);
 
@@ -488,6 +490,16 @@ export function FrameworkScreen({
       onClick: () => toggleLinePrefix("## ", "Subheading"),
     },
     {
+      label: "Numbered list",
+      icon: ListOrdered,
+      onClick: () => toggleLinePrefix("1. ", "List item"),
+    },
+    {
+      label: "Bulleted list",
+      icon: List,
+      onClick: () => toggleLinePrefix("- ", "List item"),
+    },
+    {
       label: "Bold",
       icon: Bold,
       onClick: () => toggleInlineWrap("**", "bold text"),
@@ -501,16 +513,6 @@ export function FrameworkScreen({
       label: "Link",
       icon: Link2,
       onClick: insertLink,
-    },
-    {
-      label: "Bulleted list",
-      icon: List,
-      onClick: () => toggleLinePrefix("- ", "List item"),
-    },
-    {
-      label: "Numbered list",
-      icon: ListOrdered,
-      onClick: () => toggleLinePrefix("1. ", "List item"),
     },
     {
       label: "Quote",
@@ -594,6 +596,32 @@ export function FrameworkScreen({
     anchor.download = `${slug || "framework-item"}.md`;
     anchor.click();
     URL.revokeObjectURL(url);
+  }
+
+  function readMarkdownFile(file: File): Promise<string> {
+    if (typeof file.text === "function") {
+      return file.text();
+    }
+
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(typeof reader.result === "string" ? reader.result : "");
+      reader.onerror = () => reject(new Error("Could not read file."));
+      reader.readAsText(file);
+    });
+  }
+
+  async function importMarkdownFile(file: File) {
+    if (!file) return;
+
+    try {
+      const nextContent = await readMarkdownFile(file);
+      updateDraftContent(nextContent);
+      setError(null);
+      setEditorView("plain-text");
+    } catch {
+      setError("Could not read the markdown file.");
+    }
   }
 
   useEffect(() => {
@@ -732,14 +760,40 @@ export function FrameworkScreen({
                 ))}
               </div>
 
-              <button
-                type="button"
-                onClick={downloadMarkdown}
-                className="flex items-center gap-1.5 rounded-md border border-border bg-bg px-3 py-2 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-              >
-                <Download className="h-3.5 w-3.5" />
-                Download
-              </button>
+              <div className="flex items-center gap-2">
+                <input
+                  ref={importInputRef}
+                  type="file"
+                  accept=".md,text/markdown"
+                  className="sr-only"
+                  aria-label="Upload markdown file"
+                  onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) {
+                      void importMarkdownFile(file);
+                    }
+                    event.currentTarget.value = "";
+                  }}
+                />
+
+                <button
+                  type="button"
+                  onClick={() => importInputRef.current?.click()}
+                  className="flex items-center gap-1.5 rounded-md border border-border bg-bg px-3 py-2 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                >
+                  <Upload className="h-3.5 w-3.5" />
+                  Upload
+                </button>
+
+                <button
+                  type="button"
+                  onClick={downloadMarkdown}
+                  className="flex items-center gap-1.5 rounded-md border border-border bg-bg px-3 py-2 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                >
+                  <Download className="h-3.5 w-3.5" />
+                  Download
+                </button>
+              </div>
             </div>
 
             <div className="min-h-0 flex-1 overflow-hidden px-6 py-6">

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -1,13 +1,23 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, useTransition } from "react";
 import {
+  Bold,
+  Code,
+  Heading1,
+  Heading2,
   Download,
   Eye,
+  Link2,
+  List,
+  ListOrdered,
   Pencil,
   Plus,
   Search,
   Sparkles,
+  TextQuote,
+  WrapText,
+  Italic,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -38,6 +48,16 @@ type FrameworkItemModalState =
       initialName: string;
       initialDescription: string;
     };
+
+type EditorSelection = {
+  start: number;
+  end: number;
+};
+
+type EditorViewport = {
+  scrollTop: number;
+  scrollLeft: number;
+};
 
 const SKILL_EMOJIS = [
   { emoji: "🤖", label: "Robot", keywords: ["agent", "ai", "automation"] },
@@ -242,6 +262,9 @@ export function FrameworkScreen({
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const editorTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const pendingSelectionRef = useRef<EditorSelection | null>(null);
+  const pendingViewportRef = useRef<EditorViewport | null>(null);
 
   const routeLabel = type === "skill" ? "Skills" : "Playbooks";
   const routeMetaLabel = type === "skill" ? "Framework library" : "Framework procedures";
@@ -266,6 +289,29 @@ export function FrameworkScreen({
     setItems(initialItems);
   }, [initialItems]);
 
+  useLayoutEffect(() => {
+    if (editorView !== "plain-text") {
+      return;
+    }
+
+    const nextSelection = pendingSelectionRef.current;
+    const nextViewport = pendingViewportRef.current;
+    pendingSelectionRef.current = null;
+    pendingViewportRef.current = null;
+
+    if (!editorTextareaRef.current) return;
+
+    if (nextSelection) {
+      editorTextareaRef.current.focus();
+      editorTextareaRef.current.setSelectionRange(nextSelection.start, nextSelection.end);
+    }
+
+    if (nextViewport) {
+      editorTextareaRef.current.scrollTop = nextViewport.scrollTop;
+      editorTextareaRef.current.scrollLeft = nextViewport.scrollLeft;
+    }
+  }, [draftItem?.content, editorView]);
+
   function emitEditedEvent(itemId: string) {
     if (type === "skill") {
       capture("framework.skill_edited", {
@@ -289,6 +335,199 @@ export function FrameworkScreen({
     setLastSavedItem(null);
     setEditorView("markdown");
   }
+
+  function updateDraftContent(
+    nextContent: string,
+    options?: {
+      selection?: EditorSelection;
+      viewport?: EditorViewport;
+    },
+  ) {
+    setDraftItem((current) => (current ? { ...current, content: nextContent } : current));
+    pendingSelectionRef.current = options?.selection ?? null;
+    pendingViewportRef.current = options?.viewport ?? null;
+  }
+
+  function withEditorSelection(
+    transform: (context: {
+      content: string;
+      selectionStart: number;
+      selectionEnd: number;
+    }) => { content: string; selection: EditorSelection },
+  ) {
+    const textarea = editorTextareaRef.current;
+    if (!draftItem || !textarea) return;
+
+    const result = transform({
+      content: draftItem.content,
+      selectionStart: textarea.selectionStart ?? 0,
+      selectionEnd: textarea.selectionEnd ?? 0,
+    });
+
+    updateDraftContent(result.content, {
+      selection: result.selection,
+      viewport: {
+        scrollTop: textarea.scrollTop,
+        scrollLeft: textarea.scrollLeft,
+      },
+    });
+  }
+
+  function toggleInlineWrap(token: string, placeholder: string) {
+    withEditorSelection(({ content, selectionStart, selectionEnd }) => {
+      const selectedText = content.slice(selectionStart, selectionEnd);
+      const hasSelection = selectionStart !== selectionEnd;
+      const wrappedSelection =
+        selectionStart >= token.length &&
+        content.slice(selectionStart - token.length, selectionStart) === token &&
+        content.slice(selectionEnd, selectionEnd + token.length) === token;
+
+      if (wrappedSelection) {
+        const nextContent =
+          content.slice(0, selectionStart - token.length) +
+          selectedText +
+          content.slice(selectionEnd + token.length);
+        return {
+          content: nextContent,
+          selection: {
+            start: selectionStart - token.length,
+            end: selectionEnd - token.length,
+          },
+        };
+      }
+
+      const insertedText = hasSelection ? selectedText : placeholder;
+      const nextContent =
+        content.slice(0, selectionStart) +
+        token +
+        insertedText +
+        token +
+        content.slice(selectionEnd);
+
+      return {
+        content: nextContent,
+        selection: {
+          start: selectionStart + token.length,
+          end: selectionStart + token.length + insertedText.length,
+        },
+      };
+    });
+  }
+
+  function toggleLinePrefix(prefix: string, placeholder: string) {
+    withEditorSelection(({ content, selectionStart, selectionEnd }) => {
+      const lineStart = content.lastIndexOf("\n", Math.max(selectionStart - 1, 0)) + 1;
+      let lineEnd = content.indexOf("\n", selectionEnd);
+      if (lineEnd === -1) lineEnd = content.length;
+
+      const block = content.slice(lineStart, lineEnd);
+      const lines = block.length > 0 ? block.split("\n") : [""];
+      const shouldRemove = lines.every((line) => line.startsWith(prefix));
+      const normalizedLines = shouldRemove
+        ? lines.map((line) => line.slice(prefix.length))
+        : lines.map((line) => (line.length > 0 ? `${prefix}${line}` : `${prefix}${placeholder}`));
+      const nextBlock = normalizedLines.join("\n");
+      const nextContent = content.slice(0, lineStart) + nextBlock + content.slice(lineEnd);
+
+      return {
+        content: nextContent,
+        selection: {
+          start: lineStart,
+          end: lineStart + nextBlock.length,
+        },
+      };
+    });
+  }
+
+  function insertLink() {
+    withEditorSelection(({ content, selectionStart, selectionEnd }) => {
+      const selectedText = content.slice(selectionStart, selectionEnd) || "link text";
+      const linkText = `[${selectedText}](https://example.com)`;
+      const nextContent =
+        content.slice(0, selectionStart) + linkText + content.slice(selectionEnd);
+
+      return {
+        content: nextContent,
+        selection: {
+          start: selectionStart + 1,
+          end: selectionStart + 1 + selectedText.length,
+        },
+      };
+    });
+  }
+
+  function insertCodeBlock() {
+    withEditorSelection(({ content, selectionStart, selectionEnd }) => {
+      const selectedText = content.slice(selectionStart, selectionEnd).trim() || "code";
+      const prefix = selectionStart > 0 && content[selectionStart - 1] !== "\n" ? "\n" : "";
+      const suffix = selectionEnd < content.length && content[selectionEnd] !== "\n" ? "\n" : "";
+      const block = `${prefix}\`\`\`\n${selectedText}\n\`\`\`${suffix}`;
+      const nextContent =
+        content.slice(0, selectionStart) + block + content.slice(selectionEnd);
+      const codeStart = selectionStart + prefix.length + 4;
+
+      return {
+        content: nextContent,
+        selection: {
+          start: codeStart,
+          end: codeStart + selectedText.length,
+        },
+      };
+    });
+  }
+
+  const toolbarItems = [
+    {
+      label: "Heading",
+      icon: Heading1,
+      onClick: () => toggleLinePrefix("# ", "Heading"),
+    },
+    {
+      label: "Subheading",
+      icon: Heading2,
+      onClick: () => toggleLinePrefix("## ", "Subheading"),
+    },
+    {
+      label: "Bold",
+      icon: Bold,
+      onClick: () => toggleInlineWrap("**", "bold text"),
+    },
+    {
+      label: "Italic",
+      icon: Italic,
+      onClick: () => toggleInlineWrap("*", "italic text"),
+    },
+    {
+      label: "Link",
+      icon: Link2,
+      onClick: insertLink,
+    },
+    {
+      label: "Bulleted list",
+      icon: List,
+      onClick: () => toggleLinePrefix("- ", "List item"),
+    },
+    {
+      label: "Numbered list",
+      icon: ListOrdered,
+      onClick: () => toggleLinePrefix("1. ", "List item"),
+    },
+    {
+      label: "Quote",
+      icon: TextQuote,
+      onClick: () => toggleLinePrefix("> ", "Quoted text"),
+    },
+    {
+      label: "Inline code",
+      icon: Code,
+      onClick: () => toggleInlineWrap("`", "code"),
+    },
+    {
+      label: "Code block",
+      icon: WrapText,
+      onClick: insertCodeBlock,
+    },
+  ] as const;
 
   function saveItem() {
     if (!draftItem) return;
@@ -586,25 +825,37 @@ export function FrameworkScreen({
                       </div>
                     </div>
                   ) : (
-                    <div className="h-full min-h-0 overflow-auto">
-                      <div className="flex min-h-full w-full flex-col">
-                        <div className="flex items-center justify-between gap-3 border-b border-white/8 px-5 py-4 md:px-6">
-                          <div className="flex items-center gap-2" aria-hidden>
-                            <span className="h-2.5 w-2.5 rounded-full bg-[#fb7185]/80" />
-                            <span className="h-2.5 w-2.5 rounded-full bg-[#fbbf24]/80" />
-                            <span className="h-2.5 w-2.5 rounded-full bg-[#4ade80]/80" />
+                    <div className="h-full min-h-0 overflow-hidden">
+                      <div className="flex h-full min-h-0 w-full flex-col">
+                        <div className="flex items-center justify-between gap-3 border-b border-white/8 bg-[#0f172a] px-5 py-4 md:px-6">
+                          <div className="min-w-0 flex-1">
+                            <div
+                              className="flex flex-wrap items-center gap-1.5"
+                              role="toolbar"
+                              aria-label="Markdown formatting"
+                            >
+                              {toolbarItems.map(({ label, icon: Icon, onClick }) => (
+                                <button
+                                  key={label}
+                                  type="button"
+                                  aria-label={label}
+                                  title={label}
+                                  onClick={onClick}
+                                  className="flex h-8 w-8 items-center justify-center rounded-md bg-slate-800/75 text-slate-200 transition hover:bg-slate-700 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                                >
+                                  <Icon className="h-3.5 w-3.5" />
+                                </button>
+                              ))}
+                            </div>
                           </div>
                           <div className="min-w-0 text-right">
-                            <p className="truncate font-mono text-[11px] uppercase tracking-[0.16em] text-slate-400">
+                            <p className="truncate font-mono text-[11px] uppercase tracking-[0.16em] text-slate-300">
                               Markdown editor
-                            </p>
-                            <p className="truncate text-[11.5px] text-slate-500">
-                              Plain text source
                             </p>
                           </div>
                         </div>
 
-                        <div className="min-h-0 flex-1 bg-linear-to-b from-[#111c31] to-[#0b1324]">
+                        <div className="min-h-0 flex-1 overflow-auto bg-linear-to-b from-[#111c31] to-[#0b1324]">
                           <div className="flex min-h-full">
                             <div
                               className="hidden w-14 shrink-0 select-none border-r border-white/7 bg-white/[0.02] px-2 py-5 text-right font-mono text-[11px] leading-7 text-slate-500 md:block"
@@ -624,11 +875,15 @@ export function FrameworkScreen({
                             </div>
 
                             <textarea
+                              ref={editorTextareaRef}
                               value={draftItem.content}
                               onChange={(event) =>
-                                setDraftItem((current) =>
-                                  current ? { ...current, content: event.target.value } : current,
-                                )
+                                updateDraftContent(event.target.value, {
+                                  viewport: {
+                                    scrollTop: event.target.scrollTop,
+                                    scrollLeft: event.target.scrollLeft,
+                                  },
+                                })
                               }
                               spellCheck={false}
                               data-testid={`framework-editor-${type}`}

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, useTransition } from "react";
+import {
+  useDeferredValue,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import {
   Bold,
   Code,
@@ -15,6 +23,7 @@ import {
   Plus,
   Search,
   Sparkles,
+  X,
   TextQuote,
   Upload,
   WrapText,
@@ -262,11 +271,15 @@ export function FrameworkScreen({
   const [itemModalState, setItemModalState] = useState<FrameworkItemModalState>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchOpen, setSearchOpen] = useState(false);
   const [pending, startTransition] = useTransition();
   const editorTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const importInputRef = useRef<HTMLInputElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
   const pendingSelectionRef = useRef<EditorSelection | null>(null);
   const pendingViewportRef = useRef<EditorViewport | null>(null);
+  const deferredSearchQuery = useDeferredValue(searchQuery);
 
   const routeLabel = type === "skill" ? "Skills" : "Playbooks";
   const routeMetaLabel = type === "skill" ? "Framework library" : "Framework procedures";
@@ -276,20 +289,42 @@ export function FrameworkScreen({
       : "A compact library of reusable execution procedures. Select a playbook to read or edit its markdown source.";
   const createLabel = type === "skill" ? "New skill" : "New playbook";
   const emojiOptions = type === "skill" ? SKILL_EMOJIS : PLAYBOOK_EMOJIS;
-  const filteredItems = useMemo(
+  const typedItems = useMemo(
     () => items.filter((item) => item.type === type),
     [items, type],
+  );
+  const normalizedSearchQuery = deferredSearchQuery.trim().toLowerCase();
+  const filteredItems = useMemo(() => {
+    if (normalizedSearchQuery.length === 0) {
+      return typedItems;
+    }
+
+    return typedItems.filter((item) =>
+      [item.name, item.description, item.content, item.id]
+        .filter(Boolean)
+        .some((value) => value.toLowerCase().includes(normalizedSearchQuery)),
+    );
+  }, [normalizedSearchQuery, typedItems]);
+  const visibleItems = useMemo(
+    () => [...filteredItems].sort((left, right) => left.name.localeCompare(right.name)),
+    [filteredItems],
   );
   const isDirty =
     draftItem !== null &&
     (lastSavedItem === null || !areFrameworkItemsEqual(draftItem, lastSavedItem));
   const deleteTarget =
-    filteredItems.find((item) => item.id === confirmDeleteId) ??
+    typedItems.find((item) => item.id === confirmDeleteId) ??
     (draftItem?.id === confirmDeleteId ? draftItem : null);
 
   useEffect(() => {
     setItems(initialItems);
   }, [initialItems]);
+
+  useEffect(() => {
+    if (searchOpen) {
+      searchInputRef.current?.focus();
+    }
+  }, [searchOpen]);
 
   useLayoutEffect(() => {
     if (editorView !== "plain-text") {
@@ -687,7 +722,10 @@ export function FrameworkScreen({
   }, [createLabel, draftItem, isDirty, pending, routeLabel, setConfig, type]);
 
   return (
-    <div className="flex h-full flex-col overflow-hidden" data-testid={`framework-screen-${type}`}>
+    <div
+      className="flex h-full min-h-0 flex-col overflow-hidden"
+      data-testid={`framework-screen-${type}`}
+    >
       <div className="shrink-0 border-b border-border bg-bg px-6 py-5">
         <div className="min-w-0">
           <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
@@ -726,7 +764,7 @@ export function FrameworkScreen({
         ) : null}
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden bg-bg-2">
+      <div className="flex min-h-0 flex-1 overflow-hidden bg-bg-2">
         {draftItem ? (
           <div className="flex h-full min-h-0 flex-col">
             <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-bg px-6 py-3">
@@ -953,55 +991,144 @@ export function FrameworkScreen({
             </div>
           </div>
         ) : (
-          <div className="flex h-full min-h-0 flex-col p-6">
-            <div className="min-h-0 flex-1 overflow-auto px-1 py-2">
-              <div
-                className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]"
-                data-testid={`framework-grid-${type}`}
-              >
-                {filteredItems.map((item) => (
-                  <div
-                    key={item.id}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => beginEdit(item)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        beginEdit(item);
-                      }
-                    }}
-                    data-testid={`framework-card-${item.id}`}
-                    className="group flex h-[104px] cursor-pointer items-center gap-3 overflow-hidden rounded-[10px] border border-border bg-bg px-4 py-4 text-left transition-all duration-150 hover:border-border-hi hover:bg-bg-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-                  >
-                    <span
-                      className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] border border-border bg-bg-2 text-[18px]"
-                      aria-hidden
-                    >
-                      {item.icon || (type === "skill" ? "🤖" : "📄")}
-                    </span>
-                    <span className="min-w-0 flex-1 overflow-hidden">
-                      <span className="block overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-semibold text-t1">
-                        {item.name}
-                      </span>
-                      <span className="mt-1 block overflow-hidden text-[11.5px] leading-[1.35] text-t2 [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]">
-                        {item.description}
-                      </span>
-                    </span>
-                  </div>
-                ))}
+          <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden px-6 py-6">
+            <div className="mx-auto flex h-full min-h-0 w-full max-w-[1180px] flex-col">
+              <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-[22px] border border-border bg-linear-to-b from-bg to-bg-2/92 shadow-[0_24px_80px_rgba(15,23,42,0.08)]">
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                  <div className="sticky top-0 z-10 border-b border-border bg-linear-to-b from-bg via-bg to-bg-2/96 px-3 py-5 backdrop-blur-sm md:px-4">
+                    <div className="flex flex-wrap items-end justify-between gap-4 md:flex-nowrap">
+                      <div className="min-w-0">
+                        <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+                          {typedItems.length} {type === "skill" ? "skills" : "playbooks"}
+                        </p>
+                        <p className="mt-2 text-[15px] font-semibold tracking-[-0.01em] text-t1">
+                          {normalizedSearchQuery.length > 0
+                            ? `${filteredItems.length} matching ${
+                                filteredItems.length === 1
+                                  ? type === "skill"
+                                    ? "skill"
+                                    : "playbook"
+                                  : type === "skill"
+                                    ? "skills"
+                                    : "playbooks"
+                              }`
+                            : type === "skill"
+                              ? "Skill Library"
+                              : "Playbook Library"}
+                        </p>
+                      </div>
 
-                {filteredItems.length === 0 ? (
-                  <div className="col-span-full flex min-h-[180px] flex-col items-center justify-center rounded-[14px] border border-dashed border-border-hi bg-bg px-6 text-center">
-                    <Sparkles className="mb-3 h-5 w-5 text-t3" />
-                    <p className="text-[13px] font-medium text-t1">
-                      No {type === "skill" ? "skills" : "playbooks"} yet
-                    </p>
-                    <p className="mt-1 max-w-sm text-[11.5px] leading-5 text-t3">
-                      Create the first {type === "skill" ? "skill" : "playbook"} to populate this library.
-                    </p>
+                      <div className="flex w-full justify-start md:ml-auto md:w-auto md:justify-end">
+                        <div
+                          className={cn(
+                            "flex items-center overflow-hidden rounded-xl border border-border bg-bg-2 transition-[width,border-color,background-color,box-shadow] duration-200",
+                            searchOpen || searchQuery.length > 0
+                              ? "w-full max-w-[360px] border-border-hi bg-bg-3 shadow-[0_12px_30px_rgba(15,23,42,0.08)]"
+                              : "w-12",
+                          )}
+                        >
+                          <button
+                            type="button"
+                            aria-label={`Search ${type === "skill" ? "skills" : "playbooks"}`}
+                            onClick={() => setSearchOpen(true)}
+                            className="flex h-12 w-12 shrink-0 items-center justify-center text-t3 transition hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                          >
+                            <Search className="h-4 w-4" />
+                          </button>
+                          <input
+                            ref={searchInputRef}
+                            value={searchQuery}
+                            onChange={(event) => setSearchQuery(event.target.value)}
+                            onFocus={() => setSearchOpen(true)}
+                            onBlur={() => {
+                              if (searchQuery.trim().length === 0) {
+                                setSearchOpen(false);
+                              }
+                            }}
+                            placeholder={`Search ${type === "skill" ? "skills" : "playbooks"}`}
+                            className={cn(
+                              "min-w-0 bg-transparent pr-4 text-[13px] text-t1 outline-none placeholder:text-t3 transition-[opacity,width,padding] duration-200",
+                              searchOpen || searchQuery.length > 0
+                                ? "w-[min(308px,calc(100vw-10rem))] px-0 opacity-100"
+                                : "w-0 px-0 opacity-0",
+                            )}
+                          />
+                          {searchQuery.length > 0 ? (
+                            <button
+                              type="button"
+                              aria-label="Clear search"
+                              onClick={() => {
+                                setSearchQuery("");
+                                searchInputRef.current?.focus();
+                              }}
+                              className="mr-2 flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-t3 transition hover:bg-bg hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                            >
+                              <X className="h-3.5 w-3.5" />
+                            </button>
+                          ) : null}
+                        </div>
+                      </div>
+                    </div>
                   </div>
-                ) : null}
+
+                  <div className="p-3 md:p-4">
+                  {visibleItems.length > 0 ? (
+                    <div
+                      className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+                      data-testid={`framework-grid-${type}`}
+                    >
+                      {visibleItems.map((item) => (
+                        <button
+                          key={item.id}
+                          type="button"
+                          onClick={() => beginEdit(item)}
+                          data-testid={`framework-card-${item.id}`}
+                          className="group flex min-h-[168px] flex-col justify-between rounded-[18px] border border-border bg-bg-2/88 px-5 py-5 text-left transition-[background-color,border-color,transform,box-shadow] duration-150 hover:border-border-hi hover:bg-bg-3/92 hover:shadow-[0_16px_40px_rgba(15,23,42,0.08)] focus-visible:-translate-y-[1px] focus-visible:border-border-hi focus-visible:bg-bg-3/92 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                        >
+                          <div className="flex items-start justify-between gap-4">
+                            <div className="min-w-0 flex-1">
+                              <h2 className="overflow-hidden text-[18px] leading-[1.15] font-semibold tracking-[-0.02em] text-t1 [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]">
+                                {item.name}
+                              </h2>
+                            </div>
+                            <span
+                              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-border bg-bg text-[18px] text-t1 transition-colors group-hover:border-border-hi group-hover:bg-bg-2"
+                              aria-hidden
+                            >
+                              {item.icon || (type === "skill" ? "🤖" : "📄")}
+                            </span>
+                          </div>
+
+                          <div className="mt-5 min-w-0">
+                            <p className="overflow-hidden text-[13px] leading-6 text-t2 [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:3]">
+                              {item.description}
+                            </p>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <div
+                      className="flex min-h-full min-w-0 items-center justify-center rounded-[18px] border border-dashed border-border-hi bg-bg-2/72 px-6 py-10 text-center"
+                      data-testid={`framework-grid-${type}`}
+                    >
+                      <div className="max-w-md">
+                        <Sparkles className="mx-auto h-5 w-5 text-t3" />
+                        <p className="mt-4 text-[15px] font-semibold tracking-[-0.01em] text-t1">
+                          {typedItems.length === 0
+                            ? `No ${type === "skill" ? "skills" : "playbooks"} yet`
+                            : `No ${type === "skill" ? "skills" : "playbooks"} match that search`}
+                        </p>
+                        <p className="mt-2 text-[12.5px] leading-6 text-t2">
+                          {typedItems.length === 0
+                            ? `Create the first ${type === "skill" ? "skill" : "playbook"} to start building this library.`
+                            : `Try a different title or keyword to keep scanning the library.`}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </div>
+                </div>
               </div>
             </div>
           </div>

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -827,7 +827,7 @@ export function FrameworkScreen({
                   ) : (
                     <div className="h-full min-h-0 overflow-hidden">
                       <div className="flex h-full min-h-0 w-full flex-col">
-                        <div className="flex items-center justify-between gap-3 border-b border-white/8 bg-[#0f172a] px-5 py-4 md:px-6">
+                        <div className="flex items-center justify-between gap-3 border-b border-border-hi bg-bg-2 px-5 py-4 md:px-6">
                           <div className="min-w-0 flex-1">
                             <div
                               className="flex flex-wrap items-center gap-1.5"
@@ -841,7 +841,7 @@ export function FrameworkScreen({
                                   aria-label={label}
                                   title={label}
                                   onClick={onClick}
-                                  className="flex h-8 w-8 items-center justify-center rounded-md bg-slate-800/75 text-slate-200 transition hover:bg-slate-700 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                                  className="flex h-8 w-8 items-center justify-center rounded-md bg-bg-3 text-t2 transition hover:bg-bg-4 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
                                 >
                                   <Icon className="h-3.5 w-3.5" />
                                 </button>
@@ -849,16 +849,16 @@ export function FrameworkScreen({
                             </div>
                           </div>
                           <div className="min-w-0 text-right">
-                            <p className="truncate font-mono text-[11px] uppercase tracking-[0.16em] text-slate-300">
+                            <p className="truncate font-mono text-[11px] uppercase tracking-[0.16em] text-t2">
                               Markdown editor
                             </p>
                           </div>
                         </div>
 
-                        <div className="min-h-0 flex-1 overflow-auto bg-linear-to-b from-[#111c31] to-[#0b1324]">
+                        <div className="min-h-0 flex-1 overflow-auto bg-linear-to-b from-bg-2 to-bg-3">
                           <div className="flex min-h-full">
                             <div
-                              className="hidden w-14 shrink-0 select-none border-r border-white/7 bg-white/[0.02] px-2 py-5 text-right font-mono text-[11px] leading-7 text-slate-500 md:block"
+                              className="hidden w-14 shrink-0 select-none border-r border-border bg-bg px-2 py-5 text-right font-mono text-[11px] leading-7 text-t3 md:block"
                               aria-hidden
                             >
                               {Array.from(
@@ -887,7 +887,7 @@ export function FrameworkScreen({
                               }
                               spellCheck={false}
                               data-testid={`framework-editor-${type}`}
-                              className="block min-h-full w-full resize-none bg-transparent px-5 py-5 font-mono text-[13px] leading-7 text-slate-100 outline-none transition placeholder:text-slate-500 md:px-6"
+                              className="block min-h-full w-full resize-none bg-transparent px-5 py-5 font-mono text-[13px] leading-7 text-t1 outline-none transition placeholder:text-t3 md:px-6"
                             />
                           </div>
                         </div>

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -90,6 +90,15 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
   }
 
   const hasPending = pendingCount > 0;
+  const saveDisabled =
+    config?.mode === "template-editor"
+      ? config.saveDisabled
+      : config?.mode === "page"
+        ? (config.saveDisabled ?? true)
+        : true;
+  const showSaveButton =
+    (config?.mode === "template-editor" || config?.mode === "page") &&
+    typeof config.onSave === "function";
 
   return (
     <>
@@ -159,19 +168,19 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
             config?.actions ?? null
           )}
 
-          {config?.mode === "template-editor" ? (
+          {showSaveButton ? (
             <button
               type="button"
               onClick={config.onSave}
-              disabled={config.saveDisabled}
+              disabled={saveDisabled}
               className={cn(
                 "flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11.5px] font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
-                config.saveDisabled
+                saveDisabled
                   ? "cursor-not-allowed border border-border bg-bg-2 text-t3 opacity-70"
                   : "border border-[#10b981] bg-[#10b981] text-white shadow-[0_0_0_1px_rgba(16,185,129,0.16),0_8px_22px_rgba(16,185,129,0.24)] hover:bg-[#22c55e]",
               )}
             >
-              {!config.saveDisabled ? (
+              {!saveDisabled ? (
                 <span
                   aria-hidden
                   className="h-1.5 w-1.5 rounded-full bg-white shadow-[0_0_10px_rgba(255,255,255,0.7)]"

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -4,7 +4,10 @@ import { useEffect, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Bell, Pencil } from "lucide-react";
 
-import { useDashboardTopBar } from "@/components/dashboard-topbar-context";
+import {
+  type DashboardTopBarCrumb,
+  useDashboardTopBar,
+} from "@/components/dashboard-topbar-context";
 import { CheckpointPanel } from "@/components/workflows/checkpoint-panel";
 import { cn } from "@/lib/utils";
 
@@ -38,13 +41,15 @@ const ROUTE_LABELS: ReadonlyArray<{ test: (path: string) => boolean; crumbs: str
   },
 ];
 
-function deriveCrumbs(pathname: string | null): string[] {
-  if (!pathname) return ["Overview"];
+function deriveCrumbs(pathname: string | null): DashboardTopBarCrumb[] {
+  if (!pathname) return [{ label: "Overview" }];
   for (const entry of ROUTE_LABELS) {
-    if (entry.test(pathname)) return entry.crumbs;
+    if (entry.test(pathname)) {
+      return entry.crumbs.map((label) => ({ label }));
+    }
   }
   const last = pathname.split("/").filter(Boolean).pop() ?? "Overview";
-  return [last.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())];
+  return [{ label: last.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()) }];
 }
 
 export interface TopBarProps {
@@ -96,7 +101,7 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
           {crumbs.map((crumb, idx) => {
             const isLast = idx === crumbs.length - 1;
             return (
-              <span key={`${crumb}-${idx}`} className="flex items-center gap-1.5">
+              <span key={`${crumb.label}-${idx}`} className="flex items-center gap-1.5">
                 {idx > 0 && <span className="text-t3">›</span>}
                 {isLast && config?.mode === "template-editor" ? (
                   <input
@@ -121,16 +126,24 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
                     aria-label="Workflow template name"
                   />
                 ) : (
-                  <span
+                  <button
+                    type="button"
+                    onClick={crumb.onClick}
+                    disabled={!crumb.onClick || isLast}
                     className={
                       isLast
                         ? "truncate text-[13px] font-semibold text-t1"
-                        : "truncate text-[13px] font-medium text-t2"
+                        : cn(
+                            "truncate text-[13px] font-medium text-t2 transition",
+                            crumb.onClick
+                              ? "cursor-pointer hover:text-t1"
+                              : "cursor-default",
+                          )
                     }
                     aria-current={isLast ? "page" : undefined}
                   >
-                    {crumb}
-                  </span>
+                    {crumb.label}
+                  </button>
                 )}
               </span>
             );

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -1,23 +1,19 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Bell, Pencil } from "lucide-react";
+import { Pencil } from "lucide-react";
 
 import {
   type DashboardTopBarCrumb,
   useDashboardTopBar,
 } from "@/components/dashboard-topbar-context";
-import { CheckpointPanel } from "@/components/workflows/checkpoint-panel";
 import { cn } from "@/lib/utils";
 
 /**
  * Dashboard top bar.
  *
- * Renders a route-derived breadcrumb and the My Tasks pill. The pill shows an
- * amber badge when there are pending checkpoints and opens CheckpointPanel on
- * click. `initialPendingCount` is server-rendered for a fast first paint;
- * the panel refreshes from the DB when opened.
+ * Renders a route-derived breadcrumb plus route-specific controls.
  *
  * Visual contract: prototype `TopBar` (`Process Canvas.html`).
  */
@@ -52,12 +48,7 @@ function deriveCrumbs(pathname: string | null): DashboardTopBarCrumb[] {
   return [{ label: last.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()) }];
 }
 
-export interface TopBarProps {
-  /** Server-rendered initial count for fast first paint. */
-  initialPendingCount?: number;
-}
-
-export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
+export function TopBar() {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -67,8 +58,6 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
     !!pathname && WORKFLOW_INSTANCE_ROUTE_REGEX.test(pathname);
   const editMode = searchParams.get("edit") === "1";
 
-  const [panelOpen, setPanelOpen] = useState(false);
-  const [pendingCount, setPendingCount] = useState(initialPendingCount);
   const [templateLabelDraft, setTemplateLabelDraft] = useState("");
 
   useEffect(() => {
@@ -89,7 +78,6 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
     router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
   }
 
-  const hasPending = pendingCount > 0;
   const saveDisabled =
     config?.mode === "template-editor"
       ? config.saveDisabled
@@ -206,43 +194,8 @@ export function TopBar({ initialPendingCount = 0 }: TopBarProps) {
               {editMode ? "Save" : "Edit"}
             </button>
           ) : null}
-
-          {config?.mode !== "template-editor" ? (
-            <button
-              type="button"
-              aria-label={`My Tasks${hasPending ? ` — ${pendingCount} pending` : ""}`}
-              aria-expanded={panelOpen}
-              onClick={() => setPanelOpen((v) => !v)}
-              data-testid="topbar-my-tasks-btn"
-              className={cn(
-                "relative flex cursor-pointer items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[11.5px] font-medium transition",
-                "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
-                hasPending
-                  ? "border-[rgba(245,158,11,0.35)] bg-[rgba(245,158,11,0.08)] text-[#fbbf24] hover:bg-[rgba(245,158,11,0.14)]"
-                  : "border-border bg-bg-2 text-t2 hover:border-border-hi hover:bg-bg-3 hover:text-t1",
-              )}
-            >
-              <Bell className="h-3.5 w-3.5" />
-              My Tasks
-              {hasPending && (
-                <span
-                  className="flex h-4 min-w-4 items-center justify-center rounded-full bg-[#f59e0b] px-1 font-mono text-[9px] font-bold text-white"
-                  aria-hidden
-                  data-testid="topbar-pending-badge"
-                >
-                  {pendingCount}
-                </span>
-              )}
-            </button>
-          ) : null}
         </div>
       </header>
-
-      <CheckpointPanel
-        open={panelOpen}
-        onClose={() => setPanelOpen(false)}
-        onPendingCountChange={setPendingCount}
-      />
     </>
   );
 }

--- a/products/dashboard/components/ui/confirm-modal.tsx
+++ b/products/dashboard/components/ui/confirm-modal.tsx
@@ -7,6 +7,7 @@ interface ConfirmModalProps {
   title: string;
   description: ReactNode;
   confirmLabel?: string;
+  confirmDisabled?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -15,6 +16,7 @@ export function ConfirmModal({
   title,
   description,
   confirmLabel = "Delete",
+  confirmDisabled = false,
   onConfirm,
   onCancel,
 }: ConfirmModalProps) {
@@ -79,7 +81,8 @@ export function ConfirmModal({
           <button
             type="button"
             onClick={onConfirm}
-            className="rounded-lg bg-[#ef4444] px-5 py-2 text-[13px] font-semibold text-white transition hover:opacity-90"
+            disabled={confirmDisabled}
+            className="rounded-lg bg-[#ef4444] px-5 py-2 text-[13px] font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {confirmLabel}
           </button>

--- a/products/dashboard/components/workflows/header-actions-menu.tsx
+++ b/products/dashboard/components/workflows/header-actions-menu.tsx
@@ -66,7 +66,7 @@ export function HeaderActionsMenu({
           aria-label={`Open ${entityName} actions`}
           aria-expanded={open}
           onClick={() => setOpen((current) => !current)}
-          className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-md border border-border-hi bg-bg-3 text-t2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition hover:border-border-hi hover:bg-bg-4 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent aria-expanded:border-accent aria-expanded:bg-primary-bg aria-expanded:text-accent"
+          className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-md border border-border bg-bg-2 text-t2 transition hover:border-border-hi hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent aria-expanded:border-accent aria-expanded:bg-primary-bg aria-expanded:text-accent"
         >
           <Ellipsis className="h-[15px] w-[15px]" strokeWidth={2.4} />
         </button>

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -115,7 +115,11 @@ export function ProcessMatrix({
   useEffect(() => {
     setConfig({
       mode: "workflow-instance",
-      crumbs: ["Workflows", template?.label ?? "Workflow", instance.label],
+      crumbs: [
+        { label: "Workflows" },
+        { label: template?.label ?? "Workflow" },
+        { label: instance.label },
+      ],
       actions: (
         <HeaderActionsMenu
           entityLabel={instance.label}

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -314,7 +314,7 @@ export function TemplateEditorScreen({
   useEffect(() => {
     setConfig({
       mode: "template-editor",
-      crumbs: ["Workflows", draft.label],
+      crumbs: [{ label: "Workflows" }, { label: draft.label }],
       label: draft.label,
       onLabelChange: (value) =>
         setDraft((current) => ({ ...current, label: value })),

--- a/products/dashboard/e2e/framework-skills.spec.ts
+++ b/products/dashboard/e2e/framework-skills.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const baseURL = process.env.BASE_URL || "http://localhost:3000";
+const bypassSecret = process.env.AUTH_E2E_BYPASS_SECRET;
+const hasSupabaseRuntime =
+  !!process.env.NEXT_PUBLIC_SUPABASE_URL &&
+  !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+async function authenticateWithBypass(page: Page) {
+  test.skip(
+    !bypassSecret,
+    "AUTH_E2E_BYPASS_SECRET is required for authenticated E2E",
+  );
+
+  await page.context().addCookies([
+    {
+      name: "dashboard_e2e_auth",
+      value: `${bypassSecret}:e2e-user:${encodeURIComponent("e2e@example.com")}`,
+      url: baseURL,
+    },
+  ]);
+}
+
+test.describe("framework skills", () => {
+  test("loads seed data, creates a skill, edits it, and deletes it", async ({ page }) => {
+    test.skip(
+      !hasSupabaseRuntime,
+      "Supabase runtime credentials required for the framework skills happy path",
+    );
+
+    await authenticateWithBypass(page);
+    await page.goto("/framework/skills");
+
+    await expect(page.getByTestId("framework-screen-skill")).toBeVisible();
+    await expect(page.getByTestId("framework-grid-skill")).toContainText("PM");
+
+    const skillName = `E2E Skill ${Date.now()}`;
+    const skillDescription = "Created by Playwright";
+    const renamedSkill = `${skillName} Revised`;
+    const revisedDescription = "Sharper and more polished from Playwright";
+    const savedContent = `# ${renamedSkill}\n\nSaved from Playwright.`;
+
+    await page.getByRole("button", { name: "New skill" }).click();
+    await expect(page.getByTestId("framework-add-form-skill")).toBeVisible();
+    await page.getByPlaceholder("Skill name").fill(skillName);
+    await page.getByPlaceholder("Short description").fill(skillDescription);
+    await page.getByRole("button", { name: "Create" }).click();
+
+    const skillCard = page
+      .locator('[data-testid^="framework-card-"]')
+      .filter({ hasText: skillName });
+    await expect(skillCard).toBeVisible();
+    await skillCard.click();
+
+    const editor = page.getByTestId("framework-editor-skill");
+    await expect(editor).toBeVisible();
+    await page.getByLabel("Emoji").fill("🧠");
+    await page.getByLabel("Name").fill(renamedSkill);
+    await page.getByLabel("Description").fill(revisedDescription);
+    await editor.fill(savedContent);
+    await page.getByRole("button", { name: "Save changes" }).click();
+
+    await expect(page.getByTestId("framework-grid-skill")).toBeVisible();
+    await page.reload();
+
+    const persistedCard = page
+      .locator('[data-testid^="framework-card-"]')
+      .filter({ hasText: renamedSkill });
+    await expect(persistedCard).toBeVisible();
+    await persistedCard.click();
+    await expect(page.getByTestId("framework-editor-skill")).toHaveValue(savedContent);
+    await expect(page.getByLabel("Emoji")).toHaveValue("🧠");
+    await expect(page.getByLabel("Description")).toHaveValue(revisedDescription);
+    await page.getByRole("button", { name: "Skills" }).click();
+    await expect(page.getByTestId("framework-grid-skill")).toBeVisible();
+
+    await persistedCard.hover();
+    await persistedCard.getByRole("button", { name: `Delete ${renamedSkill}` }).click();
+    await expect(page.getByRole("dialog")).toContainText(
+      "This will permanently remove this skill. This cannot be undone.",
+    );
+    await page.getByRole("button", { name: "Delete" }).click();
+    await expect(persistedCard).toHaveCount(0);
+  });
+});

--- a/products/dashboard/e2e/framework-skills.spec.ts
+++ b/products/dashboard/e2e/framework-skills.spec.ts
@@ -41,26 +41,27 @@ test.describe("framework skills", () => {
     const savedContent = `# ${renamedSkill}\n\nSaved from Playwright.`;
 
     await page.getByRole("button", { name: "New skill" }).click();
-    await expect(page.getByTestId("framework-add-form-skill")).toBeVisible();
-    await page.getByPlaceholder("Skill name").fill(skillName);
-    await page.getByPlaceholder("Short description").fill(skillDescription);
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByLabel("Title").fill(skillName);
+    await page.getByLabel("Description").fill(skillDescription);
     await page.getByRole("button", { name: "Create" }).click();
 
-    const skillCard = page
-      .locator('[data-testid^="framework-card-"]')
-      .filter({ hasText: skillName });
-    await expect(skillCard).toBeVisible();
-    await skillCard.click();
+    await expect(page.getByTestId("framework-markdown-preview-skill")).toBeVisible();
+    await page.getByLabel("Open skill actions").click();
+    await page.getByRole("button", { name: "Rename" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByLabel("Title").fill(renamedSkill);
+    await page.getByLabel("Description").fill(revisedDescription);
+    await page.getByRole("button", { name: "Apply" }).click();
+
+    await page.getByLabel("Change icon").click();
+    await page.getByLabel("Search or type emoji").fill("🧠");
+    await page.getByRole("button", { name: "Use typed emoji" }).click();
+    await page.getByRole("tab", { name: "Edit" }).click();
 
     const editor = page.getByTestId("framework-editor-skill");
-    await expect(editor).toBeVisible();
-    await page.getByLabel("Emoji").fill("🧠");
-    await page.getByLabel("Name").fill(renamedSkill);
-    await page.getByLabel("Description").fill(revisedDescription);
     await editor.fill(savedContent);
-    await page.getByRole("button", { name: "Save changes" }).click();
-
-    await expect(page.getByTestId("framework-grid-skill")).toBeVisible();
+    await page.getByRole("button", { name: "Save" }).click();
     await page.reload();
 
     const persistedCard = page
@@ -68,14 +69,15 @@ test.describe("framework skills", () => {
       .filter({ hasText: renamedSkill });
     await expect(persistedCard).toBeVisible();
     await persistedCard.click();
+    await page.getByRole("tab", { name: "Edit" }).click();
     await expect(page.getByTestId("framework-editor-skill")).toHaveValue(savedContent);
-    await expect(page.getByLabel("Emoji")).toHaveValue("🧠");
-    await expect(page.getByLabel("Description")).toHaveValue(revisedDescription);
+    await expect(page.getByText(revisedDescription)).toBeVisible();
     await page.getByRole("button", { name: "Skills" }).click();
     await expect(page.getByTestId("framework-grid-skill")).toBeVisible();
 
-    await persistedCard.hover();
-    await persistedCard.getByRole("button", { name: `Delete ${renamedSkill}` }).click();
+    await persistedCard.click();
+    await page.getByLabel("Open skill actions").click();
+    await page.getByRole("button", { name: "Delete" }).click();
     await expect(page.getByRole("dialog")).toContainText(
       "This will permanently remove this skill. This cannot be undone.",
     );

--- a/products/dashboard/lib/analytics/events.ts
+++ b/products/dashboard/lib/analytics/events.ts
@@ -54,6 +54,10 @@ export type AnalyticsEvent =
       event: "workflow.template_edited";
       properties: { template_id: string; edited_by: string };
     }
+  | {
+      event: "framework.skill_edited";
+      properties: { item_id: string; edited_by: string };
+    }
   // ── Agent run panel ───────────────────────────────────────────────────────
   | { event: "dashboard.agent_run_opened"; properties: { task_id: string } }
   // ── My Tasks panel ────────────────────────────────────────────────────────

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -718,5 +718,21 @@ export function createWorkflowRepository(
 
       return mapFrameworkItem(unwrap("upsertFrameworkItem", data, error) as FrameworkItemRow);
     },
+
+    async deleteFrameworkItem(itemId: string): Promise<void> {
+      const { data, error } = await client
+        .from("framework_items")
+        .delete()
+        .eq("id", itemId)
+        .select("*")
+        .maybeSingle();
+
+      if (error) {
+        throw new WorkflowRepositoryError("deleteFrameworkItem failed", error);
+      }
+      if (!data) {
+        throw new WorkflowRepositoryError("deleteFrameworkItem returned no row");
+      }
+    },
   };
 }

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -265,4 +265,5 @@ export interface WorkflowRepository {
   ): Promise<WorkflowEvent>;
   getFrameworkItems(type?: FrameworkItemType): Promise<FrameworkItem[]>;
   upsertFrameworkItem(item: FrameworkItem): Promise<FrameworkItem>;
+  deleteFrameworkItem(itemId: string): Promise<void>;
 }

--- a/products/dashboard/package-lock.json
+++ b/products/dashboard/package-lock.json
@@ -21,6 +21,8 @@
         "posthog-node": "^5.29.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "tailwind-merge": "^2.6.0"
       },
       "devDependencies": {
@@ -4288,6 +4290,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4323,12 +4334,45 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
     },
     "node_modules/@types/mysql": {
       "version": "2.15.27",
@@ -4372,7 +4416,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4411,6 +4454,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -4419,6 +4468,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@vercel/analytics": {
       "version": "2.0.1",
@@ -5032,6 +5087,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -5135,6 +5200,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -5150,6 +5225,46 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -5284,6 +5399,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -5367,7 +5492,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -5445,6 +5569,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -5459,7 +5596,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5473,6 +5609,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -5608,6 +5757,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -5655,6 +5816,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -5680,6 +5851,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5856,6 +6033,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/headers-polyfill": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
@@ -5882,6 +6099,16 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -5967,6 +6194,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -5977,12 +6244,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-node-process": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
       "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -6555,6 +6844,16 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -6628,12 +6927,855 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -6990,6 +8132,31 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -7322,6 +8489,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
@@ -7397,6 +8574,33 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -7419,6 +8623,72 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -7689,6 +8959,16 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -7763,6 +9043,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -7822,6 +9116,24 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -8159,6 +9471,26 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tsconfck": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
@@ -8215,6 +9547,93 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/until-async": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
@@ -8253,6 +9672,34 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -8798,6 +10245,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/products/dashboard/package.json
+++ b/products/dashboard/package.json
@@ -28,6 +28,8 @@
     "posthog-node": "^5.29.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- deliver the framework skills/playbooks browsing and editing surfaces with compact cards, updated search interactions, and improved editor ergonomics
- add markdown authoring/import workflow support and align editor theming with dashboard visual tokens
- simplify top-bar behavior and align header action menu styling across framework and workflow screens

## Test plan
- [x] Run dashboard unit tests for updated top bar behavior
- [x] Verify framework screen interactions (search, card density, edit/create flows)
- [x] Confirm workflow and framework action menus share consistent trigger styling

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full framework management UI for skills/playbooks: create, rename, edit (markdown preview + editor with formatting toolbar), import/export, icon picker, and delete; modal-driven flows and inline header actions.

* **Changes**
  * Top bar: contextual Save button when supported, interactive breadcrumbs, removed “My Tasks” pill and checkpoint panel, adjusted main content scrolling.
  * Confirm dialogs support disabling the confirm action.

* **Style**
  * Consistent button cursors for enabled/disabled states.

* **Tests**
  * New unit and end-to-end tests covering framework and editor flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->