### PR TITLE
chore: promote staging to production

### DIFF
--- a/products/dashboard/next.config.ts
+++ b/products/dashboard/next.config.ts
@@ -57,6 +57,7 @@ if (appRelease && !process.env.NEXT_PUBLIC_SENTRY_RELEASE) {
 const nextConfig: NextConfig = {
   // product_id: dashboard — ai-native-framework boilerplate
   skipTrailingSlashRedirect: true,
+  outputFileTracingRoot: path.join(__dirname, "../../"),
   env: {
     NEXT_PUBLIC_APP_RELEASE: appRelease ?? "",
     NEXT_PUBLIC_RELEASE_CHANNEL: releaseChannel,

--- a/products/dashboard/package-lock.json
+++ b/products/dashboard/package-lock.json
@@ -10692,34 +10692,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -11204,10 +11176,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
-      "dev": true,
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "funding": [
         {
           "type": "opencollective",

--- a/products/dashboard/package.json
+++ b/products/dashboard/package.json
@@ -32,6 +32,9 @@
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0"
   },
+  "overrides": {
+    "postcss": ">=8.5.10"
+  },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.2",
     "@eslint/eslintrc": "^3.3.5",


### PR DESCRIPTION
## Publish to production

Merge reviewed `staging` into `main` per `ai/playbooks/publish-to-production.md`.

**Release scope:** [PR #179](https://github.com/andelizondo/ai-native-framework/pull/179) — dashboard Next.js `outputFileTracingRoot` and PostCSS alignment (staging is ahead of `main` by that promotion).

BEGIN_COMMIT_OVERRIDE
chore(dashboard): file tracing root and PostCSS resolution
END_COMMIT_OVERRIDE

---

Automated checks required by Mergify `staging-promotion` queue include `validate`, `test`, `decide`, and `migrate-staging`. Merge via regular merge commit (not squash).

Made with [Cursor](https://cursor.com)