### PR TITLE
feat(dashboard): route loading states and navigation progress

### DIFF
--- a/products/dashboard/app/(dashboard)/events/loading.tsx
+++ b/products/dashboard/app/(dashboard)/events/loading.tsx
@@ -1,0 +1,15 @@
+function Bone({ className }: { className?: string }) {
+  return (
+    <div className={`animate-pulse rounded bg-bg-2 ${className ?? ""}`} />
+  );
+}
+
+export default function EventsLoading() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 p-10">
+      <Bone className="h-5 w-28" />
+      <Bone className="h-3 w-72" />
+      <Bone className="h-3 w-56" />
+    </div>
+  );
+}

--- a/products/dashboard/app/(dashboard)/framework/playbooks/loading.tsx
+++ b/products/dashboard/app/(dashboard)/framework/playbooks/loading.tsx
@@ -1,0 +1,34 @@
+function Bone({ className }: { className?: string }) {
+  return (
+    <div className={`animate-pulse rounded bg-bg-2 ${className ?? ""}`} />
+  );
+}
+
+export default function PlaybooksLoading() {
+  return (
+    <div className="flex h-full min-h-0">
+      {/* Left panel — item list */}
+      <div className="flex w-64 shrink-0 flex-col gap-2 border-r border-border p-3">
+        <Bone className="mb-1 h-7 w-full rounded-md" />
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-2 rounded-md p-2">
+            <Bone className="h-4 w-4 shrink-0 rounded" />
+            <Bone className="h-3 flex-1" />
+          </div>
+        ))}
+      </div>
+
+      {/* Right panel — editor */}
+      <div className="flex min-w-0 flex-1 flex-col p-6">
+        <Bone className="mb-4 h-5 w-56" />
+        <Bone className="mb-2 h-3 w-full" />
+        <Bone className="mb-2 h-3 w-4/5" />
+        <Bone className="mb-2 h-3 w-full" />
+        <Bone className="mb-6 h-3 w-2/3" />
+        <Bone className="mb-2 h-3 w-5/6" />
+        <Bone className="mb-2 h-3 w-full" />
+        <Bone className="h-3 w-3/4" />
+      </div>
+    </div>
+  );
+}

--- a/products/dashboard/app/(dashboard)/framework/skills/loading.tsx
+++ b/products/dashboard/app/(dashboard)/framework/skills/loading.tsx
@@ -1,0 +1,35 @@
+function Bone({ className }: { className?: string }) {
+  return (
+    <div className={`animate-pulse rounded bg-bg-2 ${className ?? ""}`} />
+  );
+}
+
+export default function SkillsLoading() {
+  return (
+    <div className="flex h-full min-h-0">
+      {/* Left panel — item list */}
+      <div className="flex w-64 shrink-0 flex-col gap-2 border-r border-border p-3">
+        <Bone className="mb-1 h-7 w-full rounded-md" />
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-2 rounded-md p-2">
+            <Bone className="h-4 w-4 shrink-0 rounded" />
+            <Bone className="h-3 flex-1" />
+          </div>
+        ))}
+      </div>
+
+      {/* Right panel — editor */}
+      <div className="flex min-w-0 flex-1 flex-col p-6">
+        <Bone className="mb-4 h-5 w-48" />
+        <Bone className="mb-2 h-3 w-full" />
+        <Bone className="mb-2 h-3 w-5/6" />
+        <Bone className="mb-2 h-3 w-full" />
+        <Bone className="mb-2 h-3 w-3/4" />
+        <Bone className="mb-6 h-3 w-full" />
+        <Bone className="mb-2 h-3 w-5/6" />
+        <Bone className="mb-2 h-3 w-full" />
+        <Bone className="h-3 w-2/3" />
+      </div>
+    </div>
+  );
+}

--- a/products/dashboard/app/(dashboard)/loading.tsx
+++ b/products/dashboard/app/(dashboard)/loading.tsx
@@ -1,0 +1,61 @@
+function Bone({ className }: { className?: string }) {
+  return (
+    <div
+      className={`animate-pulse rounded-md bg-bg-2 ${className ?? ""}`}
+    />
+  );
+}
+
+function StatCardSkeleton() {
+  return (
+    <div className="rounded-[10px] border border-border bg-bg-2 px-4 py-3.5">
+      <Bone className="h-7 w-12" />
+      <Bone className="mt-2 h-2.5 w-20" />
+      <Bone className="mt-1.5 h-2 w-14" />
+    </div>
+  );
+}
+
+function CardSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={`rounded-[10px] border border-border bg-bg-2 p-4 ${className ?? ""}`}
+    >
+      <Bone className="mb-3 h-3 w-28" />
+      <Bone className="mb-2 h-2.5 w-full" />
+      <Bone className="mb-2 h-2.5 w-5/6" />
+      <Bone className="h-2.5 w-3/4" />
+    </div>
+  );
+}
+
+export default function OverviewLoading() {
+  return (
+    <div className="overflow-y-auto p-6">
+      {/* Greeting */}
+      <header className="mb-5">
+        <Bone className="h-6 w-48" />
+        <Bone className="mt-2 h-3.5 w-72" />
+      </header>
+
+      {/* Stat cards */}
+      <div className="mb-5 grid grid-cols-2 gap-2.5 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <StatCardSkeleton key={i} />
+        ))}
+      </div>
+
+      {/* Content grid */}
+      <div className="grid grid-cols-1 gap-3.5 lg:grid-cols-[1fr_320px]">
+        <div className="flex flex-col gap-3">
+          <CardSkeleton className="h-40" />
+          <CardSkeleton className="h-36" />
+        </div>
+        <div className="flex flex-col gap-3">
+          <CardSkeleton className="h-44" />
+          <CardSkeleton className="h-28" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/products/dashboard/app/(dashboard)/settings/loading.tsx
+++ b/products/dashboard/app/(dashboard)/settings/loading.tsx
@@ -1,0 +1,15 @@
+function Bone({ className }: { className?: string }) {
+  return (
+    <div className={`animate-pulse rounded bg-bg-2 ${className ?? ""}`} />
+  );
+}
+
+export default function SettingsLoading() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 p-10">
+      <Bone className="h-5 w-24" />
+      <Bone className="h-3 w-80" />
+      <Bone className="h-3 w-60" />
+    </div>
+  );
+}

--- a/products/dashboard/app/(dashboard)/workflows/[instanceId]/loading.tsx
+++ b/products/dashboard/app/(dashboard)/workflows/[instanceId]/loading.tsx
@@ -1,0 +1,62 @@
+function Bone({ className }: { className?: string }) {
+  return (
+    <div className={`animate-pulse rounded bg-bg-2 ${className ?? ""}`} />
+  );
+}
+
+const COLS = 3;
+const ROWS = 4;
+
+export default function WorkflowInstanceLoading() {
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      {/* Top bar area (below the shared TopBar) */}
+      <div className="flex h-10 shrink-0 items-center gap-3 border-b border-border px-4">
+        <Bone className="h-3 w-32" />
+        <Bone className="ml-auto h-6 w-16" />
+      </div>
+
+      {/* Matrix */}
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        {/* Role header row */}
+        <div
+          className="mb-2 grid gap-2"
+          style={{ gridTemplateColumns: `120px repeat(${COLS}, 1fr)` }}
+        >
+          <div />
+          {Array.from({ length: COLS }).map((_, i) => (
+            <Bone key={i} className="h-6 rounded-md" />
+          ))}
+        </div>
+
+        {/* Stage rows */}
+        <div className="flex flex-col gap-2">
+          {Array.from({ length: ROWS }).map((_, row) => (
+            <div
+              key={row}
+              className="grid gap-2"
+              style={{ gridTemplateColumns: `120px repeat(${COLS}, 1fr)` }}
+            >
+              {/* Stage label */}
+              <Bone className="h-16 rounded-md" />
+              {/* Task cells */}
+              {Array.from({ length: COLS }).map((_, col) => (
+                <div
+                  key={col}
+                  className="h-16 rounded-md border border-border bg-bg-2 p-2"
+                >
+                  {(row + col) % 3 !== 0 && (
+                    <>
+                      <Bone className="mb-1.5 h-2.5 w-3/4 animate-pulse" />
+                      <Bone className="h-2 w-1/2 animate-pulse" />
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/products/dashboard/app/layout.tsx
+++ b/products/dashboard/app/layout.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import "./globals.css";
 import { getAppRelease, getReleaseChannel } from "@/lib/release";
 import { DEFAULT_THEME, THEME_INIT_SCRIPT } from "@/lib/theme-tokens";
 import { SIDEBAR_INIT_SCRIPT } from "@/lib/sidebar";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/next";
+import { NavigationProgress } from "@/components/navigation-progress";
 
 export const metadata: Metadata = {
   title: "AI-Native Dashboard",
@@ -47,6 +49,9 @@ export default function RootLayout({
         data-release={appRelease}
         data-release-channel={getReleaseChannel()}
       >
+        <Suspense>
+          <NavigationProgress />
+        </Suspense>
         {children}
         <SpeedInsights />
         <Analytics />

--- a/products/dashboard/components/navigation-progress.tsx
+++ b/products/dashboard/components/navigation-progress.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
+
+type Phase = "idle" | "loading" | "done";
+
+const CSS = `
+  @keyframes np-grow { 0% { transform:scaleX(0) } 100% { transform:scaleX(0.85) } }
+  @keyframes np-done  { 0% { transform:scaleX(0.85);opacity:1 } 70% { transform:scaleX(1);opacity:1 } 100% { transform:scaleX(1);opacity:0 } }
+`;
+
+export function NavigationProgress() {
+  const pathname = usePathname();
+  const [phase, setPhase] = useState<Phase>("idle");
+  const prev = useRef(pathname);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      const a = (e.target as Element).closest("a");
+      if (!a) return;
+      const href = a.getAttribute("href") ?? "";
+      if (
+        !href ||
+        href.startsWith("#") ||
+        href.startsWith("mailto:") ||
+        /^https?:\/\//.test(href)
+      )
+        return;
+      const target = href.split("?")[0].split("#")[0];
+      if (target === window.location.pathname) return;
+      setPhase("loading");
+    }
+    document.addEventListener("click", onClick);
+    return () => document.removeEventListener("click", onClick);
+  }, []);
+
+  useEffect(() => {
+    if (pathname === prev.current) return;
+    prev.current = pathname;
+    setPhase("done");
+    clearTimeout(timer.current);
+    timer.current = setTimeout(() => setPhase("idle"), 500);
+  }, [pathname]);
+
+  useEffect(() => () => clearTimeout(timer.current), []);
+
+  if (phase === "idle") return null;
+
+  return (
+    <>
+      <style>{CSS}</style>
+      <div
+        aria-hidden
+        style={{
+          position: "fixed",
+          inset: "0 0 auto 0",
+          height: "2px",
+          zIndex: 9999,
+          background: "var(--accent)",
+          transformOrigin: "left center",
+          animation:
+            phase === "loading"
+              ? "np-grow 3s ease-out forwards"
+              : "np-done 0.4s ease-out forwards",
+          boxShadow: "0 0 6px var(--accent)",
+        }}
+      />
+    </>
+  );
+}

--- a/products/dashboard/components/navigation-progress.tsx
+++ b/products/dashboard/components/navigation-progress.tsx
@@ -10,27 +10,45 @@ const CSS = `
   @keyframes np-done  { 0% { transform:scaleX(0.85);opacity:1 } 70% { transform:scaleX(1);opacity:1 } 100% { transform:scaleX(1);opacity:0 } }
 `;
 
+const FAIL_SAFE_MS = 12_000;
+
 export function NavigationProgress() {
   const pathname = usePathname();
   const [phase, setPhase] = useState<Phase>("idle");
   const prev = useRef(pathname);
-  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const doneTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const failSafeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
     function onClick(e: MouseEvent) {
+      if (e.defaultPrevented) return;
+      if (e.button !== 0) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+
       const a = (e.target as Element).closest("a");
       if (!a) return;
+      if (a.target === "_blank") return;
+      if (a.hasAttribute("download")) return;
+
       const href = a.getAttribute("href") ?? "";
-      if (
-        !href ||
-        href.startsWith("#") ||
-        href.startsWith("mailto:") ||
-        /^https?:\/\//.test(href)
-      )
+      if (!href || href.startsWith("#")) return;
+
+      let url: URL;
+      try {
+        url = new URL(href, window.location.href);
+      } catch {
         return;
-      const target = href.split("?")[0].split("#")[0];
-      if (target === window.location.pathname) return;
+      }
+      if (url.protocol !== "http:" && url.protocol !== "https:") return;
+      if (url.origin !== window.location.origin) return;
+      if (url.pathname === window.location.pathname) return;
+
+      clearTimeout(failSafeTimer.current);
       setPhase("loading");
+      failSafeTimer.current = setTimeout(() => {
+        failSafeTimer.current = undefined;
+        setPhase("idle");
+      }, FAIL_SAFE_MS);
     }
     document.addEventListener("click", onClick);
     return () => document.removeEventListener("click", onClick);
@@ -39,12 +57,20 @@ export function NavigationProgress() {
   useEffect(() => {
     if (pathname === prev.current) return;
     prev.current = pathname;
+    clearTimeout(failSafeTimer.current);
+    failSafeTimer.current = undefined;
     setPhase("done");
-    clearTimeout(timer.current);
-    timer.current = setTimeout(() => setPhase("idle"), 500);
+    clearTimeout(doneTimer.current);
+    doneTimer.current = setTimeout(() => setPhase("idle"), 500);
   }, [pathname]);
 
-  useEffect(() => () => clearTimeout(timer.current), []);
+  useEffect(
+    () => () => {
+      clearTimeout(doneTimer.current);
+      clearTimeout(failSafeTimer.current);
+    },
+    [],
+  );
 
   if (phase === "idle") return null;
 


### PR DESCRIPTION
## Summary

- Adds `loading.tsx` segment boundaries for dashboard routes so navigations show consistent loading UI while server components resolve.
- Introduces a `NavigationProgress` client indicator on internal link clicks and wires it in the root layout inside `Suspense` for smoother perceived navigation.

## Validation

- [x] `npm run validate`

## Checklist

- [x] PR targets `staging` (not `main`) — only release-please and staging promotion PRs target `main`
- [x] Schema, examples, and policy stay aligned (dashboard-only UI change)
- [x] Documentation updated where behavior changed (n/a for this change)

Made with [Cursor](https://cursor.com)