### PR TITLE
feat(dashboard): subtle scrollbar styling in base CSS

### DIFF
--- a/products/dashboard/app/styles/base.css
+++ b/products/dashboard/app/styles/base.css
@@ -32,6 +32,45 @@ button:disabled {
 }
 
 /*
+ * Subtle scrollbars across the dashboard. macOS "Show scroll bars: Always"
+ * and most desktop Linux setups default to chunky always-visible bars that
+ * fight the dark UI; this normalizes them to a thin, low-contrast track
+ * that only reveals its thumb when the user is hovering the scroll
+ * container, mirroring macOS's "Automatically" overlay behavior even when
+ * the OS is set to "Always".
+ */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+*:hover {
+  scrollbar-color: var(--border-hi) transparent;
+}
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  background-color: transparent;
+  border-radius: 8px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  transition: background-color 0.15s ease;
+}
+*:hover::-webkit-scrollbar-thumb {
+  background-color: var(--border-hi);
+}
+*::-webkit-scrollbar-thumb:hover {
+  background-color: var(--t3);
+}
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/*
  * Sidebar collapse — driven by `<html data-sidebar="collapsed|expanded">`.
  *
  * The collapse state lives on the root element so the inline pre-paint


### PR DESCRIPTION
## Summary

- What changed? Added thin, low-contrast scrollbars globally in dashboard `base.css` (Firefox `scrollbar-width`/`scrollbar-color` + WebKit pseudo-elements). Thumbs appear on scrollbar hover using `--border-hi` and `--t3`.
- Why does it matter? Normalizes chunky always-visible OS scrollbars so they do not fight the dark UI; mirrors overlay-style behavior where practical.

## Validation

- [x] `npm run validate`

## Checklist

- [x] PR targets `staging` (not `main`) — only release-please and staging promotion PRs target `main`
- [x] Schema, examples, and policy stay aligned
- [x] Documentation updated where behavior changed (behavior is visual-only; no spec or docs change needed)

Made with [Cursor](https://cursor.com)