### PR TITLE
fix(dashboard): restore matrix task-card status tints + glow for 7-state taxonomy

### DIFF
--- a/products/dashboard/app/styles/components/process-matrix.css
+++ b/products/dashboard/app/styles/components/process-matrix.css
@@ -1061,13 +1061,15 @@
 .mx-floating-tooltip-sub.s-complete {
   color: var(--pill-complete-t);
 }
-.mx-floating-tooltip-sub.s-active {
+.mx-floating-tooltip-sub.s-in_progress,
+.mx-floating-tooltip-sub.s-running {
   color: var(--pill-active-t);
 }
-.mx-floating-tooltip-sub.s-pending {
+.mx-floating-tooltip-sub.s-waiting {
   color: var(--pill-pending-t);
 }
-.mx-floating-tooltip-sub.s-blocked {
+.mx-floating-tooltip-sub.s-paused,
+.mx-floating-tooltip-sub.s-failed {
   color: var(--pill-blocked-t);
 }
 .mx-floating-tooltip-sub.s-not_started {

--- a/products/dashboard/app/styles/components/task-card.css
+++ b/products/dashboard/app/styles/components/task-card.css
@@ -90,15 +90,16 @@
 }
 /* Generic "demands attention" treatment: full-opacity bar with a pulsing
  * glow whose color is taken from the task's status class via the
- * `--bar-glow-color` var. Used for `pending_approval` (amber, awaiting
- * approval) and `blocked`/failed (red, needs intervention). */
+ * `--bar-glow-color` var. Used for `paused` (red, awaiting human action)
+ * and `failed` (red, needs intervention). The 7-state model collapses
+ * the old amber `pending_approval` into `paused` with a `paused_reason`. */
 .task-card.bar-glow {
   --bar-glow-color: var(--role-color, var(--border));
 }
-.task-card.s-pending.bar-glow {
-  --bar-glow-color: var(--pill-pending-d);
+.task-card.s-paused.bar-glow {
+  --bar-glow-color: var(--pill-blocked-d);
 }
-.task-card.s-blocked.bar-glow {
+.task-card.s-failed.bar-glow {
   --bar-glow-color: var(--pill-blocked-d);
 }
 .task-card.bar-glow::before {
@@ -140,29 +141,38 @@
   opacity: 0.8;
 }
 /* Faint status-tinted wash on every card except `not_started` — keeps a row
- * of cards readable as a sequence of states (blue→amber→green→…) without
- * needing to read the pill. The mix ratio is small enough to stay quiet
- * under the title and pill, and the variable resolves per status class. */
-.task-card.s-active,
-.task-card.s-pending,
-.task-card.s-blocked,
-.task-card.s-complete {
+ * of cards readable as a sequence of states (amber→red→blue→green→…)
+ * without needing to read the pill. The mix ratio is small enough to stay
+ * quiet under the title and pill, and the variable resolves per status
+ * class. PR 2 (AEL-60) extended the taxonomy to 7 states; the wash maps:
+ *  waiting → pending palette, paused/failed → blocked, in_progress/running
+ *  → active, complete → complete. */
+.task-card.s-waiting,
+.task-card.s-paused,
+.task-card.s-in_progress,
+.task-card.s-running,
+.task-card.s-complete,
+.task-card.s-failed {
   background: color-mix(in srgb, var(--card-wash, transparent) 5%, var(--bg-2));
 }
-.task-card.s-active:hover,
-.task-card.s-pending:hover,
-.task-card.s-blocked:hover,
-.task-card.s-complete:hover {
+.task-card.s-waiting:hover,
+.task-card.s-paused:hover,
+.task-card.s-in_progress:hover,
+.task-card.s-running:hover,
+.task-card.s-complete:hover,
+.task-card.s-failed:hover {
   background: color-mix(in srgb, var(--card-wash, transparent) 8%, var(--bg-3));
 }
-.task-card.s-active {
-  --card-wash: var(--pill-active-d);
-}
-.task-card.s-pending {
+.task-card.s-waiting {
   --card-wash: var(--pill-pending-d);
 }
-.task-card.s-blocked {
+.task-card.s-paused,
+.task-card.s-failed {
   --card-wash: var(--pill-blocked-d);
+}
+.task-card.s-in_progress,
+.task-card.s-running {
+  --card-wash: var(--pill-active-d);
 }
 .task-card.s-complete {
   --card-wash: var(--pill-complete-d);
@@ -432,21 +442,47 @@
   background: var(--pill-complete-bg);
   --pill-stroke: color-mix(in srgb, var(--pill-complete-d) 30%, var(--border));
 }
-.s-active .s-pill {
+.s-in_progress .s-pill,
+.s-running .s-pill {
   background: var(--pill-active-bg);
   --pill-stroke: color-mix(in srgb, var(--pill-active-d) 30%, var(--border));
 }
-.s-pending .s-pill {
+.s-waiting .s-pill {
   background: var(--pill-pending-bg);
   --pill-stroke: color-mix(in srgb, var(--pill-pending-d) 30%, var(--border));
 }
-.s-blocked .s-pill {
+.s-paused .s-pill,
+.s-failed .s-pill {
   background: var(--pill-blocked-bg);
   --pill-stroke: color-mix(in srgb, var(--pill-blocked-d) 30%, var(--border));
 }
 .s-not_started .s-pill {
   background: var(--pill-ns-bg);
   --pill-stroke: color-mix(in srgb, var(--pill-ns-d) 30%, var(--border));
+}
+/* `running` is a transient sub-state of `in_progress`; nudge the pill
+ * with a soft pulse so the matrix communicates that an agent is actively
+ * executing without changing the underlying color family. */
+.s-running .s-pill {
+  animation: tc-running-pulse 1.6s ease-in-out infinite;
+}
+@keyframes tc-running-pulse {
+  0%,
+  100% {
+    box-shadow:
+      inset 0 0 0 1px var(--pill-stroke, transparent),
+      0 0 0 0 color-mix(in srgb, var(--pill-active-d) 50%, transparent);
+  }
+  50% {
+    box-shadow:
+      inset 0 0 0 1px var(--pill-stroke, transparent),
+      0 0 0 4px color-mix(in srgb, var(--pill-active-d) 18%, transparent);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .s-running .s-pill {
+    animation: none;
+  }
 }
 .s-text {
   font-size: 9.5px;
@@ -457,13 +493,15 @@
 .s-complete .s-text {
   color: var(--pill-complete-t);
 }
-.s-active .s-text {
+.s-in_progress .s-text,
+.s-running .s-text {
   color: var(--pill-active-t);
 }
-.s-pending .s-text {
+.s-waiting .s-text {
   color: var(--pill-pending-t);
 }
-.s-blocked .s-text {
+.s-paused .s-text,
+.s-failed .s-text {
   color: var(--pill-blocked-t);
 }
 .s-not_started .s-text {


### PR DESCRIPTION
## Summary

Follow-up fix to [PR #216](https://github.com/andelizondo/ai-native-framework/pull/216) (AEL-61). PR 2 (AEL-60) renamed the status pill classes from `s-active|s-pending|s-blocked|s-complete|s-not_started` to the 7-state names (`s-not_started|s-waiting|s-paused|s-in_progress|s-running|s-complete|s-failed`) in the TypeScript lookup tables, but `task-card.css` and `process-matrix.css` still keyed off the old names — so the per-status background wash, pill fill, pill text color, and `bar-glow` accent silently stopped applying once a card had a 7-state status.

PR #216 made it visible by exercising the new states through the playbook drawer; this PR restores the original styling by mapping the new class names to the existing pill palettes per the documented mapping in `task-status.ts`:

- `waiting` → pending palette (amber)
- `paused` / `failed` → blocked palette (red)
- `in_progress` / `running` → active palette (sky/indigo)
- `complete` → complete palette (emerald)
- `not_started` → ns palette (neutral)

`running` additionally gets a soft pulsing ring on the pill so the matrix communicates that an agent is actively executing without changing the underlying color family. Reduced-motion users opt out via the existing `prefers-reduced-motion` media query.

`bar-glow` keys off `s-paused` / `s-failed` (both red) — the old `pending_approval` collapsed into `paused` per the design.

No TS/component changes; CSS-only.

## Test plan

- [x] `npm test` — all 299 tests pass
- [ ] Manual: open `/workflows/<instance>` and confirm matrix cards render with status tints, hover wash, status-badge fills, `bar-glow` for paused/failed, pulsing ring on running

🤖 Generated with [Claude Code](https://claude.com/claude-code)