### PR TITLE
feat(dashboard): matrix card pips + unmet-input glyph (AEL-62)

### DIFF
--- a/products/dashboard/__tests__/components/workflows/playbook-drawer.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/playbook-drawer.test.tsx
@@ -130,6 +130,7 @@ function makeInstance(): WorkflowInstanceDetail {
     skills: SKILLS,
     tasks: [],
     events: [],
+    taskIO: [],
     createdAt: "2026-05-10T00:00:00Z",
     updatedAt: "2026-05-10T00:00:00Z",
   };

--- a/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
@@ -119,6 +119,7 @@ function instance(tasks: WorkflowTask[]): WorkflowInstanceDetail {
     updatedAt: "2026-04-19T12:00:00Z",
     tasks,
     events: [],
+    taskIO: tasks.map((t) => ({ taskId: t.id, outputs: [], hasUnmetLinkedInput: false })),
   };
 }
 
@@ -195,6 +196,29 @@ describe("ProcessMatrix", () => {
 
     const validation = screen.getByTestId("matrix-stage-validation");
     expect(within(validation).getAllByTestId(/^matrix-pip-/)).toHaveLength(1);
+  });
+
+  it("forwards instance.taskIO to TaskCard so output pips render on the matrix", () => {
+    const inst = instance([
+      task({ id: "io-1", skillId: "sales-ops", stageId: "pre-sales", status: "in_progress" }),
+    ]);
+    inst.taskIO = [
+      {
+        taskId: "io-1",
+        outputs: [
+          { id: "out-a", position: 0, status: "produced" },
+          { id: "out-b", position: 1, status: "pending" },
+        ],
+        hasUnmetLinkedInput: true,
+      },
+    ];
+
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} />);
+
+    expect(screen.getByTestId("task-pip-rail-io-1")).toBeInTheDocument();
+    expect(screen.getByTestId("task-pip-io-1-out-a").dataset.status).toBe("produced");
+    expect(screen.getByTestId("task-pip-io-1-out-b").dataset.status).toBe("pending");
+    expect(screen.getByTestId("task-unmet-input-io-1")).toBeInTheDocument();
   });
 
   it("toggles the role-collapsed class and hides labels when the toggle is pressed", async () => {

--- a/products/dashboard/__tests__/components/workflows/task-card.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/task-card.test.tsx
@@ -158,6 +158,111 @@ describe("TaskCard", () => {
     expect(badge.className).toContain("tc-info-badge--error");
   });
 
+  describe("IO state — output pips and unmet linked-input glyph", () => {
+    it("renders one filled pip per produced output and hollow pips otherwise", () => {
+      render(
+        <TaskCard
+          task={task({ id: "io-card" })}
+          playbook={PLAYBOOK}
+          skillColor="#6366f1"
+          barState="bar-active"
+          ioState={{
+            taskId: "io-card",
+            outputs: [
+              { id: "o-1", position: 0, status: "produced" },
+              { id: "o-2", position: 1, status: "pending" },
+              { id: "o-3", position: 2, status: "pending" },
+            ],
+            hasUnmetLinkedInput: false,
+          }}
+        />,
+      );
+      expect(screen.getByTestId("task-pip-rail-io-card")).toBeInTheDocument();
+      expect(screen.getByTestId("task-pip-io-card-o-1").dataset.status).toBe("produced");
+      expect(screen.getByTestId("task-pip-io-card-o-2").dataset.status).toBe("pending");
+      expect(screen.getByTestId("task-pip-io-card-o-3").dataset.status).toBe("pending");
+    });
+
+    it("marks failed outputs with the failed data-status (renders as a ring)", () => {
+      render(
+        <TaskCard
+          task={task({ id: "io-failed" })}
+          playbook={PLAYBOOK}
+          skillColor="#6366f1"
+          barState="bar-glow"
+          ioState={{
+            taskId: "io-failed",
+            outputs: [{ id: "o-1", position: 0, status: "failed" }],
+            hasUnmetLinkedInput: false,
+          }}
+        />,
+      );
+      expect(screen.getByTestId("task-pip-io-failed-o-1").dataset.status).toBe("failed");
+    });
+
+    it("does not render the pip rail when ioState is omitted (template view)", () => {
+      render(
+        <TaskCard
+          task={task({ id: "io-none" })}
+          playbook={PLAYBOOK}
+          skillColor="#6366f1"
+          barState="bar-ready"
+        />,
+      );
+      expect(screen.queryByTestId("task-pip-rail-io-none")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("task-unmet-input-io-none")).not.toBeInTheDocument();
+    });
+
+    it("does not render the pip rail when ioState carries no outputs", () => {
+      render(
+        <TaskCard
+          task={task({ id: "io-empty" })}
+          playbook={PLAYBOOK}
+          skillColor="#6366f1"
+          barState="bar-ready"
+          ioState={{ taskId: "io-empty", outputs: [], hasUnmetLinkedInput: false }}
+        />,
+      );
+      expect(screen.queryByTestId("task-pip-rail-io-empty")).not.toBeInTheDocument();
+    });
+
+    it("renders the unmet-input glyph when a linked input is unsatisfied", () => {
+      render(
+        <TaskCard
+          task={task({ id: "io-waiting" })}
+          playbook={PLAYBOOK}
+          skillColor="#6366f1"
+          barState="bar-locked"
+          ioState={{
+            taskId: "io-waiting",
+            outputs: [],
+            hasUnmetLinkedInput: true,
+          }}
+        />,
+      );
+      const glyph = screen.getByTestId("task-unmet-input-io-waiting");
+      expect(glyph).toBeInTheDocument();
+      expect(glyph).toHaveAttribute("aria-label", "Waiting on upstream output");
+    });
+
+    it("omits the unmet-input glyph when all linked inputs are received", () => {
+      render(
+        <TaskCard
+          task={task({ id: "io-ok" })}
+          playbook={PLAYBOOK}
+          skillColor="#6366f1"
+          barState="bar-active"
+          ioState={{
+            taskId: "io-ok",
+            outputs: [{ id: "o-1", position: 0, status: "produced" }],
+            hasUnmetLinkedInput: false,
+          }}
+        />,
+      );
+      expect(screen.queryByTestId("task-unmet-input-io-ok")).not.toBeInTheDocument();
+    });
+  });
+
   it("renders the checkpoint pip only when the task has checkpoint: true", () => {
     const { rerender } = render(
       <TaskCard

--- a/products/dashboard/app/styles/components/task-card.css
+++ b/products/dashboard/app/styles/components/task-card.css
@@ -209,6 +209,48 @@
    * the status pill upward — keeps the pill on a stable baseline. */
   min-height: calc(1.3em * 2);
 }
+/* Output pip rail (PR 4 / AEL-62). Sits between the title and the status
+ * row. One pip per declared `playbook_outputs` row, sorted by position. The
+ * rail itself only mounts when the parent passes `ioState` with at least one
+ * output, so the template editor (which has no IO) keeps its prior layout. */
+.tc-pip-rail {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  height: 6px;
+  margin-top: 2px;
+}
+.tc-pip {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: 1px solid var(--border-2);
+  background: transparent;
+  transition: background 0.15s, border-color 0.15s;
+}
+/* Reuse the existing pill-* tokens as the canonical "ok" / "err" semantic
+ * colors — the spec called for `--ok` / `--err` but those don't exist in
+ * the token set and these are the matching emerald / red anchors. */
+.tc-pip[data-status="produced"] {
+  background: var(--pill-complete-d);
+  border-color: var(--pill-complete-d);
+}
+.tc-pip[data-status="failed"] {
+  background: transparent;
+  border-color: var(--pill-blocked-d);
+}
+.tc-pip[data-status="skipped"] {
+  background: transparent;
+  border-style: dashed;
+}
+.tc-unmet-input-glyph {
+  color: var(--t3);
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
 .tc-status-row {
   display: flex;
   align-items: center;

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -180,6 +180,11 @@ export function ProcessMatrix({
     [playbookOptions],
   );
 
+  const ioByTaskId = useMemo(
+    () => new Map((instance.taskIO ?? []).map((io) => [io.taskId, io])),
+    [instance.taskIO],
+  );
+
   const handleStatusChange = useCallback(
     (taskId: string, next: WorkflowTaskStatus) => {
       const previous = localTasks.find((t) => t.id === taskId);
@@ -846,6 +851,7 @@ export function ProcessMatrix({
                                 skillColor={skillColor}
                                 barState={barClass(task, canStart(task, localTasks))}
                                 editMode={editMode}
+                                ioState={ioByTaskId.get(task.id)}
                                 onClick={
                                   editMode
                                     ? undefined

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -5,6 +5,7 @@ import {
   AlertTriangle,
   Check,
   CircleAlert,
+  CornerUpRight,
   Pencil,
   StickyNote,
   Trash2,
@@ -23,6 +24,7 @@ import {
 } from "@/lib/workflows/task-status";
 import type {
   FrameworkItem,
+  TaskIOSummary,
   WorkflowTask,
   WorkflowTaskStatus,
 } from "@/lib/workflows/types";
@@ -49,6 +51,10 @@ export interface TaskCardProps {
   /** Called when the user picks a new status from the badge popover.
    *  Omit to render the status badge as a static pill (no popover). */
   onStatusChange?: (next: WorkflowTaskStatus) => void;
+  /** Per-task IO state used to render the output pip rail and the
+   *  unmet-linked-input glyph. Omit (e.g. on the template editor) to
+   *  suppress both affordances. */
+  ioState?: TaskIOSummary;
 }
 
 export function TaskCard({
@@ -62,6 +68,7 @@ export function TaskCard({
   onRemove,
   templateView = false,
   onStatusChange,
+  ioState,
 }: TaskCardProps) {
   const statusClass = TASK_STATUS_PILL_CLASS[task.status];
   const statusLabel = TASK_STATUS_LABEL[task.status];
@@ -100,7 +107,37 @@ export function TaskCard({
     >
       <div className="tc-top">
         <div className="tc-title">{title}</div>
+        {ioState?.hasUnmetLinkedInput ? (
+          <span
+            className="tc-unmet-input-glyph"
+            role="img"
+            aria-label="Waiting on upstream output"
+            title="Waiting on upstream output"
+            data-testid={`task-unmet-input-${task.id}`}
+          >
+            <CornerUpRight aria-hidden size={11} strokeWidth={2.1} />
+          </span>
+        ) : null}
       </div>
+      {ioState && ioState.outputs.length > 0 ? (
+        <div
+          className="tc-pip-rail"
+          role="list"
+          aria-label="Outputs progress"
+          data-testid={`task-pip-rail-${task.id}`}
+        >
+          {ioState.outputs.map((output) => (
+            <span
+              key={output.id}
+              role="listitem"
+              className="tc-pip"
+              data-status={output.status}
+              data-testid={`task-pip-${task.id}-${output.id}`}
+              aria-label={`Output ${output.position + 1}: ${output.status}`}
+            />
+          ))}
+        </div>
+      ) : null}
       <div className="tc-status-row">
         {templateView ? (
           <div

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -7,6 +7,7 @@ import type {
   OutputArtifact,
   PlaybookOutput,
   PlaybookOutputKind,
+  TaskIOSummary,
   TaskInputState,
   TaskOutput,
   TaskOutputStatus,
@@ -422,6 +423,89 @@ export class WorkflowRepositoryError extends Error {
   }
 }
 
+/**
+ * Batch-load per-task IO state for an instance: outputs progress (one row per
+ * `playbook_outputs` declaration, joined with the matching `task_outputs`
+ * status if present) and a boolean flag for any unsatisfied `linked` input.
+ *
+ * Three queries scoped to the instance's task ids — small fixed cost regardless
+ * of task count, so the matrix avoids per-card fetches.
+ */
+async function loadInstanceTaskIO(
+  client: SupabaseClient,
+  tasks: WorkflowTask[],
+): Promise<TaskIOSummary[]> {
+  if (tasks.length === 0) return [];
+  const taskIds = tasks.map((t) => t.id);
+  const playbookIds = Array.from(
+    new Set(tasks.map((t) => t.playbookId).filter((id): id is string => Boolean(id))),
+  );
+
+  const [pbOutputsRes, taskOutputsRes, taskInputsRes] = await Promise.all([
+    playbookIds.length > 0
+      ? client
+          .from("playbook_outputs")
+          .select("*")
+          .in("playbook_id", playbookIds)
+          .order("position", { ascending: true })
+      : Promise.resolve({ data: [], error: null } as const),
+    client.from("task_outputs").select("*").in("task_id", taskIds),
+    client.from("task_inputs").select("*").in("task_id", taskIds),
+  ]);
+
+  if (pbOutputsRes.error) {
+    throw new WorkflowRepositoryError("loadInstanceTaskIO playbook_outputs failed", pbOutputsRes.error);
+  }
+  if (taskOutputsRes.error) {
+    throw new WorkflowRepositoryError("loadInstanceTaskIO task_outputs failed", taskOutputsRes.error);
+  }
+  if (taskInputsRes.error) {
+    throw new WorkflowRepositoryError("loadInstanceTaskIO task_inputs failed", taskInputsRes.error);
+  }
+
+  const pbOutputsByPlaybook = new Map<string, PlaybookOutputRow[]>();
+  for (const row of (pbOutputsRes.data ?? []) as PlaybookOutputRow[]) {
+    const list = pbOutputsByPlaybook.get(row.playbook_id) ?? [];
+    list.push(row);
+    pbOutputsByPlaybook.set(row.playbook_id, list);
+  }
+
+  const taskOutputByTaskAndOutput = new Map<string, TaskOutputRow>();
+  for (const row of (taskOutputsRes.data ?? []) as TaskOutputRow[]) {
+    taskOutputByTaskAndOutput.set(`${row.task_id}::${row.output_id}`, row);
+  }
+
+  const receivedInputsByTask = new Map<string, Set<string>>();
+  for (const row of (taskInputsRes.data ?? []) as TaskInputRow[]) {
+    if (!row.received) continue;
+    const set = receivedInputsByTask.get(row.task_id) ?? new Set<string>();
+    set.add(row.input_id);
+    receivedInputsByTask.set(row.task_id, set);
+  }
+
+  return tasks.map((task) => {
+    const pbOutputs = task.playbookId
+      ? (pbOutputsByPlaybook.get(task.playbookId) ?? [])
+      : [];
+    const outputs = pbOutputs
+      .slice()
+      .sort((a, b) => a.position - b.position)
+      .map((po) => {
+        const tor = taskOutputByTaskAndOutput.get(`${task.id}::${po.id}`);
+        return {
+          id: po.id,
+          position: po.position,
+          status: (tor?.status ?? "pending") as TaskOutputStatus,
+        };
+      });
+    const received = receivedInputsByTask.get(task.id) ?? new Set<string>();
+    const hasUnmetLinkedInput = task.inputs.some(
+      (input) => input.linkMode === "linked" && !received.has(input.id),
+    );
+    return { taskId: task.id, outputs, hasUnmetLinkedInput };
+  });
+}
+
 function unwrap<T>(label: string, data: T | null, error: unknown): T {
   if (error) {
     throw new WorkflowRepositoryError(`${label} failed`, error);
@@ -498,10 +582,14 @@ export function createWorkflowRepository(
         throw new WorkflowRepositoryError("getInstance events failed", eventsErr);
       }
 
+      const tasks = (taskRows ?? []).map((row) => mapTask(row as WorkflowTaskRow));
+      const taskIO = await loadInstanceTaskIO(client, tasks);
+
       return {
         ...mapInstance(instanceRow as WorkflowInstanceRow),
-        tasks: (taskRows ?? []).map((row) => mapTask(row as WorkflowTaskRow)),
+        tasks,
         events: (eventRows ?? []).map((row) => mapEvent(row as WorkflowEventRow)),
+        taskIO,
       };
     },
 
@@ -668,7 +756,8 @@ export function createWorkflowRepository(
         tasks = (insertedTasks ?? []).map((row) => mapTask(row as WorkflowTaskRow));
       }
 
-      return { ...instance, tasks, events: [] };
+      const taskIO = await loadInstanceTaskIO(client, tasks);
+      return { ...instance, tasks, events: [], taskIO };
     },
 
     async updateInstance(

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -226,6 +226,28 @@ export interface WorkflowInstance {
 export interface WorkflowInstanceDetail extends WorkflowInstance {
   tasks: WorkflowTask[];
   events: WorkflowEvent[];
+  /** Per-task IO summary — outputs progress + unmet linked-input flag —
+   *  batched into the instance fetch so the matrix can render pips/glyphs
+   *  on every card without an additional round-trip per card. One entry per
+   *  task in `tasks`; tasks with no declared outputs and no linked inputs
+   *  still appear with empty `outputs` and `hasUnmetLinkedInput: false`. */
+  taskIO: TaskIOSummary[];
+}
+
+/**
+ * Compact IO state used by `TaskCard` to render the output pip rail and the
+ * unmet linked-input glyph. Source data lives in `task_outputs` /
+ * `task_inputs` / `playbook_outputs`; this is the batched view.
+ */
+export interface TaskIOSummary {
+  taskId: string;
+  /** One entry per declared `playbook_outputs` row, sorted by `position`
+   *  ascending. `status` reflects the matching `task_outputs.status` if a
+   *  row exists, otherwise defaults to `"pending"`. */
+  outputs: { id: string; position: number; status: TaskOutputStatus }[];
+  /** True iff at least one `linked` input on the task has no `task_inputs`
+   *  row with `received=true`. */
+  hasUnmetLinkedInput: boolean;
 }
 
 export interface FrameworkItem {


### PR DESCRIPTION
## Summary

PR 4 of 4 for the [Playbook Drawer redesign](https://linear.app/aelizondo/issue/AEL-58) — closes [AEL-62](https://linear.app/aelizondo/issue/AEL-62).

Surfaces per-task IO state on each matrix `TaskCard`:

- **Output pips** — one circle per declared `playbook_outputs.position`. Filled when the matching `task_outputs.status === 'produced'`, ringed in red when `failed`, hollow otherwise. Sits in a 6px-tall rail between the title and status row.
- **Unmet linked-input glyph** — a small ⤴ (`CornerUpRight`, 11px, `var(--t3)`) next to the title when any `linked` input on the task has no `task_inputs.received=true` row, signalling "waiting on upstream output".

Both affordances render only when the parent passes the new optional `ioState` prop, so the template-editor view stays unchanged.

## Implementation

- `WorkflowInstanceDetail` gains a `taskIO: TaskIOSummary[]` field. `getInstance` (and `createInstance`) batch-loads it via three queries scoped to the instance's task ids — `playbook_outputs` for the declarations, `task_outputs` for status, `task_inputs` for received state. No per-card fetches.
- `ProcessMatrix` builds an in-memory `Map<taskId, TaskIOSummary>` once and passes the corresponding entry to each `TaskCard`. `MiniTaskCell` is intentionally skipped (no room for pips).

## Token deviation

The ticket specs `var(--ok)` / `var(--err)` for fill / ring colors. Those tokens don't exist in [tokens.css](products/dashboard/app/styles/tokens.css). Reused `--pill-complete-d` (emerald) and `--pill-blocked-d` (red) which are the canonical "ok / err" semantic anchors already used by status pills, rather than introducing new tokens.

## Test plan

- [x] `npm test` — 30 files / 306 tests passing
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — no new errors (the 7 pre-existing errors in `__tests__/auth/*` and `top-bar.test` predate this PR)
- [x] Unit: `task-card.test.tsx` covers produced / failed / pending / no-ioState / unmet-input glyph cases
- [x] Component: `process-matrix.test.tsx` confirms `instance.taskIO` propagates to the rendered cards
- [ ] Manual smoke (`npm run dev`): open an instance with declared outputs, flip one to `produced` via the drawer, confirm the matching pip fills; toggle `task_inputs.received=false` via SQL and confirm the ⤴ glyph appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)