### PR TITLE
feat(dashboard): outputs schema + 7-state status enum (AEL-60)

### DIFF
--- a/products/dashboard/__tests__/app/workflows/actions.test.ts
+++ b/products/dashboard/__tests__/app/workflows/actions.test.ts
@@ -71,12 +71,15 @@ function makeTask(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
     skillId: "skill-1",
     stageId: "stage-1",
     notes: "",
-    status: "pending_approval",
+    status: "paused",
     substatus: "",
     checkpoint: true,
     inputs: [],
     playbookId: null,
     owners: [],
+    pausedReason: "checkpoint",
+    pausedBy: null,
+    pausedAt: "2026-04-19T12:00:00Z",
     createdAt: "2026-04-19T12:00:00Z",
     updatedAt: "2026-04-19T12:00:00Z",
     ...overrides,
@@ -114,10 +117,10 @@ function setupRepo(transitioned: WorkflowTask | null): RepoMocks {
     addEvent: vi.fn().mockResolvedValue(event),
   };
 
-  const repo: Partial<WorkflowRepository> = {
+  const repo = {
     transitionPendingCheckpoint: mocks.transitionPendingCheckpoint,
     addEvent: mocks.addEvent,
-  };
+  } as unknown as Partial<WorkflowRepository>;
 
   mockGetRepo.mockResolvedValue(repo);
   return mocks;
@@ -163,12 +166,12 @@ describe("resolveCheckpointAction precondition gate", () => {
     await expect(
       resolveCheckpointAction("task-1", "approved"),
     ).rejects.toThrow(
-      /missing, not a checkpoint, or no longer pending_approval/,
+      /missing, not a checkpoint, or not paused on a checkpoint/,
     );
 
     expect(repo.transitionPendingCheckpoint).toHaveBeenCalledWith(
       "task-1",
-      "complete",
+      "in_progress",
     );
     expect(repo.addEvent).not.toHaveBeenCalled();
     expect(mockRevalidatePath).not.toHaveBeenCalled();
@@ -181,7 +184,7 @@ describe("resolveCheckpointAction precondition gate", () => {
 
     expect(repo.transitionPendingCheckpoint).toHaveBeenCalledWith(
       "task-1",
-      "complete",
+      "in_progress",
     );
   });
 
@@ -192,24 +195,24 @@ describe("resolveCheckpointAction precondition gate", () => {
 
     expect(repo.transitionPendingCheckpoint).toHaveBeenCalledWith(
       "task-1",
-      "complete",
+      "in_progress",
     );
     expect(repo.addEvent).toHaveBeenCalledTimes(1);
     expect(repo.addEvent.mock.calls[0]?.[1].name).toBe(
       "workflow.checkpoint_approved",
     );
     expect(mockRevalidatePath).toHaveBeenCalledWith("/", "layout");
-    expect(result.task.status).toBe("complete");
+    expect(result.task.status).toBe("in_progress");
   });
 
-  it("maps `rejected` resolution to status=blocked + checkpoint_rejected event", async () => {
+  it("maps `rejected` resolution to status=failed + checkpoint_rejected event", async () => {
     const repo = setupRepo(makeTask());
 
     await resolveCheckpointAction("task-1", "rejected");
 
     expect(repo.transitionPendingCheckpoint).toHaveBeenCalledWith(
       "task-1",
-      "blocked",
+      "failed",
     );
     expect(repo.addEvent.mock.calls[0]?.[1].name).toBe(
       "workflow.checkpoint_rejected",
@@ -225,7 +228,7 @@ describe("resolveCheckpointAction precondition gate", () => {
     expect(repo.transitionPendingCheckpoint).toHaveBeenCalledTimes(1);
     expect(mockCaptureError).toHaveBeenCalledTimes(1);
     expect(mockRevalidatePath).toHaveBeenCalledWith("/", "layout");
-    expect(result.task.status).toBe("complete");
+    expect(result.task.status).toBe("in_progress");
   });
 });
 
@@ -416,9 +419,16 @@ describe("workflow matrix edit actions", () => {
     ).rejects.toThrow("updateTemplateAction: template color is required");
   });
 
-  it("startTaskAction uses the atomic status transition and records an event", async () => {
-    const started = makeTask({ id: "task-start", status: "active", checkpoint: false });
-    const updateTaskIfStatus = vi.fn().mockResolvedValue(started);
+  it("startTaskAction validates inputs received then flips to in_progress", async () => {
+    const started = makeTask({ id: "task-start", status: "in_progress", checkpoint: false });
+    const drawer = {
+      task: makeTask({ id: "task-start", status: "not_started", checkpoint: false }),
+      inputs: [],
+      outputs: [],
+      playbookOutputs: [],
+    };
+    const getDrawerData = vi.fn().mockResolvedValue(drawer);
+    const updateTask = vi.fn().mockResolvedValue(started);
     const addEvent = vi.fn().mockResolvedValue({
       id: "event-5",
       instanceId: started.instanceId,
@@ -430,39 +440,37 @@ describe("workflow matrix edit actions", () => {
     });
 
     mockGetRepo.mockResolvedValue({
-      updateTaskIfStatus,
+      getDrawerData,
+      updateTask,
       addEvent,
-      getTask: vi.fn(),
     } satisfies Partial<WorkflowRepository>);
 
     const result = await startTaskAction("task-start");
 
-    expect(updateTaskIfStatus).toHaveBeenCalledWith("task-start", "not_started", {
-      status: "active",
-    });
+    expect(getDrawerData).toHaveBeenCalledWith("task-start");
+    expect(updateTask).toHaveBeenCalledWith("task-start", { status: "in_progress" });
     expect(addEvent.mock.calls[0]?.[1].name).toBe("workflow.task_started");
     expect(mockRevalidatePath).toHaveBeenCalledWith("/", "layout");
-    expect(result.task.status).toBe("active");
+    expect(result.task.status).toBe("in_progress");
   });
 
-  it("cancelRunningTaskAction rejects with the same error when the task is no longer active", async () => {
+  it("cancelRunningTaskAction rejects when the task is no longer in_progress/running", async () => {
     const current = makeTask({ id: "task-cancel", status: "complete", checkpoint: false });
-    const updateTaskIfStatus = vi.fn().mockResolvedValue(null);
     const getTask = vi.fn().mockResolvedValue(current);
+    const updateTask = vi.fn();
 
     mockGetRepo.mockResolvedValue({
-      updateTaskIfStatus,
       getTask,
+      updateTask,
       addEvent: vi.fn(),
     } satisfies Partial<WorkflowRepository>);
 
     await expect(cancelRunningTaskAction("task-cancel")).rejects.toThrow(
-      /task is not active/,
+      /not in_progress or running/,
     );
 
-    expect(updateTaskIfStatus).toHaveBeenCalledWith("task-cancel", "active", {
-      status: "blocked",
-    });
+    expect(getTask).toHaveBeenCalledWith("task-cancel");
+    expect(updateTask).not.toHaveBeenCalled();
   });
 
   it("retryBlockedTaskAction rejects with task not found when the row no longer exists", async () => {
@@ -479,8 +487,8 @@ describe("workflow matrix edit actions", () => {
       /task not found/,
     );
 
-    expect(updateTaskIfStatus).toHaveBeenCalledWith("task-retry", "blocked", {
-      status: "active",
+    expect(updateTaskIfStatus).toHaveBeenCalledWith("task-retry", "failed", {
+      status: "in_progress",
     });
   });
 });

--- a/products/dashboard/__tests__/components/overview/overview-screen.test.tsx
+++ b/products/dashboard/__tests__/components/overview/overview-screen.test.tsx
@@ -95,12 +95,15 @@ function snapshotWithData(): OverviewSnapshot {
         skillId: "pm",
         stageId: "discovery",
         notes: "Backlog ready for sprint",
-        status: "pending_approval",
+        status: "paused",
         substatus: "",
         checkpoint: true,
         inputs: [],
         playbookId: null,
         owners: [],
+        pausedReason: "checkpoint",
+        pausedBy: null,
+        pausedAt: "2026-04-19T12:00:00Z",
         createdAt: "2026-04-19T12:00:00Z",
         updatedAt: "2026-04-19T12:00:00Z",
       },
@@ -125,7 +128,7 @@ function snapshotWithData(): OverviewSnapshot {
         skillId: "designer",
         stageId: "design",
         notes: "Prototype review",
-        status: "active",
+        status: "in_progress",
         substatus: "",
         checkpoint: false,
         inputs: [],
@@ -262,7 +265,7 @@ describe("OverviewScreen", () => {
   it("falls back to 'All clear ✓' when no checkpoints are pending", () => {
     const snapshot = snapshotWithData();
     snapshot.tasks = snapshot.tasks.map((t) =>
-      t.status === "pending_approval" ? { ...t, status: "complete" } : t,
+      t.status === "paused" ? { ...t, status: "complete" as const } : t,
     );
 
     render(

--- a/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
@@ -147,7 +147,7 @@ describe("ProcessMatrix", () => {
         id: "k-1",
         skillId: "sales-ops",
         stageId: "pre-sales",
-        status: "active",
+        status: "in_progress",
       }),
       task({
         id: "k-2",
@@ -182,7 +182,7 @@ describe("ProcessMatrix", () => {
 
   it("renders one pip per task in each stage, tinted by the task's role", () => {
     const inst = instance([
-      task({ id: "k-1", skillId: "sales-ops", stageId: "pre-sales", status: "active" }),
+      task({ id: "k-1", skillId: "sales-ops", stageId: "pre-sales", status: "in_progress" }),
       task({ id: "k-2", skillId: "pm", stageId: "pre-sales", status: "not_started" }),
       task({ id: "k-3", skillId: "sales-ops", stageId: "validation", status: "complete" }),
     ]);
@@ -199,7 +199,7 @@ describe("ProcessMatrix", () => {
 
   it("toggles the role-collapsed class and hides labels when the toggle is pressed", async () => {
     const inst = instance([
-      task({ id: "k-1", skillId: "sales-ops", stageId: "pre-sales", status: "active" }),
+      task({ id: "k-1", skillId: "sales-ops", stageId: "pre-sales", status: "in_progress" }),
     ]);
     const user = userEvent.setup();
 
@@ -225,7 +225,7 @@ describe("ProcessMatrix", () => {
 
   it("collapses an individual stage column and renders only its pip strip", async () => {
     const inst = instance([
-      task({ id: "k-1", skillId: "sales-ops", stageId: "pre-sales", status: "active" }),
+      task({ id: "k-1", skillId: "sales-ops", stageId: "pre-sales", status: "in_progress" }),
       task({ id: "k-2", skillId: "pm", stageId: "pre-sales", status: "complete" }),
     ]);
     const user = userEvent.setup();
@@ -252,7 +252,7 @@ describe("ProcessMatrix", () => {
 
   it("collapses an individual skill row and renders mini cells across the row", async () => {
     const inst = instance([
-      task({ id: "k-1", skillId: "sales-ops", stageId: "pre-sales", status: "active" }),
+      task({ id: "k-1", skillId: "sales-ops", stageId: "pre-sales", status: "in_progress" }),
       task({ id: "k-2", skillId: "sales-ops", stageId: "validation", status: "complete" }),
       task({ id: "k-3", skillId: "pm", stageId: "pre-sales", status: "not_started" }),
     ]);
@@ -300,7 +300,7 @@ describe("ProcessMatrix", () => {
   });
 
   it("shows edit affordances and creates a task in an empty cell", async () => {
-    const inst = instance([task({ id: "k-1", status: "active" })]);
+    const inst = instance([task({ id: "k-1", status: "in_progress" })]);
     const user = userEvent.setup();
     const created = task({
       id: "created-1",
@@ -319,7 +319,7 @@ describe("ProcessMatrix", () => {
   });
 
   it("removes a task after confirm", async () => {
-    const inst = instance([task({ id: "k-1", status: "active" })]);
+    const inst = instance([task({ id: "k-1", status: "in_progress" })]);
     const user = userEvent.setup();
     mockDeleteTaskAction.mockResolvedValue(undefined);
 

--- a/products/dashboard/__tests__/components/workflows/task-card.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/task-card.test.tsx
@@ -16,7 +16,7 @@ function task(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
     skillId: "sales-ops",
     stageId: "pre-sales",
     notes: "",
-    status: "active",
+    status: "in_progress",
     substatus: "",
     checkpoint: false,
     inputs: [],
@@ -68,9 +68,11 @@ describe("TaskCard", () => {
 
   it.each<[WorkflowTask["status"], TaskBarState, string]>([
     ["complete", "bar-complete", "Complete"],
-    ["active", "bar-active", "In progress"],
-    ["pending_approval", "bar-glow", "Pending approval"],
-    ["blocked", "bar-glow", "Failed"],
+    ["in_progress", "bar-active", "In progress"],
+    ["running", "bar-active", "Running"],
+    ["paused", "bar-glow", "Paused"],
+    ["failed", "bar-glow", "Failed"],
+    ["waiting", "bar-locked", "Waiting"],
     ["not_started", "bar-ready", "Not started"],
     ["not_started", "bar-locked", "Not started"],
   ])(
@@ -145,7 +147,7 @@ describe("TaskCard", () => {
   it("renders an error info-badge when the task is blocked", () => {
     render(
       <TaskCard
-        task={task({ id: "blocked-task", status: "blocked" })}
+        task={task({ id: "blocked-task", status: "failed" })}
         playbook={PLAYBOOK}
         skillColor="#6366f1"
         barState="bar-glow"

--- a/products/dashboard/__tests__/components/workflows/task-drawer.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/task-drawer.test.tsx
@@ -100,12 +100,15 @@ function makeTask(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
     skillId: "sales-ops",
     stageId: "pre-sales",
     notes: "Scope review",
-    status: "pending_approval",
+    status: "paused",
     substatus: "",
     checkpoint: true,
     inputs: [],
     playbookId: null,
     owners: [],
+    pausedReason: "checkpoint",
+    pausedBy: null,
+    pausedAt: "2026-04-19T12:00:00Z",
     createdAt: "2026-04-19T12:00:00Z",
     updatedAt: "2026-04-19T12:00:00Z",
     ...overrides,
@@ -213,7 +216,7 @@ describe("TaskDrawer", () => {
 
   describe("Details tab — primary action card", () => {
     it("shows Approve + Reject buttons for pending_approval task", () => {
-      renderDrawer({ status: "pending_approval", checkpoint: true });
+      renderDrawer({ status: "paused", checkpoint: true, pausedReason: "checkpoint" });
       expect(screen.getByTestId("td-approve-btn")).toBeInTheDocument();
       expect(screen.getByTestId("td-reject-btn")).toBeInTheDocument();
     });
@@ -226,7 +229,7 @@ describe("TaskDrawer", () => {
     });
 
     it("shows active playbook row with stop control for running task", () => {
-      renderDrawer({ status: "active", checkpoint: false, playbookId:"demo-pb" });
+      renderDrawer({ status: "in_progress", checkpoint: false, playbookId:"demo-pb" });
       const playbookCard = screen.getByTestId("td-playbook-card");
       expect(playbookCard).not.toHaveAttribute("role", "button");
       expect(screen.getByTestId("td-pb-stop-run-btn")).toBeInTheDocument();
@@ -241,14 +244,14 @@ describe("TaskDrawer", () => {
   describe("Cancel run", () => {
     it("calls cancelRunningTaskAction and onTaskUpdate when stop is clicked", async () => {
       const updatedTask = makeTask({
-        status: "blocked",
+        status: "failed",
         checkpoint: false,
         playbookId:"demo-pb",
       });
       mockCancelRun.mockResolvedValue({ task: updatedTask });
       const onTaskUpdate = vi.fn();
       const { task } = renderDrawer(
-        { status: "active", checkpoint: false, playbookId:"demo-pb" },
+        { status: "in_progress", checkpoint: false, playbookId:"demo-pb" },
         [],
         vi.fn(),
         onTaskUpdate,
@@ -270,14 +273,14 @@ describe("TaskDrawer", () => {
   describe("Retry run", () => {
     it("calls retryBlockedTaskAction and onTaskUpdate when retry is clicked", async () => {
       const updatedTask = makeTask({
-        status: "active",
+        status: "in_progress",
         checkpoint: false,
         playbookId:"demo-pb",
       });
       mockRetryBlocked.mockResolvedValue({ task: updatedTask });
       const onTaskUpdate = vi.fn();
       const { task } = renderDrawer(
-        { status: "blocked", checkpoint: false, playbookId:"demo-pb" },
+        { status: "failed", checkpoint: false, playbookId:"demo-pb" },
         [],
         vi.fn(),
         onTaskUpdate,
@@ -306,9 +309,9 @@ describe("TaskDrawer", () => {
     it("invokes onViewLiveRun for every eligible playbook-card status and skips not_started without a handler", async () => {
       const user = userEvent.setup();
       const runnableStatuses: WorkflowTask["status"][] = [
-        "active",
-        "blocked",
-        "pending_approval",
+        "in_progress",
+        "failed",
+        "paused",
         "complete",
       ];
 
@@ -336,10 +339,10 @@ describe("TaskDrawer", () => {
 
   describe("Approve flow", () => {
     it("calls approveDrawerCheckpointAction and onTaskUpdate on success", async () => {
-      const updatedTask = makeTask({ status: "active" });
+      const updatedTask = makeTask({ status: "in_progress" });
       mockApprove.mockResolvedValue({ task: updatedTask });
       const onTaskUpdate = vi.fn();
-      const { task } = renderDrawer({ status: "pending_approval" }, [], vi.fn(), onTaskUpdate);
+      const { task } = renderDrawer({ status: "paused" }, [], vi.fn(), onTaskUpdate);
 
       const approveBtn = screen.getByTestId("td-approve-btn");
       await act(async () => {
@@ -356,7 +359,7 @@ describe("TaskDrawer", () => {
 
     it("captures error if approve action throws", async () => {
       mockApprove.mockRejectedValue(new Error("Server error"));
-      renderDrawer({ status: "pending_approval" });
+      renderDrawer({ status: "paused" });
 
       await act(async () => {
         fireEvent.click(screen.getByTestId("td-approve-btn"));
@@ -369,7 +372,7 @@ describe("TaskDrawer", () => {
   describe("Reject flow", () => {
     it("calls rejectDrawerCheckpointAction on reject", async () => {
       mockReject.mockResolvedValue(undefined);
-      const { task } = renderDrawer({ status: "pending_approval" });
+      const { task } = renderDrawer({ status: "paused" });
 
       await act(async () => {
         fireEvent.click(screen.getByTestId("td-reject-btn"));

--- a/products/dashboard/__tests__/lib/workflows/aggregate.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/aggregate.test.ts
@@ -69,6 +69,11 @@ function task(
   status: WorkflowTask["status"] = "not_started",
   overrides: Partial<WorkflowTask> = {},
 ): WorkflowTask {
+  // PR 2 / AEL-60: pickPendingCheckpoints now requires checkpoint=true AND
+  // pausedReason='checkpoint' (paused for any other reason isn't a pending
+  // approval). The helper applies that default for paused tasks so existing
+  // fixtures keep flagging as pending checkpoints.
+  const isPausedCheckpoint = status === "paused";
   return {
     id,
     instanceId,
@@ -77,10 +82,13 @@ function task(
     notes: "",
     status,
     substatus: "",
-    checkpoint: false,
+    checkpoint: isPausedCheckpoint,
     inputs: [],
     playbookId: null,
     owners: [],
+    pausedReason: isPausedCheckpoint ? "checkpoint" : null,
+    pausedBy: null,
+    pausedAt: isPausedCheckpoint ? "2026-04-19T12:00:00Z" : null,
     createdAt: "2026-04-19T12:00:00Z",
     updatedAt: "2026-04-19T12:00:00Z",
     ...overrides,
@@ -150,8 +158,8 @@ describe("computeOverviewStats", () => {
       ],
       tasks: [
         task("k-1", "i-1", "complete"),
-        task("k-2", "i-1", "active"),
-        task("k-3", "i-2", "pending_approval"),
+        task("k-2", "i-1", "in_progress"),
+        task("k-3", "i-2", "paused"),
         task("k-4", "i-2", "not_started"),
         task("k-5", "i-3", "complete"),
       ],
@@ -179,7 +187,7 @@ describe("computeTemplateHealth", () => {
       instances: [instance("i-a", "delivery"), instance("i-b", "product")],
       tasks: [
         task("k-1", "i-a", "complete"),
-        task("k-2", "i-a", "active"),
+        task("k-2", "i-a", "in_progress"),
         task("k-3", "i-a", "complete"),
         task("k-4", "i-b", "not_started"),
       ],
@@ -214,8 +222,8 @@ describe("pickPendingCheckpoints", () => {
       templates: [t1],
       instances: [i1],
       tasks: [
-        task("k-1", "i-1", "pending_approval"),
-        task("k-2", "i-1", "active"),
+        task("k-1", "i-1", "paused"),
+        task("k-2", "i-1", "in_progress"),
       ],
       events: [],
     };
@@ -231,7 +239,7 @@ describe("pickPendingCheckpoints", () => {
     const snapshot: OverviewSnapshot = {
       templates: [],
       instances: [],
-      tasks: [task("k-orphan", "ghost", "pending_approval")],
+      tasks: [task("k-orphan", "ghost", "paused")],
       events: [],
     };
     expect(pickPendingCheckpoints(snapshot)).toEqual([]);
@@ -246,10 +254,10 @@ describe("pickActiveTasks", () => {
       templates: [t1],
       instances: [i1],
       tasks: [
-        task("k-1", "i-1", "active", { playbookId: "Discovery call v3" }),
-        task("k-2", "i-1", "pending_approval"),
+        task("k-1", "i-1", "in_progress", { playbookId: "Discovery call v3" }),
+        task("k-2", "i-1", "paused"),
         task("k-3", "i-1", "complete"),
-        task("k-4", "i-1", "active", { playbookId: null }),
+        task("k-4", "i-1", "in_progress", { playbookId: null }),
       ],
       events: [],
     };
@@ -265,7 +273,7 @@ describe("pickActiveTasks", () => {
     const snapshot: OverviewSnapshot = {
       templates: [],
       instances: [],
-      tasks: [task("k-orphan", "ghost", "active")],
+      tasks: [task("k-orphan", "ghost", "in_progress")],
       events: [],
     };
     expect(pickActiveTasks(snapshot)).toEqual([]);
@@ -276,7 +284,7 @@ describe("pickActiveTasks", () => {
     const snapshot: OverviewSnapshot = {
       templates: [],
       instances: [i1],
-      tasks: [task("k-1", "i-1", "active")],
+      tasks: [task("k-1", "i-1", "in_progress")],
       events: [],
     };
     const active = pickActiveTasks(snapshot);

--- a/products/dashboard/__tests__/lib/workflows/classify-owner.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/classify-owner.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyOwner } from "@/lib/workflows/classify-owner";
+
+describe("classifyOwner", () => {
+  it("classifies labels with the agent: prefix as agent (case-insensitive)", () => {
+    expect(classifyOwner("agent:foo")).toBe("agent");
+    expect(classifyOwner("AGENT:Sales Ops")).toBe("agent");
+    expect(classifyOwner("Agent: bar")).toBe("agent");
+  });
+
+  it("classifies plain names as person", () => {
+    expect(classifyOwner("Andres")).toBe("person");
+    expect(classifyOwner("Hans / Dave")).toBe("person");
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(classifyOwner("   agent:foo  ")).toBe("agent");
+  });
+
+  it("treats empty strings defensively as person", () => {
+    expect(classifyOwner("")).toBe("person");
+    expect(classifyOwner("   ")).toBe("person");
+  });
+
+  it("treats non-string input defensively as person", () => {
+    expect(classifyOwner(undefined as unknown as string)).toBe("person");
+    expect(classifyOwner(null as unknown as string)).toBe("person");
+  });
+});

--- a/products/dashboard/__tests__/lib/workflows/derive-status.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/derive-status.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveStatus } from "@/lib/workflows/derive-status";
+import type {
+  TaskInputState,
+  TaskOutput,
+  WorkflowInput,
+  WorkflowTaskStatus,
+} from "@/lib/workflows/types";
+
+function linked(id: string): WorkflowInput {
+  return { id, name: id, linkMode: "linked" };
+}
+function manual(id: string): WorkflowInput {
+  return { id, name: id, linkMode: "manual" };
+}
+function inputState(inputId: string, received: boolean): TaskInputState {
+  return { id: `ti-${inputId}`, taskId: "t-1", inputId, received };
+}
+function output(status: TaskOutput["status"], outputId = "o-1"): TaskOutput {
+  return {
+    id: `to-${outputId}`,
+    taskId: "t-1",
+    outputId,
+    status,
+    createdAt: "2026-05-07T00:00:00Z",
+  };
+}
+
+function call(args: Partial<Parameters<typeof deriveStatus>[0]>): WorkflowTaskStatus {
+  return deriveStatus({
+    persisted: "not_started",
+    pausedReason: null,
+    inputs: [],
+    inputDefs: [],
+    outputs: [],
+    agentRun: null,
+    ...args,
+  });
+}
+
+describe("deriveStatus", () => {
+  it("complete is terminal — no signal can move it", () => {
+    expect(
+      call({
+        persisted: "complete",
+        pausedReason: "checkpoint",
+        outputs: [output("failed")],
+        agentRun: { status: "failed" },
+      }),
+    ).toBe("complete");
+  });
+
+  it("failed wins when any output failed", () => {
+    expect(
+      call({
+        persisted: "in_progress",
+        outputs: [output("produced"), output("failed", "o-2")],
+      }),
+    ).toBe("failed");
+  });
+
+  it("failed wins when the agent run failed", () => {
+    expect(
+      call({ persisted: "in_progress", agentRun: { status: "failed" } }),
+    ).toBe("failed");
+  });
+
+  it("complete when outputs are non-empty and every output produced", () => {
+    expect(
+      call({
+        persisted: "in_progress",
+        outputs: [output("produced"), output("produced", "o-2")],
+      }),
+    ).toBe("complete");
+  });
+
+  it("paused beats waiting and running", () => {
+    expect(
+      call({
+        persisted: "in_progress",
+        pausedReason: "checkpoint",
+        inputDefs: [linked("a")],
+        inputs: [inputState("a", false)],
+        agentRun: { status: "running" },
+      }),
+    ).toBe("paused");
+  });
+
+  it("running requires an active agent run", () => {
+    expect(
+      call({ persisted: "in_progress", agentRun: { status: "running" } }),
+    ).toBe("running");
+  });
+
+  it("in_progress carries through when no other rule matches", () => {
+    expect(call({ persisted: "in_progress" })).toBe("in_progress");
+  });
+
+  it("waiting when any linked input is unreceived", () => {
+    expect(
+      call({
+        inputDefs: [linked("a"), linked("b"), manual("c")],
+        inputs: [inputState("a", true), inputState("b", false)],
+      }),
+    ).toBe("waiting");
+  });
+
+  it("manual inputs do not gate readiness", () => {
+    expect(
+      call({
+        inputDefs: [manual("c")],
+        inputs: [inputState("c", false)],
+      }),
+    ).toBe("not_started");
+  });
+
+  it("not_started when nothing else matches", () => {
+    expect(call({})).toBe("not_started");
+  });
+
+  it("empty pausedReason string is ignored", () => {
+    expect(call({ persisted: "in_progress", pausedReason: "   " })).toBe(
+      "in_progress",
+    );
+  });
+
+  it("all linked inputs received and persisted=not_started → not_started", () => {
+    expect(
+      call({
+        inputDefs: [linked("a")],
+        inputs: [inputState("a", true)],
+      }),
+    ).toBe("not_started");
+  });
+});

--- a/products/dashboard/__tests__/lib/workflows/matrix.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/matrix.test.ts
@@ -39,7 +39,7 @@ function linked(ref: string | undefined, name = "linked"): WorkflowInput {
 
 describe("canStart", () => {
   it("returns true for tasks already past not_started regardless of inputs", () => {
-    const a = task("a", { status: "active", inputs: [linked("missing")] });
+    const a = task("a", { status: "in_progress", inputs: [linked("missing")] });
     expect(canStart(a, [a])).toBe(true);
   });
 
@@ -54,7 +54,7 @@ describe("canStart", () => {
   });
 
   it("requires every linked input's upstream task to be complete", () => {
-    const upstream = task("up", { playbookId: "pdr-review", status: "active" });
+    const upstream = task("up", { playbookId: "pdr-review", status: "in_progress" });
     const downstream = task("down", { inputs: [linked("pdr-review")] });
     expect(canStart(downstream, [upstream, downstream])).toBe(false);
 
@@ -88,9 +88,9 @@ describe("canStart", () => {
 describe("barClass", () => {
   it("maps each task status to its prototype bar-state class", () => {
     expect(barClass(task("c", { status: "complete" }), false)).toBe("bar-complete");
-    expect(barClass(task("a", { status: "active" }), false)).toBe("bar-active");
-    expect(barClass(task("p", { status: "pending_approval" }), true)).toBe("bar-glow");
-    expect(barClass(task("b", { status: "blocked" }), true)).toBe("bar-glow");
+    expect(barClass(task("a", { status: "in_progress" }), false)).toBe("bar-active");
+    expect(barClass(task("p", { status: "paused" }), true)).toBe("bar-glow");
+    expect(barClass(task("b", { status: "failed" }), true)).toBe("bar-glow");
   });
 
   it("splits not_started tasks into ready/locked based on canStart", () => {

--- a/products/dashboard/__tests__/lib/workflows/repository.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/repository.test.ts
@@ -409,13 +409,13 @@ describe("workflow repository", () => {
       const targetTaskId = instance.tasks[0].id;
 
       const updated = await repo.updateTask(targetTaskId, {
-        status: "active",
+        status: "in_progress",
         substatus: "Agent began work",
         notes: "Started",
       });
 
       expect(updated.id).toBe(targetTaskId);
-      expect(updated.status).toBe("active");
+      expect(updated.status).toBe("in_progress");
       expect(updated.substatus).toBe("Agent began work");
       expect(updated.notes).toBe("Started");
 
@@ -507,11 +507,12 @@ describe("workflow repository", () => {
       expect(fetched).toBeNull();
     });
 
-    it("filters legacy non-data-flow trigger types out of `inputs` on read", async () => {
-      // Legacy row authored before AEL-59: the JSONB `triggers` column
-      // carried `manual` / `event` / `schedule` / `webhook` items. The
-      // read shim drops them; only `task` / `after_task` survive as
-      // `linked` inputs.
+    it("forward-maps legacy trigger-shaped JSONB to linked inputs on read", async () => {
+      // PR 2 / AEL-60 renamed the column to `inputs` and PR 1's runtime
+      // wrote canonical WorkflowInput JSONB. Defensively, rows authored
+      // before PR 1 may still carry the legacy trigger shape — the
+      // normalizeInputs shim maps them forward. Only `task` / `after_task`
+      // map to a `linked` input; everything else is dropped.
       store.workflow_tasks.push({
         id: "legacy-task",
         instance_id: "inst-x",
@@ -521,16 +522,18 @@ describe("workflow repository", () => {
         status: "not_started",
         substatus: "",
         checkpoint: false,
-        triggers: [
+        inputs: [
           { type: "manual", label: "Manual start" },
           { type: "event", eventName: "external.signal" },
           { type: "schedule", label: "Cron" },
           { type: "webhook", label: "Hook" },
           { type: "after_task", taskRef: "presales-qualification", label: "After PD" },
         ],
-        gates: [{ type: "approval", label: "Approve" }],
         playbook_id: "pdr-review",
         owners: [],
+        paused_reason: null,
+        paused_by: null,
+        paused_at: null,
         created_at: "2026-04-19T12:00:00Z",
         updated_at: "2026-04-19T12:00:00Z",
       });
@@ -552,28 +555,28 @@ describe("workflow repository", () => {
   });
 
   describe("transitionPendingCheckpoint", () => {
-    it("flips a pending_approval checkpoint task to the requested status atomically", async () => {
+    it("resumes a paused checkpoint task to the requested status atomically", async () => {
       const repo = createWorkflowRepository(makeFakeClient(store));
       const instance = await repo.createInstance("client-delivery", "Acme Corp");
       const checkpoint = instance.tasks.find((t) => t.checkpoint)!;
 
-      // Templates materialize tasks in `not_started`; promote to
-      // pending_approval so the conditional UPDATE's predicates match.
-      await repo.updateTask(checkpoint.id, { status: "pending_approval" });
+      // PR 2 routes checkpoint approval through pause/resume semantics —
+      // the predicate now requires status='paused' AND paused_reason='checkpoint'.
+      await repo.pauseTask(checkpoint.id, "checkpoint");
 
       const transitioned = await repo.transitionPendingCheckpoint(
         checkpoint.id,
-        "complete",
+        "in_progress",
       );
 
       expect(transitioned).not.toBeNull();
       expect(transitioned!.id).toBe(checkpoint.id);
-      expect(transitioned!.status).toBe("complete");
+      expect(transitioned!.status).toBe("in_progress");
       expect(transitioned!.checkpoint).toBe(true);
 
-      // Persisted: a re-read sees the new status.
       const refetched = await repo.getTask(checkpoint.id);
-      expect(refetched!.status).toBe("complete");
+      expect(refetched!.status).toBe("in_progress");
+      expect(refetched!.pausedReason).toBeNull();
     });
 
     it("returns null when the task is not a checkpoint (UPDATE matches no row, no write)", async () => {
@@ -581,30 +584,27 @@ describe("workflow repository", () => {
       const instance = await repo.createInstance("client-delivery", "Acme Corp");
       const nonCheckpoint = instance.tasks.find((t) => !t.checkpoint)!;
 
-      // Even after promoting status, the `checkpoint = TRUE` predicate
-      // must fail and the UPDATE must not write — the row stays
-      // untouched so subsequent flows see truthful state.
-      await repo.updateTask(nonCheckpoint.id, { status: "pending_approval" });
+      await repo.pauseTask(nonCheckpoint.id, "checkpoint");
 
       const transitioned = await repo.transitionPendingCheckpoint(
         nonCheckpoint.id,
-        "complete",
+        "in_progress",
       );
 
       expect(transitioned).toBeNull();
       const refetched = await repo.getTask(nonCheckpoint.id);
-      expect(refetched!.status).toBe("pending_approval");
+      expect(refetched!.status).toBe("paused");
     });
 
-    it("returns null when the task is not in pending_approval (UPDATE matches no row, no write)", async () => {
+    it("returns null when the task is not paused on a checkpoint reason", async () => {
       const repo = createWorkflowRepository(makeFakeClient(store));
       const instance = await repo.createInstance("client-delivery", "Acme Corp");
       const checkpoint = instance.tasks.find((t) => t.checkpoint)!;
 
-      // Checkpoint exists but is still `not_started` from materialization.
+      // Checkpoint exists but is still `not_started` — predicate fails.
       const transitioned = await repo.transitionPendingCheckpoint(
         checkpoint.id,
-        "complete",
+        "in_progress",
       );
 
       expect(transitioned).toBeNull();
@@ -617,7 +617,7 @@ describe("workflow repository", () => {
 
       const transitioned = await repo.transitionPendingCheckpoint(
         "does-not-exist",
-        "complete",
+        "in_progress",
       );
 
       expect(transitioned).toBeNull();
@@ -647,12 +647,12 @@ describe("workflow repository", () => {
       const target = instance.tasks[0]!;
 
       const transitioned = await repo.updateTaskIfStatus(target.id, "not_started", {
-        status: "active",
+        status: "in_progress",
       });
 
       expect(transitioned).not.toBeNull();
-      expect(transitioned!.status).toBe("active");
-      expect((await repo.getTask(target.id))!.status).toBe("active");
+      expect(transitioned!.status).toBe("in_progress");
+      expect((await repo.getTask(target.id))!.status).toBe("in_progress");
     });
 
     it("returns null when updateTaskIfStatus sees a stale current status", async () => {
@@ -660,8 +660,8 @@ describe("workflow repository", () => {
       const instance = await repo.createInstance("client-delivery", "Acme Corp");
       const target = instance.tasks[0]!;
 
-      const transitioned = await repo.updateTaskIfStatus(target.id, "active", {
-        status: "blocked",
+      const transitioned = await repo.updateTaskIfStatus(target.id, "in_progress", {
+        status: "failed",
       });
 
       expect(transitioned).toBeNull();

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -9,6 +9,10 @@ import {
   type PendingCheckpoint,
 } from "@/lib/workflows/aggregate";
 import type {
+  DrawerData,
+  OutputArtifact,
+  TaskInputState,
+  TaskOutput,
   WorkflowInput,
   WorkflowInstance,
   WorkflowTask,
@@ -19,10 +23,12 @@ import type {
 
 const TASK_STATUS_VALUES: readonly WorkflowTaskStatus[] = [
   "not_started",
-  "active",
-  "pending_approval",
-  "blocked",
+  "waiting",
+  "paused",
+  "in_progress",
+  "running",
   "complete",
+  "failed",
 ];
 
 function isWorkflowTaskStatus(value: unknown): value is WorkflowTaskStatus {
@@ -164,11 +170,11 @@ export async function resolveCheckpointAction(
   // predicates into the UPDATE closes that window — when no row is
   // returned, nothing was written, and we refuse without calling
   // `addEvent` so the database state and event feed stay truthful.
-  const nextStatus = resolution === "approved" ? "complete" : "blocked";
+  const nextStatus = resolution === "approved" ? "in_progress" : "failed";
   const task = await repo.transitionPendingCheckpoint(trimmedTaskId, nextStatus);
   if (!task) {
     throw new Error(
-      "resolveCheckpointAction: task is missing, not a checkpoint, or no longer pending_approval",
+      "resolveCheckpointAction: task is missing, not a checkpoint, or not paused on a checkpoint",
     );
   }
 
@@ -239,13 +245,17 @@ export async function approveDrawerCheckpointAction(
   if (!current) {
     throw new Error("approveDrawerCheckpointAction: task not found");
   }
-  if (!current.checkpoint || current.status !== "pending_approval") {
+  if (
+    !current.checkpoint ||
+    current.status !== "paused" ||
+    current.pausedReason !== "checkpoint"
+  ) {
     throw new Error(
-      "approveDrawerCheckpointAction: task is not a pending checkpoint",
+      "approveDrawerCheckpointAction: task is not a paused checkpoint",
     );
   }
 
-  const task = await repo.updateTask(trimmedId, { status: "active" });
+  const task = await repo.resumeTask(trimmedId);
 
   try {
     await repo.addEvent(trimmedId, {
@@ -286,9 +296,13 @@ export async function rejectDrawerCheckpointAction(
   if (!task) {
     throw new Error("rejectDrawerCheckpointAction: task not found");
   }
-  if (!task.checkpoint || task.status !== "pending_approval") {
+  if (
+    !task.checkpoint ||
+    task.status !== "paused" ||
+    task.pausedReason !== "checkpoint"
+  ) {
     throw new Error(
-      "rejectDrawerCheckpointAction: task is not a pending checkpoint",
+      "rejectDrawerCheckpointAction: task is not a paused checkpoint",
     );
   }
 
@@ -585,14 +599,34 @@ export async function startTaskAction(
   if (!trimmedId) throw new Error("startTaskAction: taskId is required");
 
   const repo = await getServerWorkflowRepository();
-  const task = await repo.updateTaskIfStatus(trimmedId, "not_started", {
-    status: "active",
-  });
-  if (!task) {
-    const current = await repo.getTask(trimmedId);
-    if (!current) throw new Error("startTaskAction: task not found");
-    throw new Error("startTaskAction: task is not in not_started state");
+
+  // New precondition (PR 2 / AEL-60): "all inputs received and not paused".
+  // We read drawer data so the gate sees per-instance task_inputs state, not
+  // just the persisted column — a task may be persisted as not_started while
+  // its linked inputs are already satisfied (pre-receipt path) or vice-versa.
+  const drawer = await repo.getDrawerData(trimmedId);
+  if (!drawer) throw new Error("startTaskAction: task not found");
+  if (drawer.task.status === "paused") {
+    throw new Error("startTaskAction: task is paused");
   }
+  if (drawer.task.status === "complete" || drawer.task.status === "failed") {
+    throw new Error("startTaskAction: task already terminal");
+  }
+  const linkedDefIds = new Set(
+    drawer.task.inputs.filter((i) => i.linkMode === "linked").map((i) => i.id),
+  );
+  if (linkedDefIds.size > 0) {
+    const receivedById = new Map(
+      drawer.inputs.map((i) => [i.inputId, i.received]),
+    );
+    const allReceived = Array.from(linkedDefIds).every(
+      (id) => receivedById.get(id) === true,
+    );
+    if (!allReceived) {
+      throw new Error("startTaskAction: not all linked inputs received");
+    }
+  }
+  const task = await repo.updateTask(trimmedId, { status: "in_progress" });
 
   try {
     await repo.addEvent(trimmedId, {
@@ -613,8 +647,9 @@ export async function startTaskAction(
 }
 
 /**
- * Stop an in-flight task run: persists `status: "blocked"` (failed in UI)
- * and records `workflow.run_cancelled`. Only `active` tasks accept this path.
+ * Stop an in-flight task run: persists `status: "failed"` and records
+ * `workflow.run_cancelled`. Accepts both `in_progress` and `running` tasks
+ * (the transient sub-state distinction is meaningless for cancellation).
  */
 export async function cancelRunningTaskAction(
   taskId: string,
@@ -625,16 +660,14 @@ export async function cancelRunningTaskAction(
   }
 
   const repo = await getServerWorkflowRepository();
-  const task = await repo.updateTaskIfStatus(trimmedId, "active", {
-    status: "blocked",
-  });
-  if (!task) {
-    const current = await repo.getTask(trimmedId);
-    if (!current) {
-      throw new Error("cancelRunningTaskAction: task not found");
-    }
-    throw new Error("cancelRunningTaskAction: task is not active");
+  const current = await repo.getTask(trimmedId);
+  if (!current) {
+    throw new Error("cancelRunningTaskAction: task not found");
   }
+  if (current.status !== "in_progress" && current.status !== "running") {
+    throw new Error("cancelRunningTaskAction: task is not in_progress or running");
+  }
+  const task = await repo.updateTask(trimmedId, { status: "failed" });
 
   try {
     await repo.addEvent(trimmedId, {
@@ -655,7 +688,7 @@ export async function cancelRunningTaskAction(
 }
 
 /**
- * Resume a failed playbook run: `blocked` → `active`.
+ * Resume a failed playbook run: `failed` → `in_progress`.
  * Used when the user chooses Retry from the Task Drawer playbook control.
  */
 export async function retryBlockedTaskAction(
@@ -667,15 +700,15 @@ export async function retryBlockedTaskAction(
   }
 
   const repo = await getServerWorkflowRepository();
-  const task = await repo.updateTaskIfStatus(trimmedId, "blocked", {
-    status: "active",
+  const task = await repo.updateTaskIfStatus(trimmedId, "failed", {
+    status: "in_progress",
   });
   if (!task) {
     const current = await repo.getTask(trimmedId);
     if (!current) {
       throw new Error("retryBlockedTaskAction: task not found");
     }
-    throw new Error("retryBlockedTaskAction: task is not blocked");
+    throw new Error("retryBlockedTaskAction: task is not failed");
   }
 
   try {
@@ -893,4 +926,198 @@ export async function deleteTemplateAction(templateId: string): Promise<void> {
   await repo.deleteTemplate(trimmedTemplateId);
 
   revalidatePath("/", "layout");
+}
+
+// ---------------------------------------------------------------------------
+// PR 2 / AEL-60 — drawer IO actions. The redesigned drawer (PR 3) calls
+// these to flip per-task input/output state. Each one persists, then emits
+// a domain event so the audit trail and analytics pick up the change.
+// ---------------------------------------------------------------------------
+
+export async function getDrawerDataAction(
+  taskId: string,
+): Promise<DrawerData | null> {
+  const trimmedId = normalizeTaskField(taskId, "taskId", 80);
+  if (!trimmedId) throw new Error("getDrawerDataAction: taskId is required");
+  const repo = await getServerWorkflowRepository();
+  return repo.getDrawerData(trimmedId);
+}
+
+async function emitTaskEvent(
+  feature: string,
+  name: string,
+  description: string,
+  task: WorkflowTask,
+  payload: Record<string, unknown> = {},
+): Promise<void> {
+  const repo = await getServerWorkflowRepository();
+  try {
+    await repo.addEvent(task.id, {
+      name,
+      description,
+      payload: { task_id: task.id, instance_id: task.instanceId, ...payload },
+    });
+  } catch (eventError) {
+    captureError(eventError, {
+      feature,
+      action: "addEvent",
+      extra: { task_id: task.id, instance_id: task.instanceId },
+    });
+  }
+}
+
+export async function markInputReceivedAction(
+  taskId: string,
+  inputId: string,
+): Promise<{ input: TaskInputState }> {
+  const trimmedId = normalizeTaskField(taskId, "taskId", 80);
+  const trimmedInputId = normalizeTaskField(inputId, "inputId", 120);
+  if (!trimmedId || !trimmedInputId) {
+    throw new Error("markInputReceivedAction: taskId and inputId are required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const input = await repo.markInputReceived(trimmedId, trimmedInputId);
+  const task = await repo.getTask(trimmedId);
+  if (task) {
+    await emitTaskEvent(
+      "workflows.mark_input_received",
+      "workflow.input_received",
+      `Input received: ${trimmedInputId}`,
+      task,
+      { input_id: trimmedInputId, mode: "manual" },
+    );
+  }
+
+  revalidatePath("/", "layout");
+  return { input };
+}
+
+export async function bypassInputAction(
+  taskId: string,
+  inputId: string,
+): Promise<{ input: TaskInputState }> {
+  const trimmedId = normalizeTaskField(taskId, "taskId", 80);
+  const trimmedInputId = normalizeTaskField(inputId, "inputId", 120);
+  if (!trimmedId || !trimmedInputId) {
+    throw new Error("bypassInputAction: taskId and inputId are required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const input = await repo.bypassInput(trimmedId, trimmedInputId);
+  const task = await repo.getTask(trimmedId);
+  if (task) {
+    await emitTaskEvent(
+      "workflows.bypass_input",
+      "workflow.input_bypassed",
+      `Input bypassed: ${trimmedInputId}`,
+      task,
+      { input_id: trimmedInputId, mode: "bypass" },
+    );
+  }
+
+  revalidatePath("/", "layout");
+  return { input };
+}
+
+export async function produceOutputAction(
+  taskId: string,
+  outputId: string,
+  artifact?: OutputArtifact,
+): Promise<{ output: TaskOutput }> {
+  const trimmedId = normalizeTaskField(taskId, "taskId", 80);
+  const trimmedOutputId = normalizeTaskField(outputId, "outputId", 80);
+  if (!trimmedId || !trimmedOutputId) {
+    throw new Error("produceOutputAction: taskId and outputId are required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const output = await repo.produceOutput(trimmedId, trimmedOutputId, artifact);
+  const task = await repo.getTask(trimmedId);
+  if (task) {
+    await emitTaskEvent(
+      "workflows.produce_output",
+      "workflow.output_produced",
+      `Output produced: ${trimmedOutputId}`,
+      task,
+      {
+        output_id: trimmedOutputId,
+        artifact_url: artifact?.artifactUrl ?? null,
+      },
+    );
+  }
+
+  revalidatePath("/", "layout");
+  return { output };
+}
+
+const MAX_PAUSE_REASON_LENGTH = 80;
+
+export async function pauseTaskAction(
+  taskId: string,
+  reason: string,
+): Promise<{ task: WorkflowTask }> {
+  const trimmedId = normalizeTaskField(taskId, "taskId", 80);
+  const trimmedReason = normalizeTaskField(reason, "reason", MAX_PAUSE_REASON_LENGTH);
+  if (!trimmedId || !trimmedReason) {
+    throw new Error("pauseTaskAction: taskId and reason are required");
+  }
+
+  const repo = await getServerWorkflowRepository();
+  const task = await repo.pauseTask(trimmedId, trimmedReason);
+  await emitTaskEvent(
+    "workflows.pause_task",
+    "workflow.task_paused",
+    `Paused: ${trimmedReason}`,
+    task,
+    { reason: trimmedReason },
+  );
+
+  revalidatePath("/", "layout");
+  return { task };
+}
+
+export async function resumeTaskAction(
+  taskId: string,
+): Promise<{ task: WorkflowTask }> {
+  const trimmedId = normalizeTaskField(taskId, "taskId", 80);
+  if (!trimmedId) throw new Error("resumeTaskAction: taskId is required");
+
+  const repo = await getServerWorkflowRepository();
+  const task = await repo.resumeTask(trimmedId);
+  await emitTaskEvent(
+    "workflows.resume_task",
+    "workflow.task_resumed",
+    `Resumed: ${task.id}`,
+    task,
+  );
+
+  revalidatePath("/", "layout");
+  return { task };
+}
+
+/**
+ * Stub: PR 3 wires the drawer's "refine playbook" affordance. There is no
+ * agent runtime in PR 2 yet, so this action only emits a domain event the
+ * drawer can render in the activity feed.
+ */
+export async function refinePlaybookAction(
+  taskId: string,
+): Promise<{ task: WorkflowTask }> {
+  const trimmedId = normalizeTaskField(taskId, "taskId", 80);
+  if (!trimmedId) throw new Error("refinePlaybookAction: taskId is required");
+
+  const repo = await getServerWorkflowRepository();
+  const task = await repo.getTask(trimmedId);
+  if (!task) throw new Error("refinePlaybookAction: task not found");
+
+  await emitTaskEvent(
+    "workflows.refine_playbook",
+    "workflow.playbook_refine_requested",
+    `Refine requested: ${task.id}`,
+    task,
+  );
+
+  revalidatePath("/", "layout");
+  return { task };
 }

--- a/products/dashboard/components/workflows/agent-run-panel.tsx
+++ b/products/dashboard/components/workflows/agent-run-panel.tsx
@@ -238,7 +238,7 @@ const SEED_NOT_STARTED: AgentRun = {
 function pickSeedRun(task: WorkflowTask): AgentRun {
   if (task.status === "not_started") return SEED_NOT_STARTED;
   if (task.status === "complete")    return SEED_COMPLETE;
-  if (task.status === "blocked")     return SEED_FAILED;
+  if (task.status === "failed")      return SEED_FAILED;
   if (task.checkpoint)               return SEED_CHECKPOINT;
   return SEED_RUNNING;
 }
@@ -262,14 +262,15 @@ function initialExpanded(task: WorkflowTask, steps: AgentRunStep[]): Set<string>
     case "not_started":
       // All collapsed — preview mode
       return new Set();
-    case "active":
-    case "pending_approval":
+    case "in_progress":
+    case "running":
+    case "paused":
       // Only the current active/waiting step
       return new Set(steps.filter((s) => s.status === "active" || s.status === "waiting").map((s) => s.id));
     case "complete":
       // All done steps expanded
       return new Set(steps.map((s) => s.id));
-    case "blocked":
+    case "failed":
       // Done + failed steps expanded
       return new Set(steps.filter((s) => s.status === "done" || s.status === "failed").map((s) => s.id));
     default:
@@ -296,8 +297,9 @@ function runMetaLabel(
   switch (task.status) {
     case "not_started":  return `${totalSteps} steps · not started`;
     case "complete":     return `Completed · ${totalSteps}/${totalSteps} steps`;
-    case "blocked":      return `Failed · ${doneCount}/${totalSteps} steps`;
-    case "active":       return `Running ${elapsed} · ${doneCount}/${totalSteps} steps`;
+    case "failed":       return `Failed · ${doneCount}/${totalSteps} steps`;
+    case "in_progress":
+    case "running":      return `Running ${elapsed} · ${doneCount}/${totalSteps} steps`;
     default:             return `${doneCount}/${totalSteps} steps`;
   }
 }
@@ -398,7 +400,8 @@ export function AgentRunPanel({
   // `isApproved` means approveDrawerCheckpointAction has already flipped
   // `task.status` to "active" while preserving `task.checkpoint`, so this
   // combination represents a checkpointed task that has been approved to continue.
-  const isApproved = task.status === "active" && task.checkpoint;
+  const isApproved =
+    (task.status === "in_progress" || task.status === "running") && task.checkpoint;
 
   return (
     <div
@@ -447,7 +450,7 @@ export function AgentRunPanel({
             className={cn(
               "arp-progress-fill",
               task.status === "complete" && "arp-progress-fill--complete",
-              task.status === "blocked"  && "arp-progress-fill--failed",
+              task.status === "failed"   && "arp-progress-fill--failed",
             )}
             style={{ width: `${progressPct}%` }}
           />

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -63,7 +63,11 @@ import type {
   WorkflowTaskStatus,
   WorkflowTemplate,
 } from "@/lib/workflows/types";
-import { TASK_STATUS_VAR } from "@/lib/workflows/task-status";
+import {
+  TASK_STATUS_LABEL,
+  TASK_STATUS_PILL_CLASS,
+  TASK_STATUS_VAR,
+} from "@/lib/workflows/task-status";
 
 import { AddPlaybookModal } from "./add-playbook-modal";
 import { AgentRunPanel } from "./agent-run-panel";
@@ -1131,26 +1135,8 @@ function MiniTaskCell({
       : task.status === "complete"
         ? 0.7
         : 1;
-  const statusLabel =
-    task.status === "active"
-      ? "In progress"
-      : task.status === "pending_approval"
-        ? "Pending approval"
-        : task.status === "blocked"
-          ? "Failed"
-          : task.status === "complete"
-            ? "Complete"
-            : "Not started";
-  const statusClass =
-    task.status === "active"
-      ? "s-active"
-      : task.status === "pending_approval"
-        ? "s-pending"
-        : task.status === "blocked"
-          ? "s-blocked"
-          : task.status === "complete"
-            ? "s-complete"
-            : "s-not_started";
+  const statusLabel = TASK_STATUS_LABEL[task.status];
+  const statusClass = TASK_STATUS_PILL_CLASS[task.status];
   return (
     <button
       type="button"
@@ -1158,7 +1144,7 @@ function MiniTaskCell({
       data-testid={`task-mini-${task.id}`}
       data-status={task.status}
       data-pulse={
-        task.status === "pending_approval" || task.status === "blocked"
+        task.status === "paused" || task.status === "failed"
           ? "true"
           : undefined
       }

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -139,7 +139,7 @@ export function TaskCard({
               testId={`task-checkpoint-${task.id}`}
             />
           ) : null}
-          {!templateView && task.status === "blocked" ? (
+          {!templateView && task.status === "failed" ? (
             <InfoBadge
               tone="error"
               icon={CircleAlert}

--- a/products/dashboard/components/workflows/task-drawer.tsx
+++ b/products/dashboard/components/workflows/task-drawer.tsx
@@ -77,11 +77,13 @@ function InputsEditor({ items }: InputsEditorProps) {
 // ── Details tab ───────────────────────────────────────────────────────────────
 
 const STATUS_LABELS: Record<WorkflowTask["status"], string> = {
-  complete: "Complete",
-  active: "In progress",
-  pending_approval: "Pending approval",
-  blocked: "Failed",
   not_started: "Not started",
+  waiting: "Waiting",
+  paused: "Paused",
+  in_progress: "In progress",
+  running: "Running",
+  complete: "Complete",
+  failed: "Failed",
 };
 
 interface DetailsTabProps {
@@ -112,8 +114,9 @@ function DetailsTab({
   onInputsChange,
   onViewLiveRun,
 }: DetailsTabProps) {
-  const isPendingApproval = task.status === "pending_approval";
-  const isActive = task.status === "active";
+  const isPendingApproval =
+    task.status === "paused" && task.pausedReason === "checkpoint";
+  const isActive = task.status === "in_progress" || task.status === "running";
   const isNotStarted = task.status === "not_started";
   const playbookCardClickable = !!onViewLiveRun;
   const skillRow = skills.find((s) => s.id === task.skillId);
@@ -244,7 +247,7 @@ function DetailsTab({
                       ? "● Running · view steps"
                       : task.status === "complete"
                         ? "✓ Completed · view run"
-                        : task.status === "blocked"
+                        : task.status === "failed"
                           ? "✗ Failed · view run"
                           : "View run →"}
                 </div>
@@ -290,7 +293,7 @@ function DetailsTab({
                   <Check size={10} aria-hidden />
                 </div>
               )}
-              {task.status === "blocked" && (
+              {task.status === "failed" && (
                 <div className="td-pb-failed-wrap" aria-label="Failed">
                   <div className="td-pb-failed-icon">
                     <CircleAlert size={16} strokeWidth={2.25} aria-hidden />

--- a/products/dashboard/lib/workflows/aggregate.ts
+++ b/products/dashboard/lib/workflows/aggregate.ts
@@ -30,9 +30,9 @@ export interface OverviewSnapshot {
 export interface OverviewStats {
   /** Number of instances whose status is anything other than `complete`. */
   activeInstances: number;
-  /** Tasks awaiting a human decision (status === "pending_approval"). */
+  /** Tasks awaiting a human decision (status === "paused"). */
   pendingTasks: number;
-  /** Tasks currently active (status === "active"). */
+  /** Tasks currently in progress or running (status === "in_progress" | "running"). */
   activeTasks: number;
   /** Tasks that have reached the `complete` state. */
   completedTasks: number;
@@ -87,8 +87,10 @@ export function percentComplete(complete: number, total: number): number {
 export function computeOverviewStats(snapshot: OverviewSnapshot): OverviewStats {
   const tasks = snapshot.tasks;
   const completedTasks = tasks.filter((t) => t.status === "complete").length;
-  const activeTasks = tasks.filter((t) => t.status === "active").length;
-  const pendingTasks = tasks.filter((t) => t.status === "pending_approval").length;
+  const activeTasks = tasks.filter(
+    (t) => t.status === "in_progress" || t.status === "running",
+  ).length;
+  const pendingTasks = tasks.filter((t) => t.status === "paused").length;
   const activeInstances = snapshot.instances.filter(
     (i) => i.status !== "complete",
   ).length;
@@ -181,7 +183,9 @@ export function pickPendingCheckpoints(snapshot: OverviewSnapshot): PendingCheck
   const templateById = new Map(snapshot.templates.map((t) => [t.id, t]));
 
   return snapshot.tasks
-    .filter((t) => t.status === "pending_approval")
+    .filter(
+      (t) => t.status === "paused" && t.checkpoint && t.pausedReason === "checkpoint",
+    )
     .map((task) => {
       const instance = instanceById.get(task.instanceId);
       if (!instance) return null;
@@ -211,7 +215,7 @@ export function pickActiveTasks(snapshot: OverviewSnapshot): ActiveTask[] {
   const templateById = new Map(snapshot.templates.map((t) => [t.id, t]));
 
   return snapshot.tasks
-    .filter((t) => t.status === "active")
+    .filter((t) => t.status === "in_progress" || t.status === "running")
     .map((task) => {
       const instance = instanceById.get(task.instanceId);
       if (!instance) return null;

--- a/products/dashboard/lib/workflows/classify-owner.ts
+++ b/products/dashboard/lib/workflows/classify-owner.ts
@@ -1,0 +1,12 @@
+export type OwnerKind = "person" | "agent";
+
+/**
+ * Classify an owner label as a person or an AI agent. Convention: labels
+ * prefixed with `agent:` (case-insensitive) are agents; everything else is
+ * a person. Empty / non-string input is treated as a person to keep the
+ * avatar stack rendering defensively.
+ */
+export function classifyOwner(label: string): OwnerKind {
+  if (typeof label !== "string") return "person";
+  return /^agent:/i.test(label.trim()) ? "agent" : "person";
+}

--- a/products/dashboard/lib/workflows/derive-status.ts
+++ b/products/dashboard/lib/workflows/derive-status.ts
@@ -1,0 +1,68 @@
+import type {
+  TaskInputState,
+  TaskOutput,
+  WorkflowInput,
+  WorkflowTaskStatus,
+} from "@/lib/workflows/types";
+
+export interface DeriveStatusArgs {
+  /** The currently persisted status — anchors transitions that have no
+   *  signal in inputs/outputs (e.g. `complete` is terminal, `in_progress`
+   *  carries through if no override fires). */
+  persisted: WorkflowTaskStatus;
+  /** Non-null reason → `paused` wins (unless terminal `complete`). */
+  pausedReason?: string | null;
+  /** Per-task input state. The matching `inputs` definition is needed
+   *  to know which inputs are `linked` (only those gate readiness). */
+  inputs: TaskInputState[];
+  inputDefs: WorkflowInput[];
+  outputs: TaskOutput[];
+  agentRun: { status: "running" | "completed" | "failed" } | null;
+}
+
+/**
+ * Canonical status reconciler for the 7-state enum (AEL-60). Pure: given
+ * the same arguments it returns the same status. Called by every server
+ * action that mutates a task before persisting.
+ *
+ * Rule order (first match wins):
+ *  1. persisted === 'complete' is terminal.
+ *  2. Any output failed OR agent run failed → 'failed'.
+ *  3. Outputs declared AND every output produced → 'complete'.
+ *  4. pausedReason set → 'paused'.
+ *  5. agentRun.status === 'running' → 'running'.
+ *  6. persisted === 'in_progress' carries through.
+ *  7. Any linked input not yet received → 'waiting'.
+ *  8. Otherwise 'not_started'.
+ */
+export function deriveStatus(args: DeriveStatusArgs): WorkflowTaskStatus {
+  const { persisted, pausedReason, inputs, inputDefs, outputs, agentRun } = args;
+
+  if (persisted === "complete") return "complete";
+
+  const anyOutputFailed = outputs.some((o) => o.status === "failed");
+  if (anyOutputFailed || agentRun?.status === "failed") return "failed";
+
+  if (outputs.length > 0 && outputs.every((o) => o.status === "produced")) {
+    return "complete";
+  }
+
+  if (pausedReason && pausedReason.trim().length > 0) return "paused";
+
+  if (agentRun?.status === "running") return "running";
+
+  if (persisted === "in_progress") return "in_progress";
+
+  const linkedDefIds = new Set(
+    inputDefs.filter((i) => i.linkMode === "linked").map((i) => i.id),
+  );
+  if (linkedDefIds.size > 0) {
+    const receivedById = new Map(inputs.map((i) => [i.inputId, i.received]));
+    const allReceived = Array.from(linkedDefIds).every(
+      (id) => receivedById.get(id) === true,
+    );
+    if (!allReceived) return "waiting";
+  }
+
+  return "not_started";
+}

--- a/products/dashboard/lib/workflows/matrix.ts
+++ b/products/dashboard/lib/workflows/matrix.ts
@@ -12,8 +12,8 @@ import type { WorkflowTask } from "./types";
 /**
  * Bar state strings rendered by `.task-card.bar-*` (see `globals.css`).
  * `bar-glow` is the shared "demands attention" treatment used for both
- * `pending_approval` and `blocked` (UI "Failed"); the glow color is then
- * resolved from the task's status class (`s-pending`, `s-blocked`).
+ * `paused` (e.g. checkpoint) and `failed`; the glow color is then resolved
+ * from the task's status class (`s-paused`, `s-failed`).
  */
 export type TaskBarState =
   | "bar-locked"
@@ -60,11 +60,14 @@ export function barClass(
   switch (task.status) {
     case "complete":
       return "bar-complete";
-    case "active":
+    case "in_progress":
+    case "running":
       return "bar-active";
-    case "pending_approval":
-    case "blocked":
+    case "paused":
+    case "failed":
       return "bar-glow";
+    case "waiting":
+      return "bar-locked";
     case "not_started":
     default:
       return isReady ? "bar-ready" : "bar-locked";

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -1,8 +1,15 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import type {
+  DrawerData,
   FrameworkItem,
   FrameworkItemType,
+  OutputArtifact,
+  PlaybookOutput,
+  PlaybookOutputKind,
+  TaskInputState,
+  TaskOutput,
+  TaskOutputStatus,
   WorkflowEvent,
   WorkflowEventInput,
   WorkflowInput,
@@ -52,12 +59,46 @@ interface WorkflowTaskRow {
   status: WorkflowTask["status"];
   substatus: string;
   checkpoint: boolean;
-  triggers: unknown;
-  gates: unknown;
+  inputs: unknown;
   playbook_id: string | null;
   owners: unknown;
+  paused_reason: string | null;
+  paused_by: string | null;
+  paused_at: string | null;
   created_at: string;
   updated_at: string;
+}
+
+interface PlaybookOutputRow {
+  id: string;
+  playbook_id: string;
+  name: string;
+  description: string | null;
+  kind: PlaybookOutputKind | null;
+  api_check: unknown;
+  position: number;
+  created_at: string;
+}
+
+interface TaskOutputRow {
+  id: string;
+  task_id: string;
+  output_id: string;
+  status: TaskOutputStatus;
+  artifact_url: string | null;
+  artifact_meta: unknown;
+  produced_by: string | null;
+  produced_at: string | null;
+  created_at: string;
+}
+
+interface TaskInputRow {
+  id: string;
+  task_id: string;
+  input_id: string;
+  received: boolean;
+  received_at: string | null;
+  received_from: string | null;
 }
 
 interface WorkflowEventRow {
@@ -123,63 +164,90 @@ function migrateSkills(raw: unknown): WorkflowSkill[] {
   return toJsonArray<unknown>(raw).map(migrateSkill);
 }
 
-const DATA_FLOW_TRIGGER_TYPES = new Set(["task", "after_task"]);
+const VALID_LINK_MODES = new Set(["linked", "manual", "bypass"]);
 
 /**
- * Read shim. Until PR 2 (AEL-60) renames the JSONB column, the legacy
- * `triggers` array still arrives from the database. We drop trigger items
- * whose `type` is not a data-flow type (`manual`, `event`, `schedule`,
- * `webhook`) and map the survivors into the new `WorkflowInput` shape.
+ * Read the `inputs` JSONB column directly (PR 2 / AEL-60). Defensively
+ * tolerates rows authored before the column rename: if a row still carries
+ * the old trigger shape (`type: 'task' | 'after_task'`), map it forward
+ * into a `linked` input on read. New rows are always written in the
+ * canonical `WorkflowInput` shape via `inputsToJsonb`.
  */
 function normalizeInputs(raw: unknown): WorkflowInput[] {
   return toJsonArray<Record<string, unknown>>(raw)
-    .filter(
-      (item) =>
-        item != null &&
-        typeof item.type === "string" &&
-        DATA_FLOW_TRIGGER_TYPES.has(item.type),
-    )
-    .map((item) => {
-      const ref =
-        typeof item.taskRef === "string" && item.taskRef.trim()
-          ? item.taskRef.trim()
-          : typeof item.taskId === "string" && item.taskId.trim()
-            ? item.taskId.trim()
-            : undefined;
-      const id =
-        typeof item.id === "string" && item.id.trim()
-          ? item.id.trim()
-          : `linked:${ref ?? "unknown"}`;
+    .map((item): WorkflowInput | null => {
+      if (item == null) return null;
+
+      // Legacy trigger shape — best-effort forward map. New rows never hit
+      // this branch because writes go through inputsToJsonb.
+      if (typeof item.type === "string" && !item.linkMode) {
+        if (item.type !== "task" && item.type !== "after_task") return null;
+        const ref =
+          typeof item.taskRef === "string" && item.taskRef.trim()
+            ? item.taskRef.trim()
+            : typeof item.taskId === "string" && item.taskId.trim()
+              ? item.taskId.trim()
+              : undefined;
+        const id =
+          typeof item.id === "string" && item.id.trim()
+            ? item.id.trim()
+            : `linked:${ref ?? "unknown"}`;
+        const name =
+          typeof item.label === "string" && item.label.trim()
+            ? item.label.trim()
+            : ref ?? "Linked input";
+        return {
+          id,
+          name,
+          linkMode: "linked" as const,
+          upstreamTaskRef: ref,
+          upstreamOutputId: null,
+        } satisfies WorkflowInput;
+      }
+
+      const linkMode =
+        typeof item.linkMode === "string" && VALID_LINK_MODES.has(item.linkMode)
+          ? (item.linkMode as WorkflowInput["linkMode"])
+          : "linked";
+      const id = typeof item.id === "string" && item.id.trim() ? item.id.trim() : null;
+      if (!id) return null;
       const name =
-        typeof item.label === "string" && item.label.trim()
-          ? item.label.trim()
-          : ref ?? "Linked input";
+        typeof item.name === "string" && item.name.trim()
+          ? item.name.trim()
+          : id;
+      const upstreamTaskRef =
+        typeof item.upstreamTaskRef === "string" && item.upstreamTaskRef.trim()
+          ? item.upstreamTaskRef.trim()
+          : undefined;
+      const upstreamOutputId =
+        typeof item.upstreamOutputId === "string" && item.upstreamOutputId.trim()
+          ? item.upstreamOutputId.trim()
+          : null;
+      const description =
+        typeof item.description === "string" && item.description.trim()
+          ? item.description.trim()
+          : undefined;
       return {
         id,
         name,
-        linkMode: "linked" as const,
-        upstreamTaskRef: ref,
-        upstreamOutputId: null,
-      };
-    });
+        description,
+        linkMode,
+        upstreamTaskRef,
+        upstreamOutputId,
+      } satisfies WorkflowInput;
+    })
+    .filter((value): value is WorkflowInput => value !== null);
 }
 
-/**
- * Write shim. PR 2 will rewrite this once the column is renamed; for now,
- * we serialize `WorkflowInput[]` back into the legacy JSONB shape on the
- * `triggers` column. Only `linked` inputs round-trip through the legacy
- * column — `manual` / `bypass` inputs have no representation in the old
- * schema, so they are dropped on write until PR 2 lands.
- */
-function inputsToLegacyTriggers(inputs: WorkflowInput[]): unknown[] {
-  return inputs
-    .filter((input) => input.linkMode === "linked")
-    .map((input) => ({
-      type: "task" as const,
-      label: input.name,
-      taskRef: input.upstreamTaskRef,
-      id: input.id,
-    }));
+function inputsToJsonb(inputs: WorkflowInput[]): unknown[] {
+  return inputs.map((input) => ({
+    id: input.id,
+    name: input.name,
+    description: input.description ?? null,
+    linkMode: input.linkMode,
+    upstreamTaskRef: input.upstreamTaskRef ?? null,
+    upstreamOutputId: input.upstreamOutputId ?? null,
+  }));
 }
 
 function mapTemplate(row: WorkflowTemplateRow): WorkflowTemplate {
@@ -229,13 +297,54 @@ function mapTask(row: WorkflowTaskRow): WorkflowTask {
     status: row.status,
     substatus: row.substatus,
     checkpoint: row.checkpoint,
-    inputs: normalizeInputs(row.triggers),
+    inputs: normalizeInputs(row.inputs),
     playbookId: row.playbook_id,
     owners: toJsonArray<unknown>(row.owners)
       .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
       .map((value) => value.trim()),
+    pausedReason: row.paused_reason,
+    pausedBy: row.paused_by,
+    pausedAt: row.paused_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+  };
+}
+
+function mapPlaybookOutput(row: PlaybookOutputRow): PlaybookOutput {
+  return {
+    id: row.id,
+    playbookId: row.playbook_id,
+    name: row.name,
+    description: row.description,
+    kind: row.kind,
+    apiCheck: (row.api_check as Record<string, unknown> | null) ?? null,
+    position: row.position,
+    createdAt: row.created_at,
+  };
+}
+
+function mapTaskOutput(row: TaskOutputRow): TaskOutput {
+  return {
+    id: row.id,
+    taskId: row.task_id,
+    outputId: row.output_id,
+    status: row.status,
+    artifactUrl: row.artifact_url,
+    artifactMeta: (row.artifact_meta as Record<string, unknown> | null) ?? null,
+    producedBy: row.produced_by,
+    producedAt: row.produced_at,
+    createdAt: row.created_at,
+  };
+}
+
+function mapTaskInput(row: TaskInputRow): TaskInputState {
+  return {
+    id: row.id,
+    taskId: row.task_id,
+    inputId: row.input_id,
+    received: row.received,
+    receivedAt: row.received_at,
+    receivedFrom: row.received_from,
   };
 }
 
@@ -283,11 +392,12 @@ function patchToRow(patch: WorkflowTaskPatch): Record<string, unknown> {
   if (patch.status !== undefined) row.status = patch.status;
   if (patch.substatus !== undefined) row.substatus = patch.substatus;
   if (patch.checkpoint !== undefined) row.checkpoint = patch.checkpoint;
-  if (patch.inputs !== undefined) {
-    row.triggers = inputsToLegacyTriggers(patch.inputs);
-  }
+  if (patch.inputs !== undefined) row.inputs = inputsToJsonb(patch.inputs);
   if (patch.playbookId !== undefined) row.playbook_id = patch.playbookId;
   if (patch.owners !== undefined) row.owners = patch.owners;
+  if (patch.pausedReason !== undefined) row.paused_reason = patch.pausedReason;
+  if (patch.pausedBy !== undefined) row.paused_by = patch.pausedBy;
+  if (patch.pausedAt !== undefined) row.paused_at = patch.pausedAt;
   return row;
 }
 
@@ -415,12 +525,21 @@ export function createWorkflowRepository(
       taskId: string,
       nextStatus: WorkflowCheckpointTransitionStatus,
     ): Promise<WorkflowTask | null> {
+      // Approve resumes the task (clears the pause); reject leaves it
+      // failed for the matrix glow to surface. Both clear paused_* so the
+      // banner does not linger after the human decision.
       const { data, error } = await client
         .from("workflow_tasks")
-        .update({ status: nextStatus })
+        .update({
+          status: nextStatus,
+          paused_reason: null,
+          paused_by: null,
+          paused_at: null,
+        })
         .eq("id", taskId)
         .eq("checkpoint", true)
-        .eq("status", "pending_approval")
+        .eq("status", "paused")
+        .eq("paused_reason", "checkpoint")
         .select("*")
         .maybeSingle();
 
@@ -529,8 +648,7 @@ export function createWorkflowRepository(
             status: "not_started" as const,
             substatus: "",
             checkpoint: tpl.checkpoint ?? false,
-            triggers: inputsToLegacyTriggers(tpl.inputs ?? []),
-            gates: [],
+            inputs: inputsToJsonb(tpl.inputs ?? []),
             playbook_id: tpl.playbookId ?? null,
             owners: tpl.owners ?? [],
           }),
@@ -585,8 +703,7 @@ export function createWorkflowRepository(
           status: "not_started",
           substatus: "",
           checkpoint: input.checkpoint ?? false,
-          triggers: inputsToLegacyTriggers(input.inputs ?? []),
-          gates: [],
+          inputs: inputsToJsonb(input.inputs ?? []),
           playbook_id: input.playbookId ?? null,
           owners: input.owners ?? [],
         })
@@ -785,6 +902,170 @@ export function createWorkflowRepository(
         .single();
 
       return mapEvent(unwrap("addInstanceEvent", data, error) as WorkflowEventRow);
+    },
+
+    async getDrawerData(taskId: string): Promise<DrawerData | null> {
+      const { data: taskRow, error: taskErr } = await client
+        .from("workflow_tasks")
+        .select("*")
+        .eq("id", taskId)
+        .maybeSingle();
+
+      if (taskErr) {
+        throw new WorkflowRepositoryError("getDrawerData task failed", taskErr);
+      }
+      if (!taskRow) return null;
+      const task = mapTask(taskRow as WorkflowTaskRow);
+
+      const [inputsRes, outputsRes] = await Promise.all([
+        client
+          .from("task_inputs")
+          .select("*")
+          .eq("task_id", taskId)
+          .order("input_id", { ascending: true }),
+        client
+          .from("task_outputs")
+          .select("*")
+          .eq("task_id", taskId)
+          .order("created_at", { ascending: true }),
+      ]);
+
+      if (inputsRes.error) {
+        throw new WorkflowRepositoryError("getDrawerData inputs failed", inputsRes.error);
+      }
+      if (outputsRes.error) {
+        throw new WorkflowRepositoryError("getDrawerData outputs failed", outputsRes.error);
+      }
+
+      let playbookOutputs: PlaybookOutput[] = [];
+      if (task.playbookId) {
+        const { data: poRows, error: poErr } = await client
+          .from("playbook_outputs")
+          .select("*")
+          .eq("playbook_id", task.playbookId)
+          .order("position", { ascending: true });
+        if (poErr) {
+          throw new WorkflowRepositoryError("getDrawerData playbook_outputs failed", poErr);
+        }
+        playbookOutputs = (poRows ?? []).map((row) =>
+          mapPlaybookOutput(row as PlaybookOutputRow),
+        );
+      }
+
+      return {
+        task,
+        inputs: (inputsRes.data ?? []).map((row) => mapTaskInput(row as TaskInputRow)),
+        outputs: (outputsRes.data ?? []).map((row) => mapTaskOutput(row as TaskOutputRow)),
+        playbookOutputs,
+      };
+    },
+
+    async markInputReceived(taskId: string, inputId: string): Promise<TaskInputState> {
+      const { data, error } = await client
+        .from("task_inputs")
+        .upsert(
+          {
+            task_id: taskId,
+            input_id: inputId,
+            received: true,
+            received_at: new Date().toISOString(),
+            received_from: null,
+          },
+          { onConflict: "task_id,input_id" },
+        )
+        .select("*")
+        .single();
+
+      return mapTaskInput(unwrap("markInputReceived", data, error) as TaskInputRow);
+    },
+
+    async bypassInput(taskId: string, inputId: string): Promise<TaskInputState> {
+      // Same shape as markInputReceived but kept as a separate method so the
+      // audit trail (events) can distinguish manual receipt from a skip.
+      const { data, error } = await client
+        .from("task_inputs")
+        .upsert(
+          {
+            task_id: taskId,
+            input_id: inputId,
+            received: true,
+            received_at: new Date().toISOString(),
+            received_from: null,
+          },
+          { onConflict: "task_id,input_id" },
+        )
+        .select("*")
+        .single();
+
+      return mapTaskInput(unwrap("bypassInput", data, error) as TaskInputRow);
+    },
+
+    async produceOutput(
+      taskId: string,
+      outputId: string,
+      artifact?: OutputArtifact,
+    ): Promise<TaskOutput> {
+      const { data, error } = await client
+        .from("task_outputs")
+        .upsert(
+          {
+            task_id: taskId,
+            output_id: outputId,
+            status: "produced",
+            artifact_url: artifact?.artifactUrl ?? null,
+            artifact_meta: artifact?.artifactMeta ?? null,
+            produced_by: artifact?.producedBy ?? null,
+            produced_at: new Date().toISOString(),
+          },
+          { onConflict: "task_id,output_id" },
+        )
+        .select("*")
+        .single();
+
+      return mapTaskOutput(unwrap("produceOutput", data, error) as TaskOutputRow);
+    },
+
+    async pauseTask(
+      taskId: string,
+      reason: string,
+      pausedBy?: string | null,
+    ): Promise<WorkflowTask> {
+      const trimmedReason = reason.trim();
+      if (!trimmedReason) {
+        throw new WorkflowRepositoryError("pauseTask: reason is required");
+      }
+      const { data, error } = await client
+        .from("workflow_tasks")
+        .update({
+          status: "paused",
+          paused_reason: trimmedReason,
+          paused_by: pausedBy ?? null,
+          paused_at: new Date().toISOString(),
+        })
+        .eq("id", taskId)
+        .select("*")
+        .single();
+
+      return mapTask(unwrap("pauseTask", data, error) as WorkflowTaskRow);
+    },
+
+    async resumeTask(taskId: string): Promise<WorkflowTask> {
+      // Resume sends the task back to in_progress and clears the pause
+      // metadata. Callers (server actions) re-run deriveStatus afterwards
+      // to pick up any inputs/outputs that changed during the pause.
+      const { data, error } = await client
+        .from("workflow_tasks")
+        .update({
+          status: "in_progress",
+          paused_reason: null,
+          paused_by: null,
+          paused_at: null,
+        })
+        .eq("id", taskId)
+        .select("*")
+        .single();
+
+      return mapTask(unwrap("resumeTask", data, error) as WorkflowTaskRow);
     },
 
     async getFrameworkItems(type?: FrameworkItemType): Promise<FrameworkItem[]> {

--- a/products/dashboard/lib/workflows/task-status.ts
+++ b/products/dashboard/lib/workflows/task-status.ts
@@ -1,33 +1,53 @@
 import type { WorkflowTaskStatus } from "@/lib/workflows/types";
 
+/**
+ * 7-state design enum (PR 2 / AEL-60). Render code reads the persisted
+ * status; `deriveStatus()` is the single source of truth for transitions.
+ *
+ * Pill class names map to existing CSS variables in `app/globals.css`:
+ * `--pill-{state}-d` (dark/foreground) and `--pill-{state}-l` (light/bg).
+ * Variables for the new states (`waiting`, `paused`, `in_progress`,
+ * `running`, `failed`) are kept aligned with the old pill family so the
+ * stylesheet does not need a parallel rewrite — `pending → paused`,
+ * `active → in_progress`, `blocked → failed`. New `waiting` and `running`
+ * fall back to the `pending` / `active` palettes respectively.
+ */
 export const TASK_STATUS_LABEL: Record<WorkflowTaskStatus, string> = {
-  complete: "Complete",
-  active: "In progress",
-  pending_approval: "Pending approval",
-  blocked: "Failed",
   not_started: "Not started",
+  waiting: "Waiting",
+  paused: "Paused",
+  in_progress: "In progress",
+  running: "Running",
+  complete: "Complete",
+  failed: "Failed",
 };
 
 export const TASK_STATUS_PILL_CLASS: Record<WorkflowTaskStatus, string> = {
-  complete: "s-complete",
-  active: "s-active",
-  pending_approval: "s-pending",
-  blocked: "s-blocked",
   not_started: "s-not_started",
+  waiting: "s-waiting",
+  paused: "s-paused",
+  in_progress: "s-in_progress",
+  running: "s-running",
+  complete: "s-complete",
+  failed: "s-failed",
 };
 
 export const TASK_STATUS_ORDER: readonly WorkflowTaskStatus[] = [
   "not_started",
-  "active",
-  "pending_approval",
+  "waiting",
+  "paused",
+  "in_progress",
+  "running",
   "complete",
-  "blocked",
+  "failed",
 ];
 
 export const TASK_STATUS_VAR: Record<WorkflowTaskStatus, string> = {
-  complete: "var(--pill-complete-d)",
-  active: "var(--pill-active-d)",
-  pending_approval: "var(--pill-pending-d)",
-  blocked: "var(--pill-blocked-d)",
   not_started: "var(--pill-ns-d)",
+  waiting: "var(--pill-pending-d)",
+  paused: "var(--pill-pending-d)",
+  in_progress: "var(--pill-active-d)",
+  running: "var(--pill-active-d)",
+  complete: "var(--pill-complete-d)",
+  failed: "var(--pill-blocked-d)",
 };

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -8,19 +8,32 @@ export type WorkflowInstanceStatus =
   | "blocked"
   | "complete";
 
+/**
+ * The 7-state design enum (PR 2 / AEL-60). `running` is the transient
+ * sub-state of `in_progress` while an agent is actively executing. Render
+ * code reads the persisted column; `deriveStatus()` is the single source
+ * of truth for transitions on every server action that mutates task state.
+ */
 export type WorkflowTaskStatus =
   | "not_started"
-  | "active"
-  | "pending_approval"
-  | "blocked"
-  | "complete";
+  | "waiting"
+  | "paused"
+  | "in_progress"
+  | "running"
+  | "complete"
+  | "failed";
+
+/** Alias used by drawer/UI code that wants the explicit "status" name. */
+export type TaskStatus = WorkflowTaskStatus;
 
 /**
  * Legal terminal states for `WorkflowRepository.transitionPendingCheckpoint`.
+ * Drawer-checkpoint approve resumes (status flips to `in_progress`); reject
+ * surfaces as `failed` so the matrix glow lights up.
  */
 export type WorkflowCheckpointTransitionStatus =
-  | Extract<WorkflowTaskStatus, "complete">
-  | Extract<WorkflowTaskStatus, "blocked">;
+  | Extract<WorkflowTaskStatus, "in_progress">
+  | Extract<WorkflowTaskStatus, "failed">;
 
 export type FrameworkItemType = "skill" | "playbook";
 
@@ -106,8 +119,74 @@ export interface WorkflowTask {
    *  Per-task so two cards pointing at the same playbook can carry different
    *  owners (e.g. different sales people across instances). */
   owners: string[];
+  /** Why the task is paused (e.g. `'checkpoint'`, `'awaiting_input'`).
+   *  Drives the drawer pause banner; null when status !== 'paused'. */
+  pausedReason?: string | null;
+  pausedBy?: string | null;
+  pausedAt?: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Outputs and per-task IO state (PR 2 / AEL-60). `PlaybookOutput` is the
+// definition-level record stored on a Playbook; `TaskOutput` and
+// `TaskInputState` are per-task-instance state that the drawer consumes.
+// ---------------------------------------------------------------------------
+
+export type PlaybookOutputKind = "file" | "media" | "link" | "manual" | "api";
+
+export interface PlaybookOutput {
+  id: string;
+  playbookId: string;
+  name: string;
+  description?: string | null;
+  kind: PlaybookOutputKind | null;
+  apiCheck?: Record<string, unknown> | null;
+  position: number;
+  createdAt: string;
+}
+
+export type TaskOutputStatus = "pending" | "produced" | "failed" | "skipped";
+
+export interface TaskOutput {
+  id: string;
+  taskId: string;
+  outputId: string;
+  status: TaskOutputStatus;
+  artifactUrl?: string | null;
+  artifactMeta?: Record<string, unknown> | null;
+  producedBy?: string | null;
+  producedAt?: string | null;
+  createdAt: string;
+}
+
+export interface TaskInputState {
+  id: string;
+  taskId: string;
+  inputId: string;
+  received: boolean;
+  receivedAt?: string | null;
+  receivedFrom?: string | null;
+}
+
+/**
+ * Bundle returned by `WorkflowRepository.getDrawerData` so the drawer can
+ * render with one round-trip: the task itself, its per-instance input/output
+ * state, and the underlying playbook's output definitions.
+ */
+export interface DrawerData {
+  task: WorkflowTask;
+  inputs: TaskInputState[];
+  outputs: TaskOutput[];
+  playbookOutputs: PlaybookOutput[];
+}
+
+/** Optional artifact payload accepted by `produceOutputAction`. */
+export interface OutputArtifact {
+  artifactUrl?: string | null;
+  artifactMeta?: Record<string, unknown> | null;
+  producedBy?: string | null;
 }
 
 export interface WorkflowTaskCreateInput {
@@ -187,6 +266,9 @@ export interface WorkflowTaskPatch {
   inputs?: WorkflowInput[];
   playbookId?: string | null;
   owners?: string[];
+  pausedReason?: string | null;
+  pausedBy?: string | null;
+  pausedAt?: string | null;
 }
 
 export interface WorkflowTemplatePatch {
@@ -240,6 +322,27 @@ export interface WorkflowRepository {
     instanceId: string,
     event: WorkflowEventInput & { taskId?: string | null },
   ): Promise<WorkflowEvent>;
+  /** Drawer-shaped read: task + per-instance input/output state +
+   *  the underlying playbook's output definitions, in one round-trip. */
+  getDrawerData(taskId: string): Promise<DrawerData | null>;
+  /** Mark a manual input as received. Idempotent (received=true stays true). */
+  markInputReceived(taskId: string, inputId: string): Promise<TaskInputState>;
+  /** Bypass an input. Sets received=true with received_from=null so the
+   *  audit trail can distinguish "produced upstream" from "skipped". */
+  bypassInput(taskId: string, inputId: string): Promise<TaskInputState>;
+  /** Produce a task output. Flips status='produced' (which fires the
+   *  on_task_output_produced trigger). Inserts the row if missing. */
+  produceOutput(
+    taskId: string,
+    outputId: string,
+    artifact?: OutputArtifact,
+  ): Promise<TaskOutput>;
+  pauseTask(
+    taskId: string,
+    reason: string,
+    pausedBy?: string | null,
+  ): Promise<WorkflowTask>;
+  resumeTask(taskId: string): Promise<WorkflowTask>;
   getFrameworkItems(type?: FrameworkItemType): Promise<FrameworkItem[]>;
   upsertFrameworkItem(item: FrameworkItem): Promise<FrameworkItem>;
   deleteFrameworkItem(itemId: string): Promise<void>;

--- a/products/dashboard/supabase/migrations/20260507120000_playbook_outputs_and_status.sql
+++ b/products/dashboard/supabase/migrations/20260507120000_playbook_outputs_and_status.sql
@@ -1,0 +1,252 @@
+-- PR 2 / AEL-60 — Playbook Drawer redesign schema spine.
+--
+-- Builds on PR 1 (AEL-59) which renamed triggers/gates → inputs in the
+-- TypeScript layer. This migration finishes the rename on the database side
+-- and lays the new IO-state spine the redesigned drawer (PR 3) will consume:
+--
+--   * Rename workflow_tasks.triggers → inputs (gate column dropped).
+--   * Extend workflow_tasks.status from the legacy 5-value enum to the
+--     7-value design enum (not_started | waiting | paused | in_progress |
+--     running | complete | failed) and migrate existing rows.
+--   * Add paused_reason / paused_by / paused_at to workflow_tasks.
+--   * Create playbook_outputs (definition-level), task_outputs and
+--     task_inputs (per-instance state).
+--   * Install on_task_output_produced trigger that auto-flips downstream
+--     task_inputs.received when an upstream output reaches 'produced'.
+--   * Backfill task_inputs rows for already-existing tasks so live work
+--     does not appear blocked after deploy.
+--
+-- RLS follows the existing single-tenant V1 pattern (DEC-002, see
+-- 20260419120000_workflow_persistence.sql lines 9-11 and 164-168). The
+-- Linear issue mentions org-scoped policies, but this codebase has no
+-- org_id column yet — coarse "authenticated using (true)" stays consistent
+-- and tightening lands with the future multi-tenant migration.
+
+-- ---------------------------------------------------------------------------
+-- 1. Rename triggers → inputs and drop gates.
+-- ---------------------------------------------------------------------------
+alter table public.workflow_tasks rename column triggers to inputs;
+alter table public.workflow_tasks drop column if exists gates;
+
+-- ---------------------------------------------------------------------------
+-- 2. Pause-state columns. Added before the status row migration so the
+--    UPDATE below can populate paused_reason in one pass.
+-- ---------------------------------------------------------------------------
+alter table public.workflow_tasks
+  add column if not exists paused_reason text,
+  add column if not exists paused_by     text,
+  add column if not exists paused_at     timestamptz;
+
+-- ---------------------------------------------------------------------------
+-- 3. Status enum: drop the legacy CHECK constraint, migrate rows, then add
+--    the new constraint covering all 7 design states.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  con text;
+begin
+  select conname into con
+    from pg_constraint
+   where conrelid = 'public.workflow_tasks'::regclass
+     and contype = 'c'
+     and pg_get_constraintdef(oid) ilike '%status%';
+  if con is not null then
+    execute format('alter table public.workflow_tasks drop constraint %I', con);
+  end if;
+end $$;
+
+-- pending_approval → paused (with checkpoint reason); active → in_progress;
+-- blocked → failed. paused_at is set to now() so the UI banner has a
+-- timestamp; paused_by stays null since the original actor is unknown.
+update public.workflow_tasks
+   set status = case status
+                  when 'active'           then 'in_progress'
+                  when 'blocked'          then 'failed'
+                  when 'pending_approval' then 'paused'
+                  else status
+                end,
+       paused_reason = case
+                         when status = 'pending_approval' then 'checkpoint'
+                         else paused_reason
+                       end,
+       paused_at = case
+                     when status = 'pending_approval' and paused_at is null then now()
+                     else paused_at
+                   end
+ where status in ('active', 'blocked', 'pending_approval');
+
+alter table public.workflow_tasks
+  add constraint workflow_tasks_status_check
+    check (status in (
+      'not_started',
+      'waiting',
+      'paused',
+      'in_progress',
+      'running',
+      'complete',
+      'failed'
+    ));
+
+comment on column public.workflow_tasks.paused_reason is
+  'Why this task is paused (e.g. ''checkpoint'', ''awaiting_input''). Drives the drawer pause banner. Null when status != ''paused''.';
+
+-- ---------------------------------------------------------------------------
+-- 4. playbook_outputs — definition-level outputs declared on a Playbook.
+--    Outputs of one task become Inputs of others (wired via
+--    workflow_tasks.inputs[].upstreamOutputId, populated by the editor in
+--    a follow-up PR; until then outputs are admin-creatable via SQL).
+-- ---------------------------------------------------------------------------
+create table if not exists public.playbook_outputs (
+  id           uuid primary key default gen_random_uuid(),
+  playbook_id  text not null
+                 references public.framework_items(id) on delete cascade,
+  name         text not null,
+  description  text,
+  kind         text check (kind in ('file', 'media', 'link', 'manual', 'api')),
+  api_check    jsonb,
+  position     int not null default 0,
+  created_at   timestamptz not null default now(),
+  unique (playbook_id, name)
+);
+
+create index if not exists playbook_outputs_playbook_id_idx
+  on public.playbook_outputs (playbook_id);
+
+comment on table public.playbook_outputs is
+  'Outputs declared on a Playbook definition. One playbook has 1-3 outputs typically; outputs become inputs of downstream tasks via WorkflowInput.upstreamOutputId.';
+
+-- ---------------------------------------------------------------------------
+-- 5. task_outputs — per-task-instance output state. One row per
+--    (task, playbook_output) pair, materialized when the task starts
+--    (or backfilled lazily) and flipped to 'produced' when the artifact
+--    is delivered.
+-- ---------------------------------------------------------------------------
+create table if not exists public.task_outputs (
+  id            uuid primary key default gen_random_uuid(),
+  task_id       uuid not null
+                  references public.workflow_tasks(id) on delete cascade,
+  output_id     uuid not null
+                  references public.playbook_outputs(id) on delete cascade,
+  status        text not null default 'pending'
+                  check (status in ('pending', 'produced', 'failed', 'skipped')),
+  artifact_url  text,
+  artifact_meta jsonb,
+  produced_by   text,
+  produced_at   timestamptz,
+  created_at    timestamptz not null default now(),
+  unique (task_id, output_id)
+);
+
+create index if not exists task_outputs_task_id_idx
+  on public.task_outputs (task_id);
+
+comment on table public.task_outputs is
+  'Per-task instance state for each declared playbook output. Producing one (status=''produced'') triggers on_task_output_produced to satisfy downstream linked inputs.';
+
+-- ---------------------------------------------------------------------------
+-- 6. task_inputs — per-task-instance input state. One row per
+--    WorkflowInput (matched by input_id, the JSONB id field). For linked
+--    inputs the trigger below flips received=true automatically; manual
+--    inputs are flipped by markInputReceivedAction; bypass inputs are
+--    inserted with received=true at task creation.
+-- ---------------------------------------------------------------------------
+create table if not exists public.task_inputs (
+  id             uuid primary key default gen_random_uuid(),
+  task_id        uuid not null
+                   references public.workflow_tasks(id) on delete cascade,
+  input_id       text not null,
+  received       boolean not null default false,
+  received_at    timestamptz,
+  received_from  uuid references public.task_outputs(id) on delete set null,
+  unique (task_id, input_id)
+);
+
+create index if not exists task_inputs_task_id_idx
+  on public.task_inputs (task_id);
+
+comment on table public.task_inputs is
+  'Per-task instance state for each WorkflowInput. received=true unblocks the task (deriveStatus moves it from waiting → not_started/in_progress).';
+
+-- ---------------------------------------------------------------------------
+-- 7. Auto-satisfy trigger. When a task_outputs row reaches status='produced',
+--    walk every workflow_tasks row whose inputs[].upstreamOutputId points
+--    at NEW.output_id and upsert task_inputs(received=true) for the
+--    matching input slot. Runs in the same transaction as the producing
+--    write so downstream readiness is visible immediately.
+-- ---------------------------------------------------------------------------
+create or replace function public.on_task_output_produced()
+returns trigger
+language plpgsql
+as $$
+begin
+  if NEW.status = 'produced'
+     and (TG_OP = 'INSERT' or OLD.status is distinct from 'produced') then
+    with downstream as (
+      select t.id as task_id,
+             (input_def ->> 'id') as input_id
+        from public.workflow_tasks t,
+             jsonb_array_elements(coalesce(t.inputs, '[]'::jsonb)) as input_def
+       where (input_def ->> 'upstreamOutputId') = NEW.output_id::text
+         and (input_def ->> 'id') is not null
+    )
+    insert into public.task_inputs (task_id, input_id, received, received_at, received_from)
+    select task_id, input_id, true, now(), NEW.id
+      from downstream
+        on conflict (task_id, input_id)
+        do update set received      = true,
+                      received_at   = excluded.received_at,
+                      received_from = excluded.received_from;
+  end if;
+  return NEW;
+end $$;
+
+drop trigger if exists task_outputs_on_produced on public.task_outputs;
+create trigger task_outputs_on_produced
+  after insert or update of status on public.task_outputs
+  for each row execute function public.on_task_output_produced();
+
+-- ---------------------------------------------------------------------------
+-- 8. Backfill task_inputs rows for tasks that already exist. Tasks past
+--    not_started are treated as already-unblocked so live work does not
+--    appear blocked after deploy; not_started tasks stay received=false
+--    so the new waiting state actually engages.
+-- ---------------------------------------------------------------------------
+insert into public.task_inputs (task_id, input_id, received, received_at)
+select t.id,
+       (i ->> 'id'),
+       (t.status <> 'not_started'),
+       case when t.status <> 'not_started' then now() else null end
+  from public.workflow_tasks t,
+       jsonb_array_elements(coalesce(t.inputs, '[]'::jsonb)) as i
+ where (i ->> 'id') is not null
+on conflict (task_id, input_id) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 9. RLS — match the coarse "authenticated using (true)" pattern from
+--    workflow_tasks etc. (DEC-002, single-tenant V1). Org-scoped policies
+--    arrive with the future multi-tenant migration.
+-- ---------------------------------------------------------------------------
+alter table public.playbook_outputs enable row level security;
+alter table public.task_outputs     enable row level security;
+alter table public.task_inputs      enable row level security;
+
+drop policy if exists "playbook_outputs: authenticated read"  on public.playbook_outputs;
+drop policy if exists "playbook_outputs: authenticated write" on public.playbook_outputs;
+create policy "playbook_outputs: authenticated read"
+  on public.playbook_outputs for select to authenticated using (true);
+create policy "playbook_outputs: authenticated write"
+  on public.playbook_outputs for all to authenticated using (true) with check (true);
+
+drop policy if exists "task_outputs: authenticated read"  on public.task_outputs;
+drop policy if exists "task_outputs: authenticated write" on public.task_outputs;
+create policy "task_outputs: authenticated read"
+  on public.task_outputs for select to authenticated using (true);
+create policy "task_outputs: authenticated write"
+  on public.task_outputs for all to authenticated using (true) with check (true);
+
+drop policy if exists "task_inputs: authenticated read"  on public.task_inputs;
+drop policy if exists "task_inputs: authenticated write" on public.task_inputs;
+create policy "task_inputs: authenticated read"
+  on public.task_inputs for select to authenticated using (true);
+create policy "task_inputs: authenticated write"
+  on public.task_inputs for all to authenticated using (true) with check (true);


### PR DESCRIPTION
## Summary

PR 2 of the [Playbook Drawer redesign (AEL-58)](https://linear.app/aelizondo/issue/AEL-58). PR 1 ([#213](https://github.com/andelizondo/ai-native-framework/pull/213)) renamed triggers/gates → inputs at the runtime/TS layer; this PR finishes the rename on the SQL side and lays the new spine the redesigned drawer (PR 3) will consume.

- **Migration** (\`20260507120000_playbook_outputs_and_status.sql\`):
  - Renames \`workflow_tasks.triggers → inputs\`, drops \`gates\`.
  - Extends the persisted status CHECK to the 7 design states (\`not_started | waiting | paused | in_progress | running | complete | failed\`) and migrates existing rows (\`active → in_progress\`, \`blocked → failed\`, \`pending_approval → paused\` with \`paused_reason='checkpoint'\`).
  - Adds \`paused_reason / paused_by / paused_at\` to \`workflow_tasks\`.
  - Creates \`playbook_outputs\` (definition-level), \`task_outputs\` and \`task_inputs\` (per-task instance state).
  - Installs \`on_task_output_produced\` trigger that auto-flips downstream \`task_inputs.received\` when an upstream output reaches \`'produced'\`.
  - Backfills \`task_inputs\` rows for existing tasks (received=true for everything past \`not_started\` so live work doesn't appear blocked after deploy).
- **TypeScript**:
  - \`lib/workflows/derive-status.ts\` — pure reconciler called by every server action that mutates task state.
  - \`lib/workflows/classify-owner.ts\` — agent vs. person from the \`agent:\` prefix.
  - \`lib/workflows/types.ts\` — extends \`WorkflowTaskStatus\`, adds \`PlaybookOutput\`/\`TaskOutput\`/\`TaskInputState\`/\`DrawerData\`, extends repository contract.
  - \`lib/workflows/repository.ts\` — drops the legacy trigger shim, adds \`getDrawerData\`, \`markInputReceived\`, \`bypassInput\`, \`produceOutput\`, \`pauseTask\`, \`resumeTask\`.
  - \`app/(dashboard)/workflows/actions.ts\` — new IO actions; drawer checkpoint approve/reject route through pause/resume; \`startTaskAction\` precondition becomes \"all linked inputs received and not paused\".
- **Drawer/matrix consumers** (process-matrix, task-card, task-drawer, agent-run-panel, aggregate) updated to the new enum.

### Notes / deviations from spec

- **Org-scoped RLS.** Linear issue mentions org-scoped policies, but this codebase is single-tenant V1 (DEC-002). Used the existing coarse \`authenticated using (true)\` pattern; tightening lands with the future multi-tenant migration.
- **\`refinePlaybookAction\`** is a stub that emits an event — no agent runtime is wired in this PR; PR 3 will wire it.
- No \`lib/supabase/database.types.ts\` exists in this repo (types are inline in repository.ts), so the type-regen step from the spec was skipped.

## Test plan

- [x] \`npx tsc --noEmit\` clean on changed files (3 pre-existing errors in unrelated test files remain on main).
- [x] \`npm run lint\` — 0 errors.
- [x] \`npm run test\` — **281 / 281 passing**, including new \`derive-status.test.ts\` (12 cases) and \`classify-owner.test.ts\` (5 cases).
- [ ] \`npx supabase db reset\` on a fresh DB — migration replays cleanly. (Manual verification.)
- [ ] Staging migration + spot-check: \`select count(*) from workflow_tasks where status in ('active','blocked','pending_approval')\` returns 0.
- [ ] Manually flip a \`task_outputs.status\` to \`'produced'\` and observe downstream \`task_inputs.received=true\` via the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)