### PR TITLE
chore(dashboard): align Node 24 in CI and package engines

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: products/dashboard/package-lock.json
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20.19"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: products/dashboard/package-lock.json
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20.19"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: products/dashboard/package-lock.json
 
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20.19"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: products/dashboard/package-lock.json
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: products/dashboard/package-lock.json
 
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: products/dashboard/package-lock.json
 

--- a/.github/workflows/p1-autofix.yml
+++ b/.github/workflows/p1-autofix.yml
@@ -63,7 +63,7 @@ jobs:
         if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false'
         uses: actions/setup-node@v6
         with:
-          node-version: "20.19"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/p1-autofix.yml
+++ b/.github/workflows/p1-autofix.yml
@@ -63,7 +63,7 @@ jobs:
         if: steps.guard.outputs.skip == 'false' && steps.guard.outputs.is_fork == 'false'
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-node@v6
         if: steps.changes.outputs.run_tests == 'true'
         with:
-          node-version: "20.19"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: products/dashboard/package-lock.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-node@v6
         if: steps.changes.outputs.run_tests == 'true'
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: products/dashboard/package-lock.json
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
       - run: npm ci
       - run: npm run validate

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: "20.19"
+          node-version: "22"
           cache: "npm"
       - run: npm ci
       - run: npm run validate

--- a/products/dashboard/package-lock.json
+++ b/products/dashboard/package-lock.json
@@ -53,7 +53,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=20.12"
+        "node": "24.x"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/products/dashboard/package.json
+++ b/products/dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "22.x"
+    "node": "24.x"
   },
   "scripts": {
     "dev": "next dev",

--- a/products/dashboard/package.json
+++ b/products/dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20.19"
+    "node": "22.x"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Set `actions/setup-node` to **24** in e2e, nightly, p1-autofix, test, and validate workflows.
- Set `products/dashboard` `engines.node` to **`24.x`** so local and CI expectations match.

## Why Node 24
- Node 20 reached end-of-life in April 2026; Node 24 is the current Active LTS.
- Pinned-major format (`24.x`) is Vercel's recommended shape — avoids the "open-ended `>=` range" warning during deploys and prevents silent jumps to a future major.

## Risk
CI workflow and runtime constraint changes — policy should classify accordingly (`risk:med` typical for CI).