### PR TITLE
feat(dashboard): workflow sidebar, toasts, and loading polish

### DIFF
--- a/products/dashboard/__tests__/components/sidebar-workflow-tree.test.tsx
+++ b/products/dashboard/__tests__/components/sidebar-workflow-tree.test.tsx
@@ -89,7 +89,7 @@ describe("SidebarWorkflowTree", () => {
     expect(screen.getByTestId("sidebar-workflows-empty")).toBeInTheDocument();
   });
 
-  it("renders one section per template with an instance count and per-instance links", () => {
+  it("renders one section per template with template-edit links and per-instance links", () => {
     renderWithToast(
       <SidebarWorkflowTree
         templates={[TEMPLATE_A, TEMPLATE_B]}
@@ -129,10 +129,10 @@ describe("SidebarWorkflowTree", () => {
       screen.getByTestId("workflow-instance-link-inst-2"),
     ).toHaveAttribute("href", "/workflows/inst-2");
 
-    // Count pill shows instance count for the populated template
+    // Template name navigates to the template editor
     expect(
-      screen.getByTestId("workflow-template-count-client-delivery"),
-    ).toHaveTextContent("2");
+      screen.getByTestId("workflow-template-link-client-delivery"),
+    ).toHaveAttribute("href", "/workflows/templates/client-delivery/edit");
   });
 
   it("opens the create-instance modal scoped to the clicked template", async () => {

--- a/products/dashboard/__tests__/components/top-bar.test.tsx
+++ b/products/dashboard/__tests__/components/top-bar.test.tsx
@@ -84,7 +84,7 @@ describe("TopBar", () => {
     renderWithTopBarProvider(<TopBar />);
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.click(screen.getByRole("button", { name: "Customize" }));
 
     expect(replace).toHaveBeenCalledWith("/workflows/123?edit=1", { scroll: false });
   });
@@ -179,6 +179,6 @@ describe("TopBar", () => {
 
     const saveButton = screen.getByRole("button", { name: "Save" });
     expect(saveButton).toBeInTheDocument();
-    expect(saveButton.querySelector("span")).not.toBeNull();
+    expect(saveButton.querySelector("svg")).not.toBeNull();
   });
 });

--- a/products/dashboard/app/(dashboard)/framework/playbooks/loading.tsx
+++ b/products/dashboard/app/(dashboard)/framework/playbooks/loading.tsx
@@ -4,30 +4,42 @@ function Bone({ className }: { className?: string }) {
   );
 }
 
+function CardSkeleton() {
+  return (
+    <div className="flex min-h-[92px] items-center gap-3 rounded-[16px] border border-border bg-bg px-4 py-4">
+      <Bone className="h-10 w-10 shrink-0 rounded-md" />
+      <div className="min-w-0 flex-1">
+        <Bone className="h-3.5 w-1/2" />
+        <Bone className="mt-2 h-2.5 w-4/5" />
+      </div>
+    </div>
+  );
+}
+
 export default function PlaybooksLoading() {
   return (
-    <div className="flex h-full min-h-0">
-      {/* Left panel — item list */}
-      <div className="flex w-64 shrink-0 flex-col gap-2 border-r border-border p-3">
-        <Bone className="mb-1 h-7 w-full rounded-md" />
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-2 rounded-md p-2">
-            <Bone className="h-4 w-4 shrink-0 rounded" />
-            <Bone className="h-3 flex-1" />
-          </div>
-        ))}
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <div className="shrink-0 border-b border-border bg-bg px-6 py-5">
+        <Bone className="h-2.5 w-20" />
+        <Bone className="mt-2 h-5 w-44" />
+        <Bone className="mt-2 h-3 w-72" />
       </div>
 
-      {/* Right panel — editor */}
-      <div className="flex min-w-0 flex-1 flex-col p-6">
-        <Bone className="mb-4 h-5 w-56" />
-        <Bone className="mb-2 h-3 w-full" />
-        <Bone className="mb-2 h-3 w-4/5" />
-        <Bone className="mb-2 h-3 w-full" />
-        <Bone className="mb-6 h-3 w-2/3" />
-        <Bone className="mb-2 h-3 w-5/6" />
-        <Bone className="mb-2 h-3 w-full" />
-        <Bone className="h-3 w-3/4" />
+      <div className="shrink-0 border-b border-border bg-bg px-6 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <Bone className="h-9 w-full max-w-[320px] rounded-md" />
+          <Bone className="h-8 w-[120px] shrink-0 rounded-md" />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto bg-bg-2">
+        <div className="p-3 md:p-4">
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <CardSkeleton key={i} />
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/products/dashboard/app/(dashboard)/framework/skills/loading.tsx
+++ b/products/dashboard/app/(dashboard)/framework/skills/loading.tsx
@@ -4,31 +4,47 @@ function Bone({ className }: { className?: string }) {
   );
 }
 
+function CardSkeleton() {
+  return (
+    <div className="flex min-h-[92px] items-center gap-3 rounded-[16px] border border-border bg-bg px-4 py-4">
+      <Bone className="h-10 w-10 shrink-0 rounded-md" />
+      <div className="min-w-0 flex-1">
+        <Bone className="h-3.5 w-1/2" />
+        <Bone className="mt-2 h-2.5 w-4/5" />
+      </div>
+    </div>
+  );
+}
+
 export default function SkillsLoading() {
   return (
-    <div className="flex h-full min-h-0">
-      {/* Left panel — item list */}
-      <div className="flex w-64 shrink-0 flex-col gap-2 border-r border-border p-3">
-        <Bone className="mb-1 h-7 w-full rounded-md" />
-        {Array.from({ length: 7 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-2 rounded-md p-2">
-            <Bone className="h-4 w-4 shrink-0 rounded" />
-            <Bone className="h-3 flex-1" />
-          </div>
-        ))}
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      {/* Page header — eyebrow + title + subtitle. Matches
+          framework-screen's `border-b ... px-6 py-5` header so there's
+          no jump on hydration. */}
+      <div className="shrink-0 border-b border-border bg-bg px-6 py-5">
+        <Bone className="h-2.5 w-16" />
+        <Bone className="mt-2 h-5 w-40" />
+        <Bone className="mt-2 h-3 w-72" />
       </div>
 
-      {/* Right panel — editor */}
-      <div className="flex min-w-0 flex-1 flex-col p-6">
-        <Bone className="mb-4 h-5 w-48" />
-        <Bone className="mb-2 h-3 w-full" />
-        <Bone className="mb-2 h-3 w-5/6" />
-        <Bone className="mb-2 h-3 w-full" />
-        <Bone className="mb-2 h-3 w-3/4" />
-        <Bone className="mb-6 h-3 w-full" />
-        <Bone className="mb-2 h-3 w-5/6" />
-        <Bone className="mb-2 h-3 w-full" />
-        <Bone className="h-3 w-2/3" />
+      {/* Action bar — search + sort + create button cluster. Matches
+          framework-screen's sticky `px-6 py-3` toolbar. */}
+      <div className="shrink-0 border-b border-border bg-bg px-6 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <Bone className="h-9 w-full max-w-[320px] rounded-md" />
+          <Bone className="h-8 w-[110px] shrink-0 rounded-md" />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto bg-bg-2">
+        <div className="p-3 md:p-4">
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <CardSkeleton key={i} />
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/products/dashboard/app/(dashboard)/workflows/templates/[templateId]/edit/loading.tsx
+++ b/products/dashboard/app/(dashboard)/workflows/templates/[templateId]/edit/loading.tsx
@@ -7,11 +7,11 @@ function Bone({ className }: { className?: string }) {
 const COLS = 3;
 const ROWS = 4;
 
-export default function WorkflowInstanceLoading() {
+export default function TemplateEditorLoading() {
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
-      {/* Header — matches WorkflowInstanceHeader footprint so the page
-          doesn't jump on hydration. */}
+      {/* Header — matches template-editor's `border-b ... px-6 py-4`
+          eyebrow + title + subtitle so the page doesn't jump. */}
       <header className="flex shrink-0 flex-col border-b border-border bg-bg px-6 py-4">
         <Bone className="h-2.5 w-28" />
         <Bone className="mt-1 h-6 w-56" />
@@ -20,7 +20,6 @@ export default function WorkflowInstanceLoading() {
 
       {/* Matrix */}
       <div className="min-h-0 flex-1 overflow-auto p-4">
-        {/* Role header row */}
         <div
           className="mb-2 grid gap-2"
           style={{ gridTemplateColumns: `120px repeat(${COLS}, 1fr)` }}
@@ -31,7 +30,6 @@ export default function WorkflowInstanceLoading() {
           ))}
         </div>
 
-        {/* Stage rows */}
         <div className="flex flex-col gap-2">
           {Array.from({ length: ROWS }).map((_, row) => (
             <div

--- a/products/dashboard/components/framework/framework-header-actions-menu.tsx
+++ b/products/dashboard/components/framework/framework-header-actions-menu.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { Ellipsis, Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "lucide-react";
+
+import { IconButtonTooltip } from "@/components/ui/icon-button-tooltip";
 
 interface FrameworkHeaderActionsMenuProps {
   entityName: string;
@@ -14,69 +15,26 @@ export function FrameworkHeaderActionsMenu({
   onRename,
   onDelete,
 }: FrameworkHeaderActionsMenuProps) {
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const [open, setOpen] = useState(false);
-
-  useEffect(() => {
-    if (!open) return;
-
-    function handlePointerDown(event: MouseEvent) {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    }
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        setOpen(false);
-      }
-    }
-
-    document.addEventListener("mousedown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
-
   return (
-    <div ref={rootRef} className="relative">
-      <button
+    <div className="flex items-center gap-0.5 rounded-md border border-border bg-bg-2 p-0.5">
+      <IconButtonTooltip
         type="button"
-        aria-label={`Open ${entityName} actions`}
-        aria-expanded={open}
-        onClick={() => setOpen((current) => !current)}
-        className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-md border border-border bg-bg-2 text-t2 transition hover:border-border-hi hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent aria-expanded:border-accent aria-expanded:bg-primary-bg aria-expanded:text-accent"
+        tooltip={`Rename ${entityName}`}
+        onClick={onRename}
+        align="end"
       >
-        <Ellipsis className="h-[15px] w-[15px]" strokeWidth={2.4} />
-      </button>
-      {open ? (
-        <div className="absolute right-0 top-[calc(100%+8px)] z-30 min-w-[168px] rounded-xl border border-border-hi bg-bg-2 p-1.5 shadow-[var(--shadow-canvas)]">
-          <button
-            type="button"
-            onClick={() => {
-              setOpen(false);
-              onRename();
-            }}
-            className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left text-[12.5px] text-t1 transition hover:bg-bg-3"
-          >
-            <Pencil className="h-3.5 w-3.5" />
-            Rename
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setOpen(false);
-              onDelete();
-            }}
-            className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left text-[12.5px] text-[#f87171] transition hover:bg-linear-to-b hover:from-[#ef4444] hover:to-[#dc2626] hover:text-[#fff7f7]"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            Delete
-          </button>
-        </div>
-      ) : null}
+        <Pencil className="h-3.5 w-3.5" strokeWidth={2.2} />
+      </IconButtonTooltip>
+      <span aria-hidden className="h-4 w-px bg-border" />
+      <IconButtonTooltip
+        type="button"
+        tooltip={`Delete ${entityName}`}
+        onClick={onDelete}
+        align="end"
+        className="text-[#f87171] hover:bg-linear-to-b hover:from-[#ef4444] hover:to-[#dc2626] hover:text-[#fff7f7]"
+      >
+        <Trash2 className="h-3.5 w-3.5" strokeWidth={2.2} />
+      </IconButtonTooltip>
     </div>
   );
 }

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -769,23 +769,25 @@ export function FrameworkScreen({
                   }}
                 />
 
-                <button
-                  type="button"
-                  onClick={() => importInputRef.current?.click()}
-                  className="flex h-8 items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-                >
-                  <Upload className="h-3.5 w-3.5" />
-                  Upload
-                </button>
-
-                <button
-                  type="button"
-                  onClick={downloadMarkdown}
-                  className="flex h-8 items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-                >
-                  <Download className="h-3.5 w-3.5" />
-                  Download
-                </button>
+                <div className="flex h-8 items-center overflow-hidden rounded-md border border-border bg-bg">
+                  <button
+                    type="button"
+                    onClick={() => importInputRef.current?.click()}
+                    className="flex h-full items-center gap-1.5 px-2.5 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent"
+                  >
+                    <Upload className="h-3.5 w-3.5" />
+                    Upload
+                  </button>
+                  <span aria-hidden className="h-full w-px bg-border" />
+                  <button
+                    type="button"
+                    onClick={downloadMarkdown}
+                    className="flex h-full items-center gap-1.5 px-2.5 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent"
+                  >
+                    <Download className="h-3.5 w-3.5" />
+                    Download
+                  </button>
+                </div>
               </div>
             </div>
 

--- a/products/dashboard/components/top-bar.tsx
+++ b/products/dashboard/components/top-bar.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Loader2, Pencil } from "lucide-react";
+import { Loader2, Save, SlidersHorizontal } from "lucide-react";
 
 import {
   type DashboardTopBarCrumb,
@@ -200,12 +200,9 @@ export function TopBar() {
               )}
             >
               {savePending ? (
-                <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
               ) : !saveDisabled ? (
-                <span
-                  aria-hidden
-                  className="h-1.5 w-1.5 rounded-full bg-white shadow-[0_0_10px_rgba(255,255,255,0.7)]"
-                />
+                <Save className="h-3.5 w-3.5" aria-hidden strokeWidth={2.4} />
               ) : null}
               Save
             </button>
@@ -216,11 +213,11 @@ export function TopBar() {
               type="button"
               aria-pressed={editMode}
               onClick={toggleEditMode}
-              title="Edit workflow tasks"
+              title="Customize this instance"
               className="flex cursor-pointer items-center gap-1.5 rounded-md border border-border bg-bg-2 px-2.5 py-1.5 text-[11.5px] font-medium text-t2 transition hover:border-border-hi hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
-              <Pencil className="h-3.5 w-3.5" />
-              Edit
+              <SlidersHorizontal className="h-3.5 w-3.5" />
+              Customize
             </button>
           ) : null}
         </div>

--- a/products/dashboard/components/ui/icon-button-tooltip.tsx
+++ b/products/dashboard/components/ui/icon-button-tooltip.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import {
+  forwardRef,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+interface IconButtonTooltipProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  tooltip: string;
+  children: ReactNode;
+  /**
+   * Tooltip horizontal alignment relative to the button.
+   * - `start` (default): tooltip's left edge aligns with the button's
+   *   left edge, growing rightward.
+   * - `end`: tooltip's right edge aligns with the button's right edge,
+   *   growing leftward — keep this near the right edge of the
+   *   viewport.
+   */
+  align?: "start" | "end";
+}
+
+/**
+ * Icon button with a CSS-only hover/focus tooltip — anchored to the
+ * button itself (not the cursor) and positioned just below it. Mirrors
+ * the trigger pattern used by `AllowedItemsPicker`'s `+` button.
+ */
+export const IconButtonTooltip = forwardRef<HTMLButtonElement, IconButtonTooltipProps>(
+  function IconButtonTooltip({ tooltip, children, className, align = "start", ...rest }, ref) {
+    return (
+      <span className="group/tt relative inline-flex">
+        <button
+          ref={ref}
+          aria-label={tooltip}
+          className={cn(
+            "flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+            className,
+          )}
+          {...rest}
+        >
+          {children}
+        </button>
+        <span
+          role="tooltip"
+          className={cn(
+            "pointer-events-none absolute top-[calc(100%+6px)] z-[60] whitespace-nowrap rounded-md border border-border-hi bg-bg-2 px-2 py-1 text-[11px] font-medium text-t1 opacity-0 shadow-[var(--shadow-canvas)] transition-opacity duration-100 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100",
+            align === "end" ? "right-0" : "left-0",
+          )}
+        >
+          {tooltip}
+        </span>
+      </span>
+    );
+  },
+);

--- a/products/dashboard/components/ui/toaster.tsx
+++ b/products/dashboard/components/ui/toaster.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { CheckCircle2, X, XCircle } from "lucide-react";
+import { useState } from "react";
+import { CheckCircle2, ChevronDown, X, XCircle } from "lucide-react";
 
 import { useToastStore } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 
 export function Toaster() {
   const { toasts, dismiss } = useToastStore();
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
 
   if (toasts.length === 0) return null;
 
@@ -14,50 +16,95 @@ export function Toaster() {
     <div
       aria-live="polite"
       aria-label="Notifications"
-      className="pointer-events-none fixed bottom-6 right-6 z-[200] flex flex-col gap-2"
+      className="pointer-events-none fixed right-6 top-[60px] z-[200] flex flex-col gap-2"
     >
-      {toasts.map((toast) => (
-        <div
-          key={toast.id}
-          role="status"
-          className={cn(
-            "pointer-events-auto flex w-[320px] items-start gap-3 rounded-xl border border-border-hi bg-bg-2 px-4 py-3 shadow-[var(--shadow-canvas)] transition-[transform,opacity] duration-[280ms] ease-out",
-            toast.visible
-              ? "translate-y-0 opacity-100"
-              : "translate-y-3 opacity-0",
-          )}
-        >
-          <span className="mt-px shrink-0">
-            {toast.variant === "success" ? (
-              <CheckCircle2
-                className="h-[15px] w-[15px] text-(color:--pill-complete-d)"
-                strokeWidth={2.2}
-              />
-            ) : (
-              <XCircle
-                className="h-[15px] w-[15px] text-(color:--pill-blocked-d)"
-                strokeWidth={2.2}
-              />
+      {toasts.map((toast) => {
+        const accent =
+          toast.variant === "success"
+            ? "var(--pill-complete-d)"
+            : "var(--pill-blocked-d)";
+        const isOpen = expanded[toast.id] === true;
+        return (
+          <div
+            key={toast.id}
+            role="status"
+            className={cn(
+              "pointer-events-auto relative flex w-[340px] items-start gap-3 overflow-hidden rounded-xl border border-border-hi bg-bg-2 px-4 py-3 pl-[15px] shadow-[var(--shadow-canvas)] transition-[transform,opacity] duration-[280ms] ease-out",
+              toast.visible
+                ? "translate-y-0 opacity-100"
+                : "-translate-y-3 opacity-0",
             )}
-          </span>
-
-          <div className="min-w-0 flex-1">
-            <p className="text-[12.5px] font-semibold leading-5 text-t1">{toast.title}</p>
-            {toast.description ? (
-              <p className="mt-0.5 text-[12px] leading-5 text-t2">{toast.description}</p>
-            ) : null}
-          </div>
-
-          <button
-            type="button"
-            aria-label="Dismiss notification"
-            onClick={() => dismiss(toast.id)}
-            className="-mr-1 -mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-t3 transition hover:bg-bg-4 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
           >
-            <X className="h-3 w-3" />
-          </button>
-        </div>
-      ))}
+            <span
+              aria-hidden
+              className="absolute left-0 top-0 h-full w-[3px]"
+              style={{ backgroundColor: accent }}
+            />
+
+            <span className="mt-px shrink-0">
+              {toast.variant === "success" ? (
+                <CheckCircle2
+                  className="h-[15px] w-[15px]"
+                  style={{ color: accent }}
+                  strokeWidth={2.2}
+                />
+              ) : (
+                <XCircle
+                  className="h-[15px] w-[15px]"
+                  style={{ color: accent }}
+                  strokeWidth={2.2}
+                />
+              )}
+            </span>
+
+            <div className="min-w-0 flex-1">
+              <p className="text-[12.5px] font-semibold leading-5 text-t1">
+                {toast.title}
+              </p>
+              {toast.description ? (
+                <p className="mt-0.5 text-[12px] leading-5 text-t2">
+                  {toast.description}
+                </p>
+              ) : null}
+
+              {toast.detail ? (
+                <>
+                  <button
+                    type="button"
+                    aria-expanded={isOpen}
+                    onClick={() =>
+                      setExpanded((prev) => ({ ...prev, [toast.id]: !isOpen }))
+                    }
+                    className="mt-1 flex items-center gap-1 text-[11px] font-medium text-t3 transition hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
+                  >
+                    <ChevronDown
+                      className={cn(
+                        "h-3 w-3 transition-transform duration-150",
+                        isOpen && "rotate-180",
+                      )}
+                    />
+                    {isOpen ? "Hide details" : "Show details"}
+                  </button>
+                  {isOpen ? (
+                    <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words border-t border-border pt-2 font-mono text-[11px] leading-[1.45] text-t3">
+                      {toast.detail}
+                    </pre>
+                  ) : null}
+                </>
+              ) : null}
+            </div>
+
+            <button
+              type="button"
+              aria-label="Dismiss notification"
+              onClick={() => dismiss(toast.id)}
+              className="-mr-1 -mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-t3 transition hover:bg-bg-4 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/products/dashboard/components/workflows/header-actions-menu.tsx
+++ b/products/dashboard/components/workflows/header-actions-menu.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useEffect, useRef, useState } from "react";
-import { Ellipsis, Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Pencil, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { IconButtonTooltip } from "@/components/ui/icon-button-tooltip";
 import { TextInputModal } from "@/components/ui/text-input-modal";
 
 interface HeaderActionsMenuProps {
@@ -28,74 +29,32 @@ export function HeaderActionsMenu({
   requireDeleteLabelMatch = false,
 }: HeaderActionsMenuProps) {
   const router = useRouter();
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const [open, setOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [pending, setPending] = useState(false);
   const entityName = entityType === "template" ? "workflow template" : "workflow instance";
 
-  useEffect(() => {
-    if (!open) return;
-
-    function handlePointerDown(event: MouseEvent) {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    }
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        setOpen(false);
-      }
-    }
-
-    document.addEventListener("mousedown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
-
   return (
     <>
-      <div ref={rootRef} className="relative">
-        <button
+      <div className="flex items-center gap-0.5 rounded-md border border-border bg-bg-2 p-0.5">
+        <IconButtonTooltip
           type="button"
-          aria-label={`Open ${entityName} actions`}
-          aria-expanded={open}
-          onClick={() => setOpen((current) => !current)}
-          className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-md border border-border bg-bg-2 text-t2 transition hover:border-border-hi hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent aria-expanded:border-accent aria-expanded:bg-primary-bg aria-expanded:text-accent"
+          tooltip={`Rename ${entityName}`}
+          onClick={() => setRenameOpen(true)}
+          align="end"
         >
-          <Ellipsis className="h-[15px] w-[15px]" strokeWidth={2.4} />
-        </button>
-        {open ? (
-          <div className="absolute right-0 top-[calc(100%+8px)] z-30 min-w-[168px] rounded-xl border border-border-hi bg-bg-2 p-1.5 shadow-[var(--shadow-canvas)]">
-            <button
-              type="button"
-              onClick={() => {
-                setOpen(false);
-                setRenameOpen(true);
-              }}
-              className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left text-[12.5px] text-t1 transition hover:bg-bg-3"
-            >
-              <Pencil className="h-3.5 w-3.5" />
-              Rename
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setOpen(false);
-                setDeleteOpen(true);
-              }}
-              className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left text-[12.5px] text-[#f87171] transition hover:bg-linear-to-b hover:from-[#ef4444] hover:to-[#dc2626] hover:text-[#fff7f7]"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-              Delete
-            </button>
-          </div>
-        ) : null}
+          <Pencil className="h-3.5 w-3.5" strokeWidth={2.2} />
+        </IconButtonTooltip>
+        <span aria-hidden className="h-4 w-px bg-border" />
+        <IconButtonTooltip
+          type="button"
+          tooltip={`Delete ${entityName}`}
+          onClick={() => setDeleteOpen(true)}
+          align="end"
+          className="text-[#f87171] hover:bg-linear-to-b hover:from-[#ef4444] hover:to-[#dc2626] hover:text-[#fff7f7]"
+        >
+          <Trash2 className="h-3.5 w-3.5" strokeWidth={2.2} />
+        </IconButtonTooltip>
       </div>
 
       {renameOpen ? (
@@ -134,7 +93,7 @@ export function HeaderActionsMenu({
           onClose={() => {
             if (!pending) setDeleteOpen(false);
           }}
-          onSubmit={async (value) => {
+          onSubmit={async () => {
             setPending(true);
             try {
               await onDelete();

--- a/products/dashboard/components/workflows/sidebar-workflow-tree.tsx
+++ b/products/dashboard/components/workflows/sidebar-workflow-tree.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ChevronRight, Pencil, Plus } from "lucide-react";
+import { ChevronRight, Plus } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import type {
@@ -14,73 +14,14 @@ import type {
 
 import { CreateInstanceModal } from "./create-instance-modal";
 
-/**
- * Sidebar workflow tree — one collapsible section per template, with the
- * template's instances listed underneath and a per-template "+ New
- * instance" trigger that opens the create-instance modal scoped to that
- * template.
- *
- * Visual contract: prototype `Sidebar.WorkflowTree` block (`Process
- * Canvas.html` lines 494-538) and the `pt-*` class definitions in the
- * same file (lines 75-103). The shape mirrored here:
- *
- *   pt-header  → arrow · name(flex-1) · count-pill · [pending-dot]
- *   pt-instances (indent 16px)
- *     pt-instance → 5px dot · name(flex-1) · progress-bar(36px)
- *     pt-new     → "+ New instance" (always last)
- *
- * Per the issue acceptance criteria the workflow name uses the template
- * color (the prototype uses `--t2`); every other token follows the
- * prototype literally so the visual matches Process Canvas. Two further
- * deliberate tweaks vs. the prototype:
- *   - the active-instance label is left at `--t2` (prototype paints it
- *     `--accent`); the indigo row background already signals selection
- *     and the colored dot reinforces the template grouping;
- *   - every instance dot stays at the template color regardless of
- *     active/pending state — this matches the collapsed-mode rendering
- *     (one template-colored dot per instance) so the visual language
- *     stays consistent across collapsed/expanded.
- *
- * Pending state: if any task on an instance is in `pending_approval`,
- * the parent template header surfaces a small amber pending dot. The
- * instance dot itself does not change color; the row's amber pip is
- * what calls the user's attention. PR 5 has no live task aggregation,
- * so `hasPending` defaults to `false` and the visual stays inactive
- * until PR 8 wires the task drawer.
- */
-
 export interface SidebarInstanceView extends WorkflowInstance {
   /** True when any task on the instance is `pending_approval`. */
   hasPending?: boolean;
-  /**
-   * Completion ratio in [0, 1]. Optional because we don't have task
-   * counts yet in PR 5; falls back to a status-derived approximation.
-   */
-  progress?: number;
 }
 
 interface Props {
   templates: WorkflowTemplate[];
   instancesByTemplate: Record<string, SidebarInstanceView[]>;
-}
-
-/**
- * Status → progress fallback used when the parent hasn't computed an
- * exact ratio. Intentionally coarse so the bar matches the prototype's
- * "feels right" look for empty instances.
- */
-function fallbackProgress(status: WorkflowInstance["status"]): number {
-  switch (status) {
-    case "complete":
-      return 1;
-    case "active":
-      return 0.4;
-    case "blocked":
-      return 0.25;
-    case "not_started":
-    default:
-      return 0;
-  }
 }
 
 function instanceHref(instanceId: string): string {
@@ -281,95 +222,68 @@ export function SidebarWorkflowTree({ templates, instancesByTemplate }: Props) {
 
           return (
             <section key={template.id} aria-label={`${template.label} workflow`}>
-              <div
-                role="button"
-                tabIndex={0}
-                onClick={() => toggle(template.id)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    toggle(template.id);
-                  }
-                }}
-                aria-expanded={isOpen}
-                aria-controls={`tpl-${template.id}-list`}
-                data-testid={`workflow-template-toggle-${template.id}`}
-                className="group flex cursor-pointer select-none items-center gap-1.5 rounded-md px-2 py-[5px] hover:bg-bg-3 transition-colors"
-              >
-                <span
-                  className={cn(
-                    "flex h-4 w-4 shrink-0 items-center justify-center text-t3 transition-transform duration-150",
-                    isOpen && "rotate-90",
-                  )}
+              <div className="group flex select-none items-center gap-1 rounded-md py-[3px] pl-1 pr-2 hover:bg-bg-3 transition-colors">
+                <button
+                  type="button"
+                  onClick={() => toggle(template.id)}
+                  aria-expanded={isOpen}
+                  aria-controls={`tpl-${template.id}-list`}
+                  aria-label={isOpen ? "Collapse" : "Expand"}
+                  data-testid={`workflow-template-toggle-${template.id}`}
+                  className="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-t3 transition-colors hover:text-t1"
                 >
-                  <ChevronRight className="h-3 w-3" />
-                </span>
-                <span
-                  className="min-w-0 flex-1 truncate text-[12.5px] font-semibold"
-                  // Acceptance-criteria override: the prototype renders
-                  // the workflow name in `--t2`, but the AEL-48 issue
-                  // explicitly requires "workflow name colored with
-                  // template color" so glanceable scanning works.
+                  <span
+                    className={cn(
+                      "flex h-4 w-4 items-center justify-center transition-transform duration-150",
+                      isOpen && "rotate-90",
+                    )}
+                  >
+                    <ChevronRight className="h-3 w-3" />
+                  </span>
+                </button>
+
+                <Link
+                  href={`/workflows/templates/${template.id}/edit`}
+                  data-testid={`workflow-template-link-${template.id}`}
+                  className="min-w-0 flex-1 truncate rounded px-1 py-0.5 text-[13.5px] font-semibold focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
                   style={{ color: template.color }}
                 >
                   {template.label}
-                </span>
-
-                {/* Count pill — number by default, pen icon on hover.
-                    Mirrors prototype's `pt-count-pill`/`pt-count-edit`
-                    pair (lines 86-90). The pen click navigates to the
-                    template-editor stub (PR 11 wires the real route). */}
-                <Link
-                  href={`/workflows/templates/${template.id}/edit`}
-                  onClick={(e) => e.stopPropagation()}
-                  aria-label={`Edit ${template.label} template (${instances.length} ${
-                    instances.length === 1 ? "instance" : "instances"
-                  })`}
-                  data-testid={`workflow-template-count-${template.id}`}
-                  className="ml-1.5 flex h-[18px] min-w-[22px] shrink-0 items-center justify-center rounded-full border border-border bg-bg-4 px-1.5 font-mono text-[9px] font-semibold text-t3 transition-colors group-hover:border-accent group-hover:bg-primary-bg group-hover:text-accent"
-                >
-                  <span className="block group-hover:hidden">
-                    {instances.length}
-                  </span>
-                  <span className="hidden group-hover:block">
-                    <Pencil className="h-2.5 w-2.5" />
-                  </span>
                 </Link>
 
                 {templateHasPending && (
                   <span
                     aria-label="Pending checkpoints"
                     title="Pending checkpoints"
-                    className="ml-[3px] inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                    className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
                     style={{
                       backgroundColor: "var(--pill-pending-d)",
                       boxShadow: "0 0 4px rgba(245,158,11,0.6)",
                     }}
                   />
                 )}
+
+                <button
+                  type="button"
+                  aria-label={`New ${template.label} instance`}
+                  title={`New ${template.label} instance`}
+                  data-testid={`workflow-new-instance-${template.id}`}
+                  onClick={() => setModalTemplate(template)}
+                  className="flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[5px] border border-border text-t3 transition-colors hover:border-accent hover:text-accent"
+                >
+                  <Plus className="h-3 w-3" />
+                </button>
               </div>
 
               {isOpen && (
                 <ul
                   id={`tpl-${template.id}-list`}
-                  className="mb-0.5 space-y-0 pl-4"
+                  className="mb-0.5 space-y-0 pl-5"
                 >
                   {instances.map((instance) => {
                     const href = instanceHref(instance.id);
                     const active = isActive(pathname, href);
-                    // Always template color so the dot reads as "this
-                    // instance belongs to <template>" regardless of
-                    // active/pending — matches the collapsed-mode dots.
                     const dotColor = template.color;
-                    const ratio = Math.max(
-                      0,
-                      Math.min(
-                        1,
-                        typeof instance.progress === "number"
-                          ? instance.progress
-                          : fallbackProgress(instance.status),
-                      ),
-                    );
 
                     return (
                       <li key={instance.id}>
@@ -378,18 +292,29 @@ export function SidebarWorkflowTree({ templates, instancesByTemplate }: Props) {
                           aria-current={active ? "page" : undefined}
                           data-testid={`workflow-instance-link-${instance.id}`}
                           className={cn(
-                            "flex items-center gap-[7px] rounded-md px-2 py-[5px] transition-colors",
+                            "relative flex items-center gap-2 rounded-md px-2 py-[5px] transition-colors",
                             active
-                              ? "bg-primary-bg"
+                              ? "bg-primary-bg text-accent"
                               : "hover:bg-bg-3",
                           )}
                         >
+                          {active && (
+                            <span
+                              aria-hidden
+                              className="absolute left-0 top-1/2 h-[60%] w-[2px] -translate-y-1/2 rounded-r bg-accent"
+                            />
+                          )}
                           <span
                             aria-hidden
-                            className="inline-block h-[5px] w-[5px] shrink-0 rounded-full"
+                            className="inline-block h-[7px] w-[7px] shrink-0 rounded-full"
                             style={{ backgroundColor: dotColor }}
                           />
-                          <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-t2">
+                          <span
+                            className={cn(
+                              "min-w-0 flex-1 truncate text-[12.5px]",
+                              active ? "font-semibold text-accent" : "font-medium text-t2",
+                            )}
+                          >
                             {instance.label}
                           </span>
                           {instance.hasPending && (
@@ -397,46 +322,16 @@ export function SidebarWorkflowTree({ templates, instancesByTemplate }: Props) {
                               aria-label="Pending checkpoints"
                               title="Pending checkpoints"
                               className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
-                              // Same design token as the template-level
-                              // pending dot above, so changing the
-                              // pending hue in `globals.css` updates
-                              // both surfaces in one place.
                               style={{
                                 backgroundColor: "var(--pill-pending-d)",
                                 boxShadow: "0 0 5px var(--pill-pending-d)",
                               }}
                             />
                           )}
-                          <span
-                            aria-hidden
-                            className="block h-[2.5px] w-9 shrink-0 overflow-hidden rounded-[2px] bg-bg-4"
-                          >
-                            <span
-                              className="block h-full rounded-[2px] transition-[width] duration-300"
-                              style={{
-                                width: `${Math.round(ratio * 100)}%`,
-                                backgroundColor: template.color,
-                              }}
-                            />
-                          </span>
                         </Link>
                       </li>
                     );
                   })}
-
-                  <li>
-                    <button
-                      type="button"
-                      onClick={() => setModalTemplate(template)}
-                      data-testid={`workflow-new-instance-${template.id}`}
-                      className="flex w-full items-center gap-1.5 rounded-md px-2 py-[5px] text-left text-[11.5px] font-medium text-t3 transition-colors hover:bg-bg-3 hover:text-accent"
-                    >
-                      <span className="opacity-50">
-                        <Plus className="h-3 w-3" />
-                      </span>
-                      New instance
-                    </button>
-                  </li>
                 </ul>
               )}
             </section>

--- a/products/dashboard/e2e/framework-playbooks.spec.ts
+++ b/products/dashboard/e2e/framework-playbooks.spec.ts
@@ -47,8 +47,7 @@ test.describe("framework playbooks", () => {
     await page.getByRole("button", { name: "Create" }).click();
 
     await expect(page.getByTestId("framework-markdown-preview-playbook")).toBeVisible();
-    await page.getByLabel("Open playbook actions").click();
-    await page.getByRole("button", { name: "Rename" }).click();
+    await page.getByRole("button", { name: "Rename playbook" }).click();
     await expect(page.getByRole("dialog")).toBeVisible();
     await page.getByLabel("Title").fill(renamedPlaybook);
     await page.getByLabel("Description").fill(revisedDescription);
@@ -87,8 +86,7 @@ test.describe("framework playbooks", () => {
       await page.getByRole("button", { name: "Playbooks" }).click({ timeout: 2_000 }).catch(() => {});
       if ((await persistedCard.count()) > 0) {
         await persistedCard.first().click();
-        await page.getByLabel("Open playbook actions").click();
-        await page.getByRole("button", { name: "Delete" }).click();
+        await page.getByRole("button", { name: "Delete playbook" }).click();
         await expect(page.getByRole("dialog")).toContainText(
           "This will permanently remove this playbook. This cannot be undone.",
         );

--- a/products/dashboard/e2e/framework-skills.spec.ts
+++ b/products/dashboard/e2e/framework-skills.spec.ts
@@ -47,8 +47,7 @@ test.describe("framework skills", () => {
     await page.getByRole("button", { name: "Create" }).click();
 
     await expect(page.getByTestId("framework-markdown-preview-skill")).toBeVisible();
-    await page.getByLabel("Open skill actions").click();
-    await page.getByRole("button", { name: "Rename" }).click();
+    await page.getByRole("button", { name: "Rename skill" }).click();
     await expect(page.getByRole("dialog")).toBeVisible();
     await page.getByLabel("Title").fill(renamedSkill);
     await page.getByLabel("Description").fill(revisedDescription);
@@ -76,8 +75,7 @@ test.describe("framework skills", () => {
     await expect(page.getByTestId("framework-grid-skill")).toBeVisible();
 
     await persistedCard.click();
-    await page.getByLabel("Open skill actions").click();
-    await page.getByRole("button", { name: "Delete" }).click();
+    await page.getByRole("button", { name: "Delete skill" }).click();
     await expect(page.getByRole("dialog")).toContainText(
       "This will permanently remove this skill. This cannot be undone.",
     );

--- a/products/dashboard/e2e/workflows.spec.ts
+++ b/products/dashboard/e2e/workflows.spec.ts
@@ -216,7 +216,7 @@ test.describe("workflows — matrix edit mode (AEL-52)", () => {
     await authenticateWithBypass(page);
     await createFreshInstance(page, "E2E Edit Mode");
 
-    await page.getByRole("button", { name: "Edit" }).click();
+    await page.getByRole("button", { name: "Customize" }).click();
     await expect(page).toHaveURL(/edit=1/);
 
     const addTrigger = page.locator('[data-testid^="matrix-add-task-"]').first();

--- a/products/dashboard/e2e/workflows.spec.ts
+++ b/products/dashboard/e2e/workflows.spec.ts
@@ -252,7 +252,7 @@ test.describe("workflows — template editor (AEL-55)", () => {
     await page.goto("/");
 
     const editTemplate = page
-      .locator('[data-testid^="workflow-template-count-"]')
+      .locator('[data-testid^="workflow-template-link-"]')
       .first();
     await expect(editTemplate).toBeVisible();
     await editTemplate.click();

--- a/products/dashboard/lib/toast.tsx
+++ b/products/dashboard/lib/toast.tsx
@@ -16,6 +16,8 @@ export interface ToastItem {
   variant: ToastVariant;
   title: string;
   description?: string;
+  /** Admin-facing technical detail, surfaced behind an expand toggle. */
+  detail?: string;
   visible: boolean;
 }
 
@@ -50,7 +52,7 @@ interface ToastStoreContextValue {
 
 interface ToastActionsContextValue {
   success: (title: string, description?: string) => void;
-  error: (title: string, description?: string) => void;
+  error: (title: string, description?: string, detail?: string) => void;
 }
 
 const ToastStoreContext = createContext<ToastStoreContextValue | null>(null);
@@ -65,9 +67,9 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const add = useCallback(
-    (variant: ToastVariant, title: string, description?: string) => {
+    (variant: ToastVariant, title: string, description?: string, detail?: string) => {
       const id = crypto.randomUUID();
-      dispatch({ type: "add", item: { id, variant, title, description, visible: false } });
+      dispatch({ type: "add", item: { id, variant, title, description, detail, visible: false } });
       // Double rAF ensures the initial opacity-0/translate-y state is
       // painted before we flip visible → true so the CSS transition fires.
       requestAnimationFrame(() => {
@@ -88,7 +90,8 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   );
 
   const error = useCallback(
-    (title: string, description?: string) => add("error", title, description),
+    (title: string, description?: string, detail?: string) =>
+      add("error", title, description, detail),
     [add],
   );
 


### PR DESCRIPTION
## Summary

- Aligns workflow-related loading skeletons with real page layout.
- Polishes toast styling with expandable error details.
- Streamlines workflow sidebar tree and toolbar actions (inline rename/delete, grouped Upload/Download).
- Refines save affordance (icon vs dot) and renames Edit → Customize where shown.

## Validation

- [x] `npm run validate`

## Checklist

- [x] PR targets `staging` (not `main`) — only release-please and staging promotion PRs target `main`
- [x] Schema, examples, and policy stay aligned
- [x] Documentation updated where behavior changed

Made with [Cursor](https://cursor.com)