### PR TITLE
feat(dashboard): process matrix layout modes and task card refresh

### DIFF
--- a/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
@@ -212,6 +212,58 @@ describe("ProcessMatrix", () => {
     expect(screen.getByTestId("matrix-skill-dot-sales-ops")).toBeInTheDocument();
   });
 
+  it("collapses an individual stage column and renders only its pip strip", async () => {
+    const inst = instance([
+      task({ id: "k-1", skillId: "sales-ops", stageId: "pre-sales", status: "active" }),
+      task({ id: "k-2", skillId: "pm", stageId: "pre-sales", status: "complete" }),
+    ]);
+    const user = userEvent.setup();
+
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} />);
+
+    const header = screen.getByTestId("matrix-stage-pre-sales");
+    expect(within(header).getByText("Pre-Sales")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("matrix-stage-toggle-pre-sales"));
+
+    expect(header).toHaveAttribute("data-collapsed", "true");
+    // The stage name no longer appears inline in the collapsed header — it
+    // surfaces only in the hover-portaled tooltip outside this subtree.
+    expect(within(header).queryByText("Pre-Sales")).not.toBeInTheDocument();
+    // Pips remain visible to convey task density even when collapsed.
+    expect(within(header).getAllByTestId(/^matrix-pip-/)).toHaveLength(2);
+    // Body cells in the collapsed column are narrowed and become mini cells.
+    const cell = screen.getByTestId("matrix-cell-sales-ops-pre-sales");
+    expect(cell).toHaveAttribute("data-stage-collapsed", "true");
+    expect(cell).toHaveAttribute("data-mini", "true");
+    expect(within(cell).getByTestId("task-mini-k-1")).toBeInTheDocument();
+  });
+
+  it("collapses an individual skill row and renders mini cells across the row", async () => {
+    const inst = instance([
+      task({ id: "k-1", skillId: "sales-ops", stageId: "pre-sales", status: "active" }),
+      task({ id: "k-2", skillId: "sales-ops", stageId: "validation", status: "complete" }),
+      task({ id: "k-3", skillId: "pm", stageId: "pre-sales", status: "not_started" }),
+    ]);
+    const user = userEvent.setup();
+
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} />);
+
+    expect(screen.getByTestId("matrix-skill-label-sales-ops")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("matrix-skill-toggle-sales-ops"));
+
+    const row = screen.getByTestId("matrix-skill-row-sales-ops");
+    expect(row).toHaveAttribute("data-collapsed", "true");
+    expect(
+      screen.queryByTestId("matrix-skill-label-sales-ops"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("task-mini-k-1")).toBeInTheDocument();
+    expect(screen.getByTestId("task-mini-k-2")).toBeInTheDocument();
+    // Other rows remain expanded.
+    expect(screen.getByTestId("task-card-k-3")).toBeInTheDocument();
+  });
+
   it("renders the placeholder when the template is missing", () => {
     const inst = instance([]);
     renderWithTopBarProvider(<ProcessMatrix instance={inst} template={null} />);

--- a/products/dashboard/__tests__/components/workflows/task-card.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/task-card.test.tsx
@@ -91,6 +91,38 @@ describe("TaskCard", () => {
     expect(card.style.getPropertyValue("--role-color")).toBe("#10b981");
   });
 
+  it("renders the playbook avatar with the playbook's own colour", () => {
+    render(
+      <TaskCard
+        task={task({ id: "with-avatar" })}
+        playbook={{ ...PLAYBOOK, color: "#a855f7" }}
+        skillColor="#10b981"
+        barState="bar-active"
+      />,
+    );
+
+    const avatar = screen.getByTestId("task-card-avatar-with-avatar");
+    expect(avatar).toBeInTheDocument();
+    // The ItemAvatar inside renders the emoji.
+    expect(within(avatar).getByText("📄")).toBeInTheDocument();
+  });
+
+  it("overlays the checkpoint badge on the avatar (not in the title row)", () => {
+    render(
+      <TaskCard
+        task={task({ id: "cp-overlay", checkpoint: true })}
+        playbook={PLAYBOOK}
+        skillColor="#6366f1"
+        barState="bar-pending"
+      />,
+    );
+
+    const badge = screen.getByTestId("task-checkpoint-cp-overlay");
+    const avatarWrap = screen.getByTestId("task-card-avatar-cp-overlay");
+    expect(avatarWrap).toContainElement(badge);
+    expect(badge.className).toContain("tc-cp-badge-overlay");
+  });
+
   it("renders the checkpoint pip only when the task has checkpoint: true", () => {
     const { rerender } = render(
       <TaskCard

--- a/products/dashboard/app/styles/components/process-matrix.css
+++ b/products/dashboard/app/styles/components/process-matrix.css
@@ -19,7 +19,15 @@
 }
 .matrix {
   display: inline-block;
+  width: max-content;
   min-width: 100%;
+  border-bottom: 1px solid var(--border);
+}
+/* Right edge: draw on the last column header + last body cell so the
+ * border hugs the actual content width, not the scroll container width. */
+.matrix-head-row .mx-stage-hd:last-child,
+.mx-body-row .mx-task-cell:last-child {
+  border-right: 1px solid var(--border);
 }
 .matrix-head-row {
   display: flex;
@@ -29,6 +37,10 @@
   background: var(--matrix-head);
   backdrop-filter: blur(8px);
   border-bottom: 1px solid var(--border-hi);
+  /* Lock to the expanded-header height so the body never reflows when
+   * stage columns are collapsed (their content shrinks to just a chevron
+   * plus a stacked pip strip). */
+  min-height: 72px;
 }
 .mx-corner {
   width: 196px;
@@ -52,29 +64,77 @@
   transition: width 0.2s;
 }
 .matrix-wrap.roles-collapsed .mx-corner {
-  width: 44px;
+  width: 64px;
 }
+/* Skills-label collapse toggle — same hover-revealed top-right placement
+ * as the per-stage column chevron, so the affordance reads identically. */
 .mx-corner-toggle {
+  position: absolute;
+  top: 6px;
+  right: 6px;
   width: 18px;
   height: 18px;
   border-radius: 4px;
   border: 1px solid var(--border);
-  background: none;
+  background: var(--bg-2);
   color: var(--t3);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.14s;
-  flex-shrink: 0;
-  margin-left: auto;
   padding: 0;
+  opacity: 0;
+  z-index: 6;
+  transition:
+    opacity 0.14s,
+    background 0.14s,
+    color 0.14s,
+    border-color 0.14s;
+}
+.mx-corner:hover .mx-corner-toggle,
+.mx-corner-toggle:focus-visible,
+.matrix-wrap.roles-collapsed .mx-corner-toggle {
+  opacity: 1;
 }
 .mx-corner-toggle:hover {
   background: var(--bg-3);
   color: var(--t1);
+  border-color: var(--border-hi);
 }
 .mx-corner-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+/* Collapse-all sits at the top-LEFT of the corner, mirroring the per-row
+ * and per-column chevrons but with the more emphatic minimize/maximize
+ * glyph so it reads as a global affordance. */
+.mx-corner-collapse-all {
+  position: absolute;
+  bottom: 6px;
+  right: 6px;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  color: var(--t3);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  z-index: 6;
+  transition:
+    background 0.14s,
+    color 0.14s,
+    border-color 0.14s;
+}
+.mx-corner-collapse-all:hover {
+  background: var(--bg-3);
+  color: var(--t1);
+  border-color: var(--border-hi);
+}
+.mx-corner-collapse-all:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
@@ -432,8 +492,8 @@
   align-items: center;
   gap: 7px;
   /* Locked height keeps the row stable while task cards are dragged in/out.
-   * Card height = 108px + cell padding (14px*2) + breathing → 124px. */
-  height: 124px;
+   * Card height = 124px + cell padding (14px*2) + breathing → 140px. */
+  height: 140px;
   overflow: visible;
   transition: width 0.2s;
 }
@@ -453,9 +513,10 @@
   align-items: center;
 }
 .matrix-wrap.roles-collapsed .mx-role-cell {
-  width: 44px;
-  padding: 10px 7px;
+  width: 64px;
+  padding: 10px 6px;
   justify-content: center;
+  gap: 4px;
 }
 .mx-role-name {
   font-size: 12.5px;
@@ -553,9 +614,9 @@
   padding: 7px;
   border-right: 1px solid var(--border-2);
   /* Locked height matches `.mx-role-cell` so the row stays a stable
-   * rectangle while task cards drag in/out (cards themselves are 108px
-   * fixed height; cell padding 7×2 = 14, plus 2px breathing → 124px). */
-  height: 124px;
+   * rectangle while task cards drag in/out (cards themselves are 124px
+   * fixed height; cell padding 7×2 = 14, plus 2px breathing → 140px). */
+  height: 140px;
   background: var(--bg);
   transition: background 0.14s;
 }
@@ -882,4 +943,207 @@
 .mx-row-insert-empty:focus-visible .mx-row-insert-label {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+/* ── Per-stage column collapse + per-skill row collapse ──
+ *
+ * Both follow the same pattern as the existing global `.roles-collapsed`
+ * (skills-label) toggle: a small chevron button reveals on hover, and the
+ * collapsed unit shrinks to a slim band whose only content is a stack of
+ * pips (column header) or the skill avatar (row header). Cells that fall
+ * inside a collapsed column or row render as `mx-mini-cell-btn` — just the
+ * playbook avatar with its built-in tooltip. */
+
+.mx-stage-collapse-btn,
+.mx-skill-collapse-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  color: var(--t3);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  opacity: 0;
+  transition:
+    opacity 0.14s,
+    background 0.14s,
+    color 0.14s,
+    border-color 0.14s;
+  z-index: 6;
+}
+.mx-stage-hd:hover .mx-stage-collapse-btn,
+.mx-stage-collapse-btn:focus-visible,
+.mx-role-cell:hover .mx-skill-collapse-btn,
+.mx-skill-collapse-btn:focus-visible {
+  opacity: 1;
+}
+.mx-stage-collapse-btn:hover,
+.mx-skill-collapse-btn:hover {
+  background: var(--bg-3);
+  color: var(--t1);
+  border-color: var(--border-hi);
+}
+.mx-stage-collapse-btn:focus-visible,
+.mx-skill-collapse-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.mx-stage-hd-collapsed {
+  width: 36px;
+  padding: 8px 4px 8px 4px;
+  cursor: pointer;
+}
+.mx-stage-hd-collapsed .mx-stage-pips {
+  flex-direction: column;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 3px;
+  margin-top: 22px;
+}
+.mx-stage-hd-collapsed .mx-pip {
+  width: 14px;
+  height: 2.5px;
+}
+.mx-stage-hd-collapsed .mx-stage-collapse-btn {
+  opacity: 1;
+  top: 6px;
+  right: 50%;
+  transform: translateX(50%);
+}
+/* Popover that shows the stage name + sub when hovering a collapsed
+ * column header. Mirrors the ItemAvatar tooltip pattern (rounded card,
+ * border-hi, bg-2) so the design language stays consistent. */
+/* Portal-rendered floating tooltip — sits at fixed coordinates derived
+ * from the anchor element's bounding rect so it can paint outside the
+ * matrix scroll wrap (`overflow: auto`) without being clipped. Two
+ * placements share the card style; only the translate origin differs. */
+.mx-floating-tooltip {
+  pointer-events: none;
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  white-space: nowrap;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border-hi);
+  background: var(--bg-2);
+  box-shadow: var(--shadow-canvas);
+  z-index: 100;
+}
+.mx-floating-tooltip-above {
+  transform: translate(-50%, -100%);
+}
+.mx-floating-tooltip-right {
+  transform: translate(0, -50%);
+}
+.mx-floating-tooltip-name {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--t1);
+  line-height: 1.2;
+}
+.mx-floating-tooltip-sub {
+  font-size: 10.5px;
+  color: var(--t3);
+  line-height: 1.2;
+}
+.mx-floating-tooltip-sub.s-complete {
+  color: var(--pill-complete-t);
+}
+.mx-floating-tooltip-sub.s-active {
+  color: var(--pill-active-t);
+}
+.mx-floating-tooltip-sub.s-pending {
+  color: var(--pill-pending-t);
+}
+.mx-floating-tooltip-sub.s-blocked {
+  color: var(--pill-blocked-t);
+}
+.mx-floating-tooltip-sub.s-not_started {
+  color: var(--pill-ns-t);
+}
+.mx-skill-avatar-anchor {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+/* Always-visible chevron when collapsed (the header itself is the click
+ * target — but the chevron is the visual cue). */
+
+.mx-body-row-collapsed .mx-task-cell,
+.mx-body-row-collapsed .mx-role-cell {
+  height: 36px;
+}
+.mx-body-row-collapsed .mx-role-cell {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  padding-right: 6px;
+}
+.mx-body-row-collapsed .mx-role-name,
+.mx-body-row-collapsed .mx-role-owner {
+  display: none;
+}
+
+/* When the Skill column is collapsed (either globally via `.roles-collapsed`
+ * or per-row via `.mx-body-row-collapsed`), the row chevron switches from
+ * hover-revealed top-right chip to a static inline button sitting to the
+ * right of the avatar. This keeps the toggle reachable — otherwise a
+ * collapsed row inside a roles-collapsed matrix would hide its only
+ * affordance to expand back. */
+.matrix-wrap.roles-collapsed .mx-skill-collapse-btn,
+.mx-body-row-collapsed .mx-skill-collapse-btn {
+  position: static;
+  opacity: 1;
+  margin-left: auto;
+}
+
+/* Mini cell — used when the cell sits in a collapsed row OR collapsed
+ * column. The cell width comes from the column header rule above when the
+ * stage is collapsed; the height is inherited so a column-only collapse
+ * inside an expanded (140px) row keeps the cell tall and the avatar
+ * floats vertically centered. */
+.mx-task-cell-mini {
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+/* Column-collapsed body cells: shrink to match the 36px header width.
+ * `.mx-task-cell-narrow` is stamped from React on every body cell whose
+ * stage column is collapsed. Cells in non-collapsed columns keep their
+ * normal 192px width even when the row is row-collapsed (mini display
+ * doesn't imply narrow column). */
+.mx-task-cell-narrow {
+  width: 36px;
+  padding: 4px 2px;
+}
+
+.mx-mini-cell-btn {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  position: relative;
+}
+.mx-mini-cell-btn:hover {
+  background: var(--bg-2);
+}
+.mx-mini-cell-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }

--- a/products/dashboard/app/styles/components/task-card.css
+++ b/products/dashboard/app/styles/components/task-card.css
@@ -4,8 +4,8 @@
  * description use line-clamp:2 with ellipsis. */
 .task-card {
   width: 100%;
-  height: 108px;
-  padding: 9px 10px;
+  height: 124px;
+  padding: 9px 10px 9px 14px;
   border-radius: 7px;
   border: 1px solid var(--border);
   background: var(--bg-2);
@@ -89,8 +89,22 @@
 }
 .tc-top {
   display: flex;
-  align-items: flex-start;
-  gap: 5px;
+  align-items: center;
+  gap: 8px;
+}
+.tc-avatar-wrap {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  line-height: 0;
+}
+.tc-cp-badge-overlay {
+  position: absolute;
+  bottom: -2px;
+  right: -2px;
+  width: 12px;
+  height: 12px;
+  box-shadow: 0 0 0 2px var(--bg-2);
 }
 .tc-title {
   font-size: 11.5px;

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useId, useMemo, useState, useTransition } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState, useTransition } from "react";
+import { createPortal } from "react-dom";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { ChevronsLeftRight, Plus } from "lucide-react";
+import {
+  ChevronsLeftRight,
+  ChevronsRightLeft,
+  Maximize2,
+  Minimize2,
+  Plus,
+} from "lucide-react";
 import {
   DndContext,
   KeyboardSensor,
@@ -43,7 +50,7 @@ import { useToast } from "@/lib/toast";
 import { useUnsavedChangesGuard } from "@/lib/use-unsaved-changes-guard";
 import { cn } from "@/lib/utils";
 import { barClass, canStart } from "@/lib/workflows/matrix";
-import { resolveSkillColor } from "@/lib/workflows/skill-colors";
+import { resolveItemColor, resolveSkillColor } from "@/lib/workflows/skill-colors";
 import { ItemAvatar } from "@/components/framework/item-avatar";
 import type {
   FrameworkItem,
@@ -78,6 +85,54 @@ export function ProcessMatrix({
   const { setConfig } = useDashboardTopBar();
   const { success: toastSuccess, error: toastError } = useToast();
   const [collapsed, setCollapsed] = useState(false);
+  const [collapsedStageIds, setCollapsedStageIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [collapsedSkillIds, setCollapsedSkillIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const toggleStageCollapsed = useCallback((stageId: string) => {
+    setCollapsedStageIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(stageId)) next.delete(stageId);
+      else next.add(stageId);
+      return next;
+    });
+  }, []);
+
+  const toggleSkillCollapsed = useCallback((skillId: string) => {
+    setCollapsedSkillIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(skillId)) next.delete(skillId);
+      else next.add(skillId);
+      return next;
+    });
+  }, []);
+
+  const stages: WorkflowStage[] = template?.stages ?? [];
+  const skills: WorkflowSkill[] =
+    instance.skills && instance.skills.length > 0
+      ? instance.skills
+      : template?.skills ?? [];
+  const allCollapsed =
+    collapsed &&
+    stages.length > 0 &&
+    skills.length > 0 &&
+    stages.every((s) => collapsedStageIds.has(s.id)) &&
+    skills.every((s) => collapsedSkillIds.has(s.id));
+
+  const toggleCollapseAll = useCallback(() => {
+    if (allCollapsed) {
+      setCollapsed(false);
+      setCollapsedStageIds(new Set());
+      setCollapsedSkillIds(new Set());
+    } else {
+      setCollapsed(true);
+      setCollapsedStageIds(new Set(stages.map((s) => s.id)));
+      setCollapsedSkillIds(new Set(skills.map((s) => s.id)));
+    }
+  }, [allCollapsed, stages, skills]);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [dragTaskId, setDragTaskId] = useState<string | null>(null);
   const [addTaskFor, setAddTaskFor] = useState<{
@@ -166,12 +221,6 @@ export function ProcessMatrix({
     setLastSavedTasks(lastSavedTasks);
     proceed();
   }, [lastSavedTasks, pendingNavigation]);
-
-  const stages: WorkflowStage[] = template?.stages ?? [];
-  const skills: WorkflowSkill[] =
-    instance.skills && instance.skills.length > 0
-      ? instance.skills
-      : template?.skills ?? [];
 
   const tasksByCell = useMemo(() => {
     const map = new Map<string, WorkflowTask>();
@@ -423,6 +472,32 @@ export function ProcessMatrix({
         <div className="matrix" role="table" aria-label="Workflow process matrix">
           <div className="matrix-head-row" role="row">
             <div className="mx-corner" role="columnheader">
+              <button
+                type="button"
+                data-testid="matrix-collapse-all"
+                aria-pressed={allCollapsed}
+                aria-label={
+                  allCollapsed
+                    ? "Expand all rows and columns"
+                    : "Collapse all rows and columns"
+                }
+                title={
+                  allCollapsed
+                    ? "Expand all rows and columns"
+                    : "Collapse all rows and columns"
+                }
+                onClick={(event) => {
+                  event.currentTarget.blur();
+                  toggleCollapseAll();
+                }}
+                className="mx-corner-collapse-all"
+              >
+                {allCollapsed ? (
+                  <Maximize2 aria-hidden size={11} />
+                ) : (
+                  <Minimize2 aria-hidden size={11} />
+                )}
+              </button>
               {!collapsed && <span className="flex-1">Skills</span>}
               <button
                 type="button"
@@ -430,27 +505,55 @@ export function ProcessMatrix({
                 aria-pressed={collapsed}
                 aria-label={collapsed ? "Expand skill labels" : "Collapse skill labels"}
                 title={collapsed ? "Expand skill labels" : "Collapse skill labels"}
-                onClick={() => setCollapsed((value) => !value)}
+                onClick={(event) => {
+                  event.currentTarget.blur();
+                  setCollapsed((value) => !value);
+                }}
                 className="mx-corner-toggle"
-                style={collapsed ? { marginLeft: 0 } : undefined}
               >
-                <ChevronsLeftRight aria-hidden size={11} />
+                {collapsed ? (
+                  <ChevronsLeftRight aria-hidden size={11} />
+                ) : (
+                  <ChevronsRightLeft aria-hidden size={11} />
+                )}
               </button>
             </div>
 
             {stages.map((stage) => {
               const stageTasks = tasksByStage.get(stage.id) ?? [];
+              const isStageCollapsed = collapsedStageIds.has(stage.id);
               return (
                 <div
                   key={stage.id}
                   role="columnheader"
-                  className="mx-stage-hd"
+                  className={cn(
+                    "mx-stage-hd",
+                    isStageCollapsed && "mx-stage-hd-collapsed",
+                  )}
                   data-testid={`matrix-stage-${stage.id}`}
+                  data-collapsed={isStageCollapsed ? "true" : undefined}
+                  aria-label={isStageCollapsed ? stage.label : undefined}
+                  onClick={
+                    isStageCollapsed
+                      ? () => toggleStageCollapsed(stage.id)
+                      : undefined
+                  }
                 >
-                  <div className="mx-stage-name">{stage.label}</div>
-                  <div className={cn("mx-stage-sub", stage.sub?.trim() && "mx-stage-sub-plain")}>
-                    {stage.sub?.trim() || "No description"}
-                  </div>
+                  {!isStageCollapsed && (
+                    <>
+                      <div className="mx-stage-name">{stage.label}</div>
+                      <div className={cn("mx-stage-sub", stage.sub?.trim() && "mx-stage-sub-plain")}>
+                        {stage.sub?.trim() || "No description"}
+                      </div>
+                    </>
+                  )}
+                  {isStageCollapsed ? (
+                    <FloatingHoverTooltip
+                      name={stage.label}
+                      sub={stage.sub?.trim() ?? ""}
+                      placement="above"
+                    />
+                  ) : null}
                   {stageTasks.length > 0 ? (
                     <div className="mx-stage-pips" aria-hidden>
                       {stageTasks.map((task) => {
@@ -472,6 +575,33 @@ export function ProcessMatrix({
                       })}
                     </div>
                   ) : null}
+                  <button
+                    type="button"
+                    className="mx-stage-collapse-btn"
+                    data-testid={`matrix-stage-toggle-${stage.id}`}
+                    aria-pressed={isStageCollapsed}
+                    aria-label={
+                      isStageCollapsed
+                        ? `Expand ${stage.label}`
+                        : `Collapse ${stage.label}`
+                    }
+                    title={
+                      isStageCollapsed
+                        ? `Expand ${stage.label}`
+                        : `Collapse ${stage.label}`
+                    }
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      event.currentTarget.blur();
+                      toggleStageCollapsed(stage.id);
+                    }}
+                  >
+                    {isStageCollapsed ? (
+                      <ChevronsLeftRight aria-hidden size={11} />
+                    ) : (
+                      <ChevronsRightLeft aria-hidden size={11} />
+                    )}
+                  </button>
                 </div>
               );
             })}
@@ -495,25 +625,47 @@ export function ProcessMatrix({
               const frameworkSkill = skillOptions.find(
                 (item) => item.id === skill.id,
               );
+              const isSkillCollapsed = collapsedSkillIds.has(skill.id);
+              const labelHidden = collapsed || isSkillCollapsed;
               return (
                 <div
                   key={skill.id}
                   role="row"
-                  className="mx-body-row"
+                  className={cn(
+                    "mx-body-row",
+                    isSkillCollapsed && "mx-body-row-collapsed",
+                  )}
                   data-testid={`matrix-skill-row-${skill.id}`}
+                  data-collapsed={isSkillCollapsed ? "true" : undefined}
                 >
-                  <div className="mx-role-cell" role="rowheader">
-                    <span data-testid={`matrix-skill-dot-${skill.id}`}>
+                  <div
+                    className="mx-role-cell"
+                    role="rowheader"
+                    title={isSkillCollapsed ? skill.label : undefined}
+                  >
+                    <span
+                      data-testid={`matrix-skill-dot-${skill.id}`}
+                      className="mx-skill-avatar-anchor"
+                    >
                       <ItemAvatar
                         emoji={frameworkSkill?.icon ?? "•"}
                         color={skillColor}
                         label={skill.label}
-                        size={collapsed ? "xs" : "sm"}
-                        withTooltip={collapsed}
-                        tooltipPlacement="right"
+                        size={labelHidden ? "xs" : "sm"}
                       />
+                      {labelHidden ? (
+                        <FloatingHoverTooltip
+                          name={skill.label}
+                          sub={
+                            skill.owners.length > 0
+                              ? skill.owners.join(", ")
+                              : "No owner"
+                          }
+                          placement="right"
+                        />
+                      ) : null}
                     </span>
-                    {!collapsed ? (
+                    {!labelHidden ? (
                       <div
                         className="min-w-0 flex-1"
                         data-testid={`matrix-skill-label-${skill.id}`}
@@ -531,11 +683,50 @@ export function ProcessMatrix({
                         </div>
                       </div>
                     ) : null}
+                    {(
+                      <button
+                        type="button"
+                        className="mx-skill-collapse-btn"
+                        data-testid={`matrix-skill-toggle-${skill.id}`}
+                        aria-pressed={isSkillCollapsed}
+                        aria-label={
+                          isSkillCollapsed
+                            ? `Expand ${skill.label}`
+                            : `Collapse ${skill.label}`
+                        }
+                        title={
+                          isSkillCollapsed
+                            ? `Expand ${skill.label}`
+                            : `Collapse ${skill.label}`
+                        }
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          event.currentTarget.blur();
+                          toggleSkillCollapsed(skill.id);
+                        }}
+                      >
+                        {isSkillCollapsed ? (
+                          <ChevronsLeftRight
+                            aria-hidden
+                            size={11}
+                            style={{ transform: "rotate(90deg)" }}
+                          />
+                        ) : (
+                          <ChevronsRightLeft
+                            aria-hidden
+                            size={11}
+                            style={{ transform: "rotate(90deg)" }}
+                          />
+                        )}
+                      </button>
+                    )}
                   </div>
 
                   {stages.map((stage) => {
                     const task = tasksByCell.get(`${skill.id}::${stage.id}`);
                     const playbook = task?.playbookId ? playbookById.get(task.playbookId) ?? null : null;
+                    const isStageCollapsed = collapsedStageIds.has(stage.id);
+                    const isMini = isStageCollapsed || isSkillCollapsed;
 
                     return (
                       <DroppableTaskCell
@@ -543,49 +734,60 @@ export function ProcessMatrix({
                         skillId={skill.id}
                         stageId={stage.id}
                         hasTask={Boolean(task)}
-                        editMode={editMode}
+                        editMode={editMode && !isMini}
                         dragActive={Boolean(dragTaskId)}
                         dropAllowed={
                           dragAllowedSkillIds === null ||
                           dragAllowedSkillIds.has(skill.id)
                         }
+                        mini={isMini}
+                        stageCollapsed={isStageCollapsed}
                       >
                         {task ? (
-                          <DraggableTaskCard
-                            taskId={task.id}
-                            disabled={!editMode}
-                            isActive={dragTaskId === task.id}
-                          >
-                            <TaskCard
+                          isMini ? (
+                            <MiniTaskCell
                               task={task}
                               playbook={playbook}
                               skillColor={skillColor}
-                              barState={barClass(task, canStart(task, localTasks))}
-                              editMode={editMode}
                               onClick={() => setSelectedTaskId(task.id)}
-                              onEdit={
-                                editMode
-                                  ? () =>
-                                      setAddTaskFor({
-                                        mode: "edit",
-                                        taskId: task.id,
-                                        skillId: skill.id,
-                                        skillLabel: skill.label,
-                                        stageId: stage.id,
-                                        stageName: stage.label,
-                                        initial: {
-                                          playbookId: task.playbookId ?? null,
-                                          notes: task.notes ?? "",
-                                        },
-                                      })
-                                  : undefined
-                              }
-                              onRemove={
-                                editMode ? () => setConfirmDeleteTask(task) : undefined
-                              }
                             />
-                          </DraggableTaskCard>
-                        ) : editMode ? (
+                          ) : (
+                            <DraggableTaskCard
+                              taskId={task.id}
+                              disabled={!editMode}
+                              isActive={dragTaskId === task.id}
+                            >
+                              <TaskCard
+                                task={task}
+                                playbook={playbook}
+                                skillColor={skillColor}
+                                barState={barClass(task, canStart(task, localTasks))}
+                                editMode={editMode}
+                                onClick={() => setSelectedTaskId(task.id)}
+                                onEdit={
+                                  editMode
+                                    ? () =>
+                                        setAddTaskFor({
+                                          mode: "edit",
+                                          taskId: task.id,
+                                          skillId: skill.id,
+                                          skillLabel: skill.label,
+                                          stageId: stage.id,
+                                          stageName: stage.label,
+                                          initial: {
+                                            playbookId: task.playbookId ?? null,
+                                            notes: task.notes ?? "",
+                                          },
+                                        })
+                                    : undefined
+                                }
+                                onRemove={
+                                  editMode ? () => setConfirmDeleteTask(task) : undefined
+                                }
+                              />
+                            </DraggableTaskCard>
+                          )
+                        ) : editMode && !isMini ? (
                           <div
                             className="mx-empty-cell"
                             onClick={() =>
@@ -768,6 +970,8 @@ function DroppableTaskCell({
   editMode,
   dragActive,
   dropAllowed,
+  mini = false,
+  stageCollapsed = false,
   children,
 }: {
   skillId: string;
@@ -776,6 +980,8 @@ function DroppableTaskCell({
   editMode: boolean;
   dragActive: boolean;
   dropAllowed: boolean;
+  mini?: boolean;
+  stageCollapsed?: boolean;
   children: React.ReactNode;
 }) {
   const { setNodeRef, isOver } = useDroppable({
@@ -788,8 +994,12 @@ function DroppableTaskCell({
       ref={setNodeRef}
       role="cell"
       data-testid={`matrix-cell-${skillId}-${stageId}`}
+      data-mini={mini ? "true" : undefined}
+      data-stage-collapsed={stageCollapsed ? "true" : undefined}
       className={cn(
         "mx-task-cell",
+        mini && "mx-task-cell-mini",
+        stageCollapsed && "mx-task-cell-narrow",
         hasTask && "has-task",
         editMode && dragActive && !hasTask && dropAllowed && isOver && "drag-over-cell",
         editMode && dragActive && !hasTask && !dropAllowed && "drag-disallowed-cell",
@@ -797,5 +1007,145 @@ function DroppableTaskCell({
     >
       {children}
     </div>
+  );
+}
+
+function MiniTaskCell({
+  task,
+  playbook,
+  skillColor,
+  onClick,
+}: {
+  task: WorkflowTask;
+  playbook: FrameworkItem | null;
+  skillColor: string;
+  onClick?: () => void;
+}) {
+  const title = playbook?.name ?? (task.playbookId ? "Playbook removed" : "No playbook");
+  const playbookColor = playbook ? resolveItemColor(playbook) : skillColor;
+  const opacity =
+    task.status === "not_started"
+      ? 0.35
+      : task.status === "complete"
+        ? 0.55
+        : 1;
+  const statusLabel =
+    task.status === "active"
+      ? "In progress"
+      : task.status === "pending_approval"
+        ? "Pending approval"
+        : task.status === "blocked"
+          ? "Failed"
+          : task.status === "complete"
+            ? "Complete"
+            : "Not started";
+  const statusClass =
+    task.status === "active"
+      ? "s-active"
+      : task.status === "pending_approval"
+        ? "s-pending"
+        : task.status === "blocked"
+          ? "s-blocked"
+          : task.status === "complete"
+            ? "s-complete"
+            : "s-not_started";
+  return (
+    <button
+      type="button"
+      className="mx-mini-cell-btn"
+      data-testid={`task-mini-${task.id}`}
+      data-status={task.status}
+      onClick={onClick}
+      aria-label={`Open playbook: ${title} (${statusLabel})`}
+      style={{ opacity, "--role-color": skillColor } as React.CSSProperties}
+    >
+      <ItemAvatar
+        emoji={playbook?.icon ?? null}
+        color={playbookColor}
+        label={title}
+        size="xs"
+      />
+      <FloatingHoverTooltip
+        name={title}
+        sub={statusLabel}
+        placement="above"
+        subStatusClass={statusClass}
+      />
+    </button>
+  );
+}
+
+/**
+ * Hover tooltip portaled to `document.body` so it can paint above the
+ * matrix scroll wrap (`overflow: auto`) without being clipped. Anchors to
+ * its parent element via `getBoundingClientRect`. Two placements: `above`
+ * (used by collapsed stage column headers) and `right` (used by collapsed
+ * skill row avatars).
+ */
+function FloatingHoverTooltip({
+  name,
+  sub,
+  placement,
+  subStatusClass,
+}: {
+  name: string;
+  sub: string;
+  placement: "above" | "right";
+  /** Optional status pill class (`s-active`, `s-complete`, …). When set,
+   *  the subtitle inherits the matching status text colour. */
+  subStatusClass?: string;
+}) {
+  const anchorRef = useRef<HTMLSpanElement | null>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  useEffect(() => {
+    const anchor = anchorRef.current?.parentElement;
+    if (!anchor) return;
+    const show = () => {
+      const rect = anchor.getBoundingClientRect();
+      if (placement === "above") {
+        setPos({ top: rect.top, left: rect.left + rect.width / 2 });
+      } else {
+        setPos({ top: rect.top + rect.height / 2, left: rect.right });
+      }
+    };
+    const hide = () => setPos(null);
+    anchor.addEventListener("mouseenter", show);
+    anchor.addEventListener("mouseleave", hide);
+    return () => {
+      anchor.removeEventListener("mouseenter", show);
+      anchor.removeEventListener("mouseleave", hide);
+    };
+  }, [placement]);
+
+  return (
+    <>
+      <span ref={anchorRef} aria-hidden style={{ display: "none" }} />
+      {pos && typeof document !== "undefined"
+        ? createPortal(
+            <span
+              role="tooltip"
+              className={cn(
+                "mx-floating-tooltip",
+                placement === "above"
+                  ? "mx-floating-tooltip-above"
+                  : "mx-floating-tooltip-right",
+              )}
+              style={{
+                top: placement === "above" ? pos.top - 6 : pos.top,
+                left: placement === "above" ? pos.left : pos.left + 8,
+              }}
+            >
+              <span className="mx-floating-tooltip-name">{name}</span>
+              {sub ? (
+                <span className={cn("mx-floating-tooltip-sub", subStatusClass)}>
+                  {sub}
+                </span>
+              ) : null}
+            </span>,
+            document.body,
+          )
+        : null}
+    </>
   );
 }

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -1,7 +1,9 @@
 import { AlertTriangle, Pencil, Trash2 } from "lucide-react";
 
+import { ItemAvatar } from "@/components/framework/item-avatar";
 import { cn } from "@/lib/utils";
 import type { TaskBarState } from "@/lib/workflows/matrix";
+import { resolveItemColor } from "@/lib/workflows/skill-colors";
 import type { FrameworkItem, WorkflowTask } from "@/lib/workflows/types";
 
 const STATUS_LABEL: Record<WorkflowTask["status"], string> = {
@@ -56,6 +58,8 @@ export function TaskCard({
 
   const title = playbook?.name ?? (task.playbookId ? "Playbook removed" : "No playbook");
   const description = playbook?.description ?? task.notes ?? "";
+  const playbookColor = playbook ? resolveItemColor(playbook) : skillColor;
+  const playbookEmoji = playbook?.icon ?? null;
 
   return (
     <div
@@ -86,24 +90,29 @@ export function TaskCard({
       aria-label={onClick ? `Open playbook: ${title}` : undefined}
     >
       <div className="tc-top">
+        <span className="tc-avatar-wrap" data-testid={`task-card-avatar-${task.id}`}>
+          <ItemAvatar
+            emoji={playbookEmoji}
+            color={playbookColor}
+            label={title}
+            size="sm"
+          />
+          {task.checkpoint && (
+            <span
+              className="tc-cp-badge tc-cp-badge-overlay"
+              data-testid={`task-checkpoint-${task.id}`}
+              aria-label="Checkpoint required"
+              title="Checkpoint required"
+            >
+              <AlertTriangle aria-hidden size={9} strokeWidth={2.5} color="white" />
+            </span>
+          )}
+        </span>
         <div className="tc-title">{title}</div>
-        {task.checkpoint && (
-          <div
-            className="tc-cp-badge"
-            data-testid={`task-checkpoint-${task.id}`}
-            aria-label="Checkpoint required"
-            title="Checkpoint required"
-          >
-            <AlertTriangle aria-hidden size={9} strokeWidth={2.5} color="white" />
-          </div>
-        )}
       </div>
       {description ? <div className="tc-desc">{description}</div> : null}
       <div className="tc-footer">
         {hideStatusPill ? (
-          // Templates render no status pill — there's no runtime state to
-          // surface yet. We still render an empty span so the footer keeps
-          // its `space-between` layout for the action buttons.
           <span aria-hidden />
         ) : (
           <div className={cn("s-pill", statusClass)}>


### PR DESCRIPTION
## Summary

- Workflow **process matrix**: layout expand/minimize-style controls, refined cell chrome and drag/drop UX, and related CSS.
- **Task card** styling aligned with the matrix refresh; tests extended for matrix and task card behavior.

## Validation

- [x] `npm run validate`

## Checklist

- [x] PR targets `staging` (not `main`) — only release-please and staging promotion PRs target `main`
- [x] Schema, examples, and policy stay aligned
- [x] Documentation updated where behavior changed

Made with [Cursor](https://cursor.com)