### PR TITLE
feat(dashboard): implement Playbooks page with full CRUD and editor (AEL-57)

### DIFF
--- a/products/dashboard/__tests__/components/framework/framework-screen.test.tsx
+++ b/products/dashboard/__tests__/components/framework/framework-screen.test.tsx
@@ -33,6 +33,17 @@ const ITEMS: FrameworkItem[] = [
   },
 ];
 
+const PLAYBOOK_ITEMS: FrameworkItem[] = [
+  {
+    id: "pb-presales",
+    type: "playbook",
+    name: "Presales Qualification",
+    description: "Qualify new client opportunities",
+    icon: "📄",
+    content: "# Presales Qualification\n\n## Objective\n\nAssess fit.",
+  },
+];
+
 describe("FrameworkScreen", () => {
   it("shows rendered markdown by default and editable plain text on toggle", async () => {
     const user = userEvent.setup();
@@ -96,5 +107,25 @@ describe("FrameworkScreen", () => {
 
     const editor = await screen.findByTestId("framework-editor-skill");
     expect(editor).toHaveValue("# Imported Skill\n\n1. First step");
+  });
+});
+
+describe("FrameworkScreen — playbook type", () => {
+  it("renders playbook card grid and opens editor view on card click", async () => {
+    const user = userEvent.setup();
+
+    render(<FrameworkScreen initialItems={PLAYBOOK_ITEMS} type="playbook" />);
+
+    expect(screen.getByTestId("framework-screen-playbook")).toBeInTheDocument();
+    expect(screen.getByTestId("framework-grid-playbook")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("framework-card-pb-presales"));
+
+    expect(screen.getByTestId("framework-markdown-preview-playbook")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Edit" }));
+
+    expect(screen.getByTestId("framework-editor-playbook")).toBeInTheDocument();
+    expect(screen.queryByTestId("framework-markdown-preview-playbook")).not.toBeInTheDocument();
   });
 });

--- a/products/dashboard/app/(dashboard)/framework/playbooks/page.tsx
+++ b/products/dashboard/app/(dashboard)/framework/playbooks/page.tsx
@@ -1,23 +1,17 @@
+import { FrameworkScreen } from "@/components/framework/framework-screen";
 import { ShellEvents } from "@/components/shell-events";
+import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
 
-/**
- * Playbooks — placeholder.
- *
- * Real Playbooks library lands in PR 13 (AEL-57). This page exists so
- * the sidebar's Framework → Playbooks link doesn't 404 and so shell
- * events fire on the route during PR 3.
- */
-export default function PlaybooksPage() {
+export default async function PlaybooksPage() {
+  const repo = await getServerWorkflowRepository();
+  const items = await repo.getFrameworkItems("playbook");
+
   return (
-    <>
+    <div className="flex h-full min-h-0 flex-col">
       <ShellEvents route="/framework/playbooks" />
-      <div className="flex h-full flex-col items-center justify-center gap-3 p-10 text-center">
-        <h1 className="text-[16px] font-semibold text-t1">Playbooks</h1>
-        <p className="max-w-md text-[12.5px] text-t3">
-          The Playbooks library will live here. Authoring, listing, and the
-          Markdown editor land in a follow-up PR.
-        </p>
+      <div className="min-h-0 flex-1">
+        <FrameworkScreen initialItems={items} type="playbook" />
       </div>
-    </>
+    </div>
   );
 }

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -356,6 +356,11 @@ export function FrameworkScreen({
         item_id: itemId,
         edited_by: "founder",
       });
+    } else if (type === "playbook") {
+      capture("framework.playbook_edited", {
+        item_id: itemId,
+        edited_by: "founder",
+      });
     }
   }
 

--- a/products/dashboard/e2e/framework-playbooks.spec.ts
+++ b/products/dashboard/e2e/framework-playbooks.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const baseURL = process.env.BASE_URL || "http://localhost:3000";
+const bypassSecret = process.env.AUTH_E2E_BYPASS_SECRET;
+const hasSupabaseRuntime =
+  !!process.env.NEXT_PUBLIC_SUPABASE_URL &&
+  !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+async function authenticateWithBypass(page: Page) {
+  test.skip(
+    !bypassSecret,
+    "AUTH_E2E_BYPASS_SECRET is required for authenticated E2E",
+  );
+
+  await page.context().addCookies([
+    {
+      name: "dashboard_e2e_auth",
+      value: `${bypassSecret}:e2e-user:${encodeURIComponent("e2e@example.com")}`,
+      url: baseURL,
+    },
+  ]);
+}
+
+test.describe("framework playbooks", () => {
+  test("loads seed data, creates a playbook, edits it, and deletes it", async ({ page }) => {
+    test.skip(
+      !hasSupabaseRuntime,
+      "Supabase runtime credentials required for the framework playbooks happy path",
+    );
+
+    await authenticateWithBypass(page);
+    await page.goto("/framework/playbooks");
+
+    await expect(page.getByTestId("framework-screen-playbook")).toBeVisible();
+    await expect(page.getByTestId("framework-grid-playbook")).toContainText("Presales Qualification");
+
+    const playbookName = `E2E Playbook ${Date.now()}`;
+    const playbookDescription = "Created by Playwright";
+    const renamedPlaybook = `${playbookName} Revised`;
+    const revisedDescription = "Sharper and more polished from Playwright";
+    const savedContent = `# ${renamedPlaybook}\n\n## Objective\n\nSaved from Playwright.`;
+
+    await page.getByRole("button", { name: "New playbook" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByLabel("Title").fill(playbookName);
+    await page.getByLabel("Description").fill(playbookDescription);
+    await page.getByRole("button", { name: "Create" }).click();
+
+    await expect(page.getByTestId("framework-markdown-preview-playbook")).toBeVisible();
+    await page.getByLabel("Open playbook actions").click();
+    await page.getByRole("button", { name: "Rename" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByLabel("Title").fill(renamedPlaybook);
+    await page.getByLabel("Description").fill(revisedDescription);
+    await page.getByRole("button", { name: "Apply" }).click();
+
+    await page.getByLabel("Change icon").click();
+    await page.getByLabel("Search or type emoji").fill("📚");
+    await page.getByRole("button", { name: "Use typed emoji" }).click();
+    await page.getByRole("tab", { name: "Edit" }).click();
+
+    const editor = page.getByTestId("framework-editor-playbook");
+    await editor.fill(savedContent);
+    await page.getByRole("button", { name: "Save" }).click();
+    await page.reload();
+
+    const persistedCard = page
+      .locator('[data-testid^="framework-card-"]')
+      .filter({ hasText: renamedPlaybook });
+    await expect(persistedCard).toBeVisible();
+    await persistedCard.click();
+    await page.getByRole("tab", { name: "Edit" }).click();
+    await expect(page.getByTestId("framework-editor-playbook")).toHaveValue(savedContent);
+    await expect(page.getByText(revisedDescription)).toBeVisible();
+    await page.getByRole("button", { name: "Playbooks" }).click();
+    await expect(page.getByTestId("framework-grid-playbook")).toBeVisible();
+
+    await persistedCard.click();
+    await page.getByLabel("Open playbook actions").click();
+    await page.getByRole("button", { name: "Delete" }).click();
+    await expect(page.getByRole("dialog")).toContainText(
+      "This will permanently remove this playbook. This cannot be undone.",
+    );
+    await page.getByRole("button", { name: "Delete" }).click();
+    await expect(persistedCard).toHaveCount(0);
+  });
+
+  test("sidebar active state is correct for Skills and Playbooks", async ({ page }) => {
+    test.skip(
+      !hasSupabaseRuntime,
+      "Supabase runtime credentials required for sidebar active state test",
+    );
+
+    await authenticateWithBypass(page);
+
+    await page.goto("/framework/skills");
+    const skillsLink = page.getByRole("link", { name: "Skills" });
+    const playbooksLink = page.getByRole("link", { name: "Playbooks" });
+    await expect(skillsLink).toHaveAttribute("data-active", "true");
+    await expect(playbooksLink).not.toHaveAttribute("data-active", "true");
+
+    await playbooksLink.click();
+    await expect(page.getByTestId("framework-screen-playbook")).toBeVisible();
+    await expect(playbooksLink).toHaveAttribute("data-active", "true");
+    await expect(skillsLink).not.toHaveAttribute("data-active", "true");
+  });
+});

--- a/products/dashboard/e2e/framework-playbooks.spec.ts
+++ b/products/dashboard/e2e/framework-playbooks.spec.ts
@@ -61,7 +61,15 @@ test.describe("framework playbooks", () => {
 
     const editor = page.getByTestId("framework-editor-playbook");
     await editor.fill(savedContent);
-    await page.getByRole("button", { name: "Save" }).click();
+    await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          response.status() === 200 &&
+          response.url().includes("/api/framework-items"),
+      ),
+      page.getByRole("button", { name: "Save" }).click(),
+    ]);
     await page.reload();
 
     const persistedCard = page

--- a/products/dashboard/e2e/framework-playbooks.spec.ts
+++ b/products/dashboard/e2e/framework-playbooks.spec.ts
@@ -76,20 +76,27 @@ test.describe("framework playbooks", () => {
       .locator('[data-testid^="framework-card-"]')
       .filter({ hasText: renamedPlaybook });
     await expect(persistedCard).toBeVisible();
-    await persistedCard.click();
-    await page.getByRole("tab", { name: "Edit" }).click();
-    await expect(page.getByTestId("framework-editor-playbook")).toHaveValue(savedContent);
-    await expect(page.getByText(revisedDescription)).toBeVisible();
-    await page.getByRole("button", { name: "Playbooks" }).click();
-    await expect(page.getByTestId("framework-grid-playbook")).toBeVisible();
+    try {
+      await persistedCard.click();
+      await page.getByRole("tab", { name: "Edit" }).click();
+      await expect(page.getByTestId("framework-editor-playbook")).toHaveValue(savedContent);
+      await expect(page.getByText(revisedDescription)).toBeVisible();
+      await page.getByRole("button", { name: "Playbooks" }).click();
+      await expect(page.getByTestId("framework-grid-playbook")).toBeVisible();
+    } finally {
+      await page.getByRole("button", { name: "Playbooks" }).click({ timeout: 2_000 }).catch(() => {});
+      if ((await persistedCard.count()) > 0) {
+        await persistedCard.first().click();
+        await page.getByLabel("Open playbook actions").click();
+        await page.getByRole("button", { name: "Delete" }).click();
+        await expect(page.getByRole("dialog")).toContainText(
+          "This will permanently remove this playbook. This cannot be undone.",
+        );
+        await page.getByRole("button", { name: "Delete" }).click();
+      }
+      await page.reload();
+    }
 
-    await persistedCard.click();
-    await page.getByLabel("Open playbook actions").click();
-    await page.getByRole("button", { name: "Delete" }).click();
-    await expect(page.getByRole("dialog")).toContainText(
-      "This will permanently remove this playbook. This cannot be undone.",
-    );
-    await page.getByRole("button", { name: "Delete" }).click();
     await expect(persistedCard).toHaveCount(0);
   });
 

--- a/products/dashboard/lib/analytics/events.ts
+++ b/products/dashboard/lib/analytics/events.ts
@@ -58,6 +58,10 @@ export type AnalyticsEvent =
       event: "framework.skill_edited";
       properties: { item_id: string; edited_by: string };
     }
+  | {
+      event: "framework.playbook_edited";
+      properties: { item_id: string; edited_by: string };
+    }
   // ── Agent run panel ───────────────────────────────────────────────────────
   | { event: "dashboard.agent_run_opened"; properties: { task_id: string } }
   // ── My Tasks panel ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- implement the Framework Playbooks page in the dashboard
- add card-grid list browsing plus playbook create/edit/delete workflows
- ship markdown editor support for playbook authoring and updates

## Validation
- npm run validate

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playbooks page now loads live playbook data server-side and supports full management: create, rename, edit content (markdown), change icon, and delete.

* **Analytics**
  * Playbook edit actions now emit analytics events to track edits.

* **Tests**
  * Added unit tests for playbook UI and tab/navigation behaviors.
  * Added end-to-end tests validating full playbook CRUD flows and sidebar navigation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->