### PR TITLE
chore(dashboard): add App Router icon.svg

### DIFF
--- a/products/dashboard/app/icon.svg
+++ b/products/dashboard/app/icon.svg
@@ -1,0 +1,17 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">AI-Native Framework Governed Orchestration logo</title>
+  <desc id="desc">Symbol-only logo from the Governed Orchestration concept in Figma Make.</desc>
+  <path d="M30 15 L15 15 L15 105 L30 105" stroke="#000" stroke-width="3.5" fill="none" stroke-linecap="square" />
+  <path d="M90 15 L105 15 L105 105 L90 105" stroke="#000" stroke-width="3.5" fill="none" stroke-linecap="square" />
+  <rect x="35" y="35" width="50" height="50" stroke="#000" stroke-width="2.5" fill="none" />
+  <line x1="60" y1="60" x2="48" y2="48" stroke="#000" stroke-width="1.5" opacity="0.4" />
+  <line x1="60" y1="60" x2="72" y2="48" stroke="#000" stroke-width="1.5" opacity="0.4" />
+  <line x1="60" y1="60" x2="48" y2="72" stroke="#000" stroke-width="1.5" opacity="0.4" />
+  <line x1="60" y1="60" x2="72" y2="72" stroke="#000" stroke-width="1.5" opacity="0.4" />
+  <line x1="48" y1="48" x2="72" y2="48" stroke="#000" stroke-width="1.5" opacity="0.4" />
+  <circle cx="60" cy="60" r="5" fill="#000" />
+  <circle cx="48" cy="48" r="5" fill="#000" />
+  <circle cx="72" cy="48" r="5" fill="#000" />
+  <circle cx="48" cy="72" r="5" fill="#000" />
+  <circle cx="72" cy="72" r="5" fill="#000" />
+</svg>


### PR DESCRIPTION
## Summary

Adds `app/icon.svg` so the Next.js App Router serves a consistent favicon and the `/icon` static route (Governed Orchestration symbol from the product concept).

## Notes

- **Risk:** Low (static asset only).
- `next-env.d.ts` can show a spurious local diff after `next dev` (Next 16 may point at `.next/dev/types/routes.d.ts`); `next build` restores the committed path. No change to that file in this PR.

## Verification

- `npm run validate` (root) — pass
- `npm run build` in `products/dashboard` — pass locally before commit

Made with [Cursor](https://cursor.com)