### PR TITLE
feat(dashboard): theme preference selector in sidebar user menu

### DIFF
--- a/products/dashboard/__tests__/components/sidebar.test.tsx
+++ b/products/dashboard/__tests__/components/sidebar.test.tsx
@@ -8,8 +8,8 @@
  *   - Active route is reflected via aria-current=page.
  *   - The collapse toggle flips `<html data-sidebar>` so CSS can hide
  *     labels without React having to re-render the tree.
- *   - User menu opens, exposes the theme toggle and a sign-out item, and
- *     calls the shared sign-out flow when clicked.
+ *   - User menu opens, exposes theme preference options and a sign-out item,
+ *     and calls the shared sign-out flow when clicked.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -19,9 +19,9 @@ import { usePathname } from "next/navigation";
 
 import { renderWithToast } from "@/tests/test-utils";
 
-const { mockHandleSignOut, mockToggleTheme } = vi.hoisted(() => ({
+const { mockHandleSignOut, mockSetPreference } = vi.hoisted(() => ({
   mockHandleSignOut: vi.fn(),
-  mockToggleTheme: vi.fn(),
+  mockSetPreference: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/use-sign-out", () => ({
@@ -35,8 +35,8 @@ vi.mock("@/lib/auth/use-sign-out", () => ({
 vi.mock("@/lib/theme", () => ({
   useTheme: vi.fn(() => ({
     theme: "dark",
-    setTheme: vi.fn(),
-    toggleTheme: mockToggleTheme,
+    preference: "dark",
+    setPreference: mockSetPreference,
   })),
 }));
 
@@ -51,7 +51,7 @@ const TEST_USER = {
 describe("Sidebar", () => {
   beforeEach(() => {
     mockHandleSignOut.mockReset();
-    mockToggleTheme.mockReset();
+    mockSetPreference.mockReset();
     vi.mocked(usePathname).mockReturnValue("/");
     // The inline script in app/layout.tsx normally sets this before paint;
     // in jsdom we set it explicitly so the store has a starting truth.
@@ -130,7 +130,7 @@ describe("Sidebar", () => {
 
     const menu = await screen.findByRole("menu", { name: /user menu/i });
     expect(menu).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: /light mode/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /^light$/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /sign out/i })).toBeInTheDocument();
   });
 
@@ -144,19 +144,19 @@ describe("Sidebar", () => {
     await waitFor(() => expect(mockHandleSignOut).toHaveBeenCalledOnce());
   });
 
-  it("toggles the theme via the user menu and closes the menu", async () => {
+  it("sets theme preference via the user menu and closes the menu", async () => {
     const user = userEvent.setup();
     renderWithToast(<Sidebar user={TEST_USER} />);
 
     await user.click(screen.getByRole("button", { name: /open user menu/i }));
     // `userEvent` simulates a realistic open click on the trigger. The
     // menuitem click below uses `fireEvent` (synchronous) so we can assert
-    // `mockToggleTheme` and the menu-close transition without racing the
+    // `mockSetPreference` and the menu-close transition without racing the
     // outside-click handler that `userEvent`'s async pointer events would
     // schedule.
-    fireEvent.click(screen.getByRole("menuitem", { name: /light mode/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /^light$/i }));
 
-    expect(mockToggleTheme).toHaveBeenCalledOnce();
+    expect(mockSetPreference).toHaveBeenCalledExactlyOnceWith("light");
     await waitFor(() =>
       expect(screen.queryByRole("menu", { name: /user menu/i })).not.toBeInTheDocument(),
     );

--- a/products/dashboard/__tests__/lib/theme.test.ts
+++ b/products/dashboard/__tests__/lib/theme.test.ts
@@ -8,11 +8,12 @@
  * Settings page, server-rendered themed components) can rely on it.
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 
 import {
   DEFAULT_THEME,
+  DEFAULT_PREFERENCE,
   THEME_INIT_SCRIPT,
   THEME_STORAGE_KEY,
 } from "@/lib/theme-tokens";
@@ -28,59 +29,79 @@ describe("useTheme", () => {
     resetDom();
   });
 
-  it("defaults to dark when no DOM attribute is present", () => {
+  it("defaults to dark theme when no DOM attribute is present", () => {
     const { result } = renderHook(() => useTheme());
     expect(result.current.theme).toBe(DEFAULT_THEME);
   });
 
-  it("syncs with the data-theme attribute applied before mount", () => {
+  it("defaults preference to 'system' when nothing is stored", () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.preference).toBe(DEFAULT_PREFERENCE);
+    expect(result.current.preference).toBe("system");
+  });
+
+  it("syncs theme with the data-theme attribute applied before mount", () => {
     document.documentElement.setAttribute("data-theme", "light");
     const { result } = renderHook(() => useTheme());
     expect(result.current.theme).toBe("light");
   });
 
-  it("setTheme writes data-theme and persists to localStorage", () => {
+  it("setPreference('dark') writes data-theme and persists to localStorage", () => {
     const { result } = renderHook(() => useTheme());
 
-    act(() => result.current.setTheme("light"));
+    act(() => result.current.setPreference("dark"));
 
-    expect(result.current.theme).toBe("light");
-    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
-  });
-
-  it("toggleTheme flips dark <-> light and persists", () => {
-    const { result } = renderHook(() => useTheme());
-
-    act(() => result.current.toggleTheme());
-    expect(result.current.theme).toBe("light");
-    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
-
-    act(() => result.current.toggleTheme());
     expect(result.current.theme).toBe("dark");
+    expect(result.current.preference).toBe("dark");
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
   });
 
-  it("ignores unrecognised stored values and falls back to default", () => {
+  it("setPreference('light') writes data-theme and persists to localStorage", () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setPreference("light"));
+
+    expect(result.current.theme).toBe("light");
+    expect(result.current.preference).toBe("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+  });
+
+  it("setPreference('system') stores 'system' and resolves via matchMedia", () => {
+    // jsdom defaults matchMedia to non-matching (light system preference).
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setPreference("dark"));
+    act(() => result.current.setPreference("system"));
+
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("system");
+    expect(result.current.preference).toBe("system");
+    // Resolved theme must be a valid Theme value.
+    expect(["dark", "light"]).toContain(result.current.theme);
+  });
+
+  it("ignores unrecognised stored values and falls back to default preference", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "neon");
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.preference).toBe(DEFAULT_PREFERENCE);
+  });
+
+  it("ignores unrecognised data-theme attribute and falls back to default", () => {
     document.documentElement.setAttribute("data-theme", "neon");
     const { result } = renderHook(() => useTheme());
     expect(result.current.theme).toBe(DEFAULT_THEME);
   });
 
   it("shares state across consumers — one consumer's update reaches every other", () => {
-    // Two independent renderHook calls model two components mounting
-    // useTheme() side-by-side. With per-instance state they would drift
-    // after the first toggle; the shared store keeps them coherent.
     const a = renderHook(() => useTheme());
     const b = renderHook(() => useTheme());
 
-    act(() => a.result.current.setTheme("light"));
+    act(() => a.result.current.setPreference("light"));
     expect(a.result.current.theme).toBe("light");
     expect(b.result.current.theme).toBe("light");
 
-    act(() => b.result.current.toggleTheme());
+    act(() => b.result.current.setPreference("dark"));
     expect(a.result.current.theme).toBe("dark");
     expect(b.result.current.theme).toBe("dark");
   });
@@ -91,7 +112,7 @@ describe("THEME_INIT_SCRIPT", () => {
     resetDom();
   });
 
-  it("applies the persisted theme before paint", () => {
+  it("applies the persisted 'light' theme before paint", () => {
     window.localStorage.setItem(THEME_STORAGE_KEY, "light");
 
     new Function(THEME_INIT_SCRIPT)();
@@ -99,14 +120,50 @@ describe("THEME_INIT_SCRIPT", () => {
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
   });
 
-  it("falls back to the default when no preference is stored", () => {
+  it("applies the persisted 'dark' theme before paint", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "dark");
+
     new Function(THEME_INIT_SCRIPT)();
+
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("resolves via matchMedia when preference is 'system'", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "system");
+
+    // jsdom's matchMedia always returns non-matching, so system → light.
+    new Function(THEME_INIT_SCRIPT)();
+
+    expect(["dark", "light"]).toContain(
+      document.documentElement.getAttribute("data-theme"),
+    );
+  });
+
+  it("resolves via matchMedia when no preference is stored", () => {
+    new Function(THEME_INIT_SCRIPT)();
+
+    expect(["dark", "light"]).toContain(
+      document.documentElement.getAttribute("data-theme"),
+    );
+  });
+
+  it("falls back to the default when matchMedia is unavailable and nothing is stored", () => {
+    const origMatchMedia = window.matchMedia;
+    // @ts-expect-error — simulating a browser without matchMedia
+    window.matchMedia = undefined;
+
+    new Function(THEME_INIT_SCRIPT)();
+
     expect(document.documentElement.getAttribute("data-theme")).toBe(DEFAULT_THEME);
+    window.matchMedia = origMatchMedia;
   });
 
   it("falls back to the default for unrecognised stored values", () => {
     window.localStorage.setItem(THEME_STORAGE_KEY, "neon");
     new Function(THEME_INIT_SCRIPT)();
-    expect(document.documentElement.getAttribute("data-theme")).toBe(DEFAULT_THEME);
+    // Unrecognised → treated like "system" → resolved via matchMedia.
+    expect(["dark", "light"]).toContain(
+      document.documentElement.getAttribute("data-theme"),
+    );
   });
 });

--- a/products/dashboard/components/sidebar.tsx
+++ b/products/dashboard/components/sidebar.tsx
@@ -5,10 +5,12 @@ import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   BookOpen,
+  Check,
   ChevronLeft,
   ChevronRight,
   LayoutGrid,
   LogOut,
+  Monitor,
   Moon,
   Plus,
   Rss,
@@ -21,6 +23,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useSidebarCollapsed } from "@/lib/sidebar";
 import { useTheme } from "@/lib/theme";
+import type { ThemePreference } from "@/lib/theme-tokens";
 import { useSignOut } from "@/lib/auth/use-sign-out";
 import type { AuthUser } from "@/lib/auth/types";
 import type { WorkflowTemplate } from "@/lib/workflows/types";
@@ -108,22 +111,28 @@ function SidebarNavLink({
   );
 }
 
+const THEME_OPTIONS: Array<{ value: ThemePreference; label: string; icon: React.ReactNode }> = [
+  { value: "dark", label: "Dark", icon: <Moon className="h-3.5 w-3.5" /> },
+  { value: "light", label: "Light", icon: <Sun className="h-3.5 w-3.5" /> },
+  { value: "system", label: "System", icon: <Monitor className="h-3.5 w-3.5" /> },
+];
+
 function UserMenu({
   open,
   onClose,
-  onThemeToggle,
+  preference,
+  onSetPreference,
   onSignOut,
   signingOut,
   signOutError,
-  isDark,
 }: {
   open: boolean;
   onClose: () => void;
-  onThemeToggle: () => void;
+  preference: ThemePreference;
+  onSetPreference: (p: ThemePreference) => void;
   onSignOut: () => void;
   signingOut: boolean;
   signOutError: string | null;
-  isDark: boolean;
 }) {
   if (!open) return null;
   return (
@@ -132,20 +141,23 @@ function UserMenu({
       aria-label="User menu"
       className="absolute bottom-[calc(100%+4px)] left-2.5 right-2.5 z-20 rounded-[10px] border border-border-hi bg-bg-3 p-1.5 shadow-[var(--shadow-canvas)]"
     >
-      <button
-        type="button"
-        role="menuitem"
-        onClick={() => {
-          onThemeToggle();
-          onClose();
-        }}
-        className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-[12.5px] text-t2 hover:bg-bg-4 hover:text-t1 transition-colors"
-      >
-        <span className="flex h-3.5 w-3.5 items-center justify-center">
-          {isDark ? <Sun className="h-3.5 w-3.5" /> : <Moon className="h-3.5 w-3.5" />}
-        </span>
-        {isDark ? "Light mode" : "Dark mode"}
-      </button>
+      {THEME_OPTIONS.map(({ value, label, icon }) => (
+        <button
+          key={value}
+          type="button"
+          role="menuitem"
+          aria-checked={preference === value}
+          onClick={() => {
+            onSetPreference(value);
+            onClose();
+          }}
+          className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-[12.5px] text-t2 hover:bg-bg-4 hover:text-t1 transition-colors"
+        >
+          <span className="flex h-3.5 w-3.5 items-center justify-center">{icon}</span>
+          <span className="flex-1 text-left">{label}</span>
+          {preference === value && <Check className="h-3 w-3 text-accent" aria-hidden />}
+        </button>
+      ))}
 
       <div className="my-1 h-px bg-border" />
 
@@ -212,7 +224,7 @@ export function Sidebar({
 }: SidebarProps) {
   const pathname = usePathname();
   const { collapsed, toggleCollapsed } = useSidebarCollapsed();
-  const { theme, toggleTheme } = useTheme();
+  const { preference, setPreference } = useTheme();
   const { handleSignOut, loading: signingOut, error: signOutError } = useSignOut(user.provider);
 
   const [userMenuOpen, setUserMenuOpen] = useState(false);
@@ -340,13 +352,13 @@ export function Sidebar({
         <UserMenu
           open={userMenuOpen}
           onClose={() => setUserMenuOpen(false)}
-          onThemeToggle={toggleTheme}
+          preference={preference}
+          onSetPreference={setPreference}
           onSignOut={() => {
             void handleSignOut();
           }}
           signingOut={signingOut}
           signOutError={signOutError}
-          isDark={theme === "dark"}
         />
         <button
           type="button"

--- a/products/dashboard/e2e/theme.spec.ts
+++ b/products/dashboard/e2e/theme.spec.ts
@@ -5,10 +5,12 @@
  *
  * The login page intentionally uses a hard-coded dark hero card that does
  * not flip with `data-theme`. These tests pin the contract that:
- *   1. The default render is dark (matches `<html data-theme="dark">`).
- *   2. A persisted `theme=light` preference boots the page in light mode
- *      via the inline pre-paint script — exercising the real entry path
- *      for a returning user, not just a post-load DOM mutation.
+ *   1. With no persisted `theme` key, the inline pre-paint script resolves
+ *      the effective palette from `prefers-color-scheme` (default preference
+ *      is system).
+ *   2. A persisted `theme=light` or `theme=dark` value overrides that and
+ *      boots accordingly — exercising the real entry path for returning
+ *      users, not just a post-load DOM mutation.
  */
 
 import { test, expect } from "@playwright/test";
@@ -16,9 +18,17 @@ import { test, expect } from "@playwright/test";
 const THEME_STORAGE_KEY = "theme";
 
 test.describe("theme — login page renders in both themes", () => {
-  test("default render uses data-theme=\"dark\"", async ({ page }) => {
+  test("no persisted theme + prefers dark → data-theme=\"dark\"", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "dark" });
     await page.goto("/login");
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(page.getByRole("form", { name: /sign in/i })).toBeVisible();
+  });
+
+  test("no persisted theme + prefers light → data-theme=\"light\"", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "light" });
+    await page.goto("/login");
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
     await expect(page.getByRole("form", { name: /sign in/i })).toBeVisible();
   });
 

--- a/products/dashboard/lib/theme-tokens.ts
+++ b/products/dashboard/lib/theme-tokens.ts
@@ -11,9 +11,17 @@
  * `lib/theme.ts`.
  */
 
+/** The resolved/applied theme — the value written to `data-theme`. */
 export type Theme = "dark" | "light";
 
+/** The stored user preference, which may delegate to the OS. */
+export type ThemePreference = "dark" | "light" | "system";
+
+/** Fallback resolved theme for SSR and when matchMedia is unavailable. */
 export const DEFAULT_THEME: Theme = "dark";
+
+/** Default preference for new users — follow the OS. */
+export const DEFAULT_PREFERENCE: ThemePreference = "system";
 
 /** localStorage key used to persist the user's theme preference. */
 export const THEME_STORAGE_KEY = "theme";
@@ -21,11 +29,20 @@ export const THEME_STORAGE_KEY = "theme";
 /**
  * Inline script body used by `RootLayout` to rehydrate the persisted theme
  * before paint. Pure string — safe to embed in a Server Component.
+ *
+ * When the preference is "system" (or absent / unrecognised), the script
+ * resolves the effective theme via `prefers-color-scheme` so the OS setting
+ * is honoured without a flash.
  */
 export const THEME_INIT_SCRIPT = `(() => {
   try {
     const stored = window.localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});
-    const theme = stored === "light" || stored === "dark" ? stored : ${JSON.stringify(DEFAULT_THEME)};
+    let theme;
+    if (stored === "light" || stored === "dark") {
+      theme = stored;
+    } else {
+      theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
     document.documentElement.setAttribute("data-theme", theme);
   } catch {
     document.documentElement.setAttribute("data-theme", ${JSON.stringify(DEFAULT_THEME)});

--- a/products/dashboard/lib/theme.ts
+++ b/products/dashboard/lib/theme.ts
@@ -18,20 +18,56 @@
  * snapshot, drift after the first toggle, and silently flip the wrong way
  * on the next call. `useSyncExternalStore` keeps the React renders
  * coherent across all subscribers.
+ *
+ * When the preference is "system", a `matchMedia` listener fires whenever
+ * `prefers-color-scheme` changes and the app updates immediately without a
+ * page reload.
  */
 
 import { useCallback, useSyncExternalStore } from "react";
 
-import { DEFAULT_THEME, THEME_STORAGE_KEY, type Theme } from "./theme-tokens";
+import {
+  DEFAULT_PREFERENCE,
+  DEFAULT_THEME,
+  THEME_STORAGE_KEY,
+  type Theme,
+  type ThemePreference,
+} from "./theme-tokens";
 
 function isTheme(value: unknown): value is Theme {
   return value === "dark" || value === "light";
+}
+
+function isThemePreference(value: unknown): value is ThemePreference {
+  return value === "dark" || value === "light" || value === "system";
+}
+
+function getSystemTheme(): Theme {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function")
+    return DEFAULT_THEME;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
 }
 
 function readDomTheme(): Theme {
   if (typeof document === "undefined") return DEFAULT_THEME;
   const attr = document.documentElement.getAttribute("data-theme");
   return isTheme(attr) ? attr : DEFAULT_THEME;
+}
+
+function readPreference(): ThemePreference {
+  if (typeof window === "undefined") return DEFAULT_PREFERENCE;
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return isThemePreference(stored) ? stored : DEFAULT_PREFERENCE;
+  } catch {
+    return DEFAULT_PREFERENCE;
+  }
+}
+
+function resolveTheme(pref: ThemePreference): Theme {
+  return pref === "system" ? getSystemTheme() : pref;
 }
 
 const listeners = new Set<() => void>();
@@ -47,17 +83,31 @@ function emitThemeChange(): void {
   listeners.forEach((listener) => listener());
 }
 
+// Keep the DOM in sync when the OS preference changes and the user has chosen "system".
+if (typeof window !== "undefined" && typeof window.matchMedia === "function") {
+  window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", () => {
+      if (readPreference() === "system") {
+        const resolved = getSystemTheme();
+        document.documentElement.setAttribute("data-theme", resolved);
+        emitThemeChange();
+      }
+    });
+}
+
 function getServerSnapshot(): Theme {
   return DEFAULT_THEME;
 }
 
-function applyTheme(theme: Theme): void {
+function applyPreference(pref: ThemePreference): void {
+  const resolved = resolveTheme(pref);
   if (typeof document !== "undefined") {
-    document.documentElement.setAttribute("data-theme", theme);
+    document.documentElement.setAttribute("data-theme", resolved);
   }
   if (typeof window !== "undefined") {
     try {
-      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+      window.localStorage.setItem(THEME_STORAGE_KEY, pref);
     } catch {
       // Persisting is best-effort. A sandboxed browser, full storage
       // quota, or privacy mode still gets a working theme — the in-memory
@@ -68,25 +118,26 @@ function applyTheme(theme: Theme): void {
 }
 
 /**
- * Read and write the active theme.
+ * Read and write the active theme preference.
+ *
+ * - `theme` — the resolved effective theme ("dark" | "light") applied to the DOM.
+ * - `preference` — the stored preference ("dark" | "light" | "system").
+ * - `setPreference` — update the preference; "system" follows the OS in real-time.
  *
  * All subscribers share one module-level store, so an update from any
  * consumer is reflected in every other consumer's next render.
  */
 export function useTheme(): {
   theme: Theme;
-  setTheme: (theme: Theme) => void;
-  toggleTheme: () => void;
+  preference: ThemePreference;
+  setPreference: (pref: ThemePreference) => void;
 } {
   const theme = useSyncExternalStore(subscribe, readDomTheme, getServerSnapshot);
+  const preference = useSyncExternalStore(subscribe, readPreference, () => DEFAULT_PREFERENCE);
 
-  const setTheme = useCallback((next: Theme) => {
-    applyTheme(next);
+  const setPreference = useCallback((pref: ThemePreference) => {
+    applyPreference(pref);
   }, []);
 
-  const toggleTheme = useCallback(() => {
-    applyTheme(readDomTheme() === "dark" ? "light" : "dark");
-  }, []);
-
-  return { theme, setTheme, toggleTheme };
+  return { theme, preference, setPreference };
 }


### PR DESCRIPTION
## Summary

- **What changed?** The dashboard sidebar user menu now offers explicit Dark, Light, and System theme preference options backed by `useTheme().preference` / `setPreference`. Theme tokens and runtime sync were extended so persistence and DOM `data-theme` stay consistent, including system preference updates.
- **Why does it matter?** Users can choose fixed light/dark themes or follow the OS without a coarse toggle hiding those choices.

## Validation

- [x] `npm run validate` (root spec/example validation — passed)
- [x] `npm test -- --run` in `products/dashboard` — passed (246 tests)

## Checklist

- [x] PR targets `staging` (not `main`)
- [x] Schema/examples/policy unchanged — N/A this slice
- [x] Behavior change confined to dashboard shell theme UX

Labels (per execution loop risk policy): classify as **risk:med** (runtime app/UI behavior in products/dashboard).

Made with [Cursor](https://cursor.com)