### PR TITLE
feat(dashboard): input wiring picker (AEL-64)

### DIFF
--- a/products/dashboard/__tests__/components/workflows/add-playbook-modal.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/add-playbook-modal.test.tsx
@@ -1,0 +1,178 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AddPlaybookModal } from "@/components/workflows/add-playbook-modal";
+import { renderWithToast } from "@/tests/test-utils";
+import type {
+  FrameworkItem,
+  TemplateOutputGroup,
+  WorkflowInput,
+} from "@/lib/workflows/types";
+
+const PLAYBOOKS: FrameworkItem[] = [
+  {
+    id: "pb-presales",
+    type: "playbook",
+    name: "Presales",
+    description: "",
+    icon: null,
+    content: "",
+    allowedSkillIds: ["sk-pm"],
+  },
+];
+
+const OUTPUT_GROUPS: TemplateOutputGroup[] = [
+  {
+    playbookId: "pb-presales",
+    playbookName: "Presales",
+    outputs: [
+      {
+        id: "po-1",
+        playbookId: "pb-presales",
+        name: "report",
+        description: null,
+        kind: "file",
+        apiCheck: null,
+        position: 0,
+        createdAt: "2026-04-19T12:00:00Z",
+      },
+      {
+        id: "po-2",
+        playbookId: "pb-presales",
+        name: "deck",
+        description: null,
+        kind: "media",
+        apiCheck: null,
+        position: 1,
+        createdAt: "2026-04-19T12:00:00Z",
+      },
+    ],
+  },
+  {
+    playbookId: "pb-empty",
+    playbookName: "Empty",
+    outputs: [],
+  },
+];
+
+const UPSTREAM_TASKS = [
+  { id: "task-a", label: "Presales · Pre-Sales" },
+  { id: "task-b", label: "Empty · Validation" },
+];
+
+function renderModal(overrides: Partial<Parameters<typeof AddPlaybookModal>[0]> = {}) {
+  const onSubmit = vi.fn();
+  const onClose = vi.fn();
+  renderWithToast(
+    <AddPlaybookModal
+      mode="edit"
+      skillId="sk-pm"
+      skillLabel="PM"
+      stageId="pre-sales"
+      stageName="Pre-Sales"
+      playbooks={PLAYBOOKS}
+      initial={{ playbookId: "pb-presales" }}
+      upstreamTaskOptions={UPSTREAM_TASKS}
+      outputGroups={OUTPUT_GROUPS}
+      onClose={onClose}
+      onSubmit={onSubmit}
+      {...overrides}
+    />,
+  );
+  return { onSubmit, onClose };
+}
+
+describe("AddPlaybookModal — inputs editor", () => {
+  it("renders an empty-state placeholder when the task has no inputs", () => {
+    renderModal();
+    expect(screen.getByText(/No inputs declared/i)).toBeInTheDocument();
+  });
+
+  it("adds an input row, picks a playbook, then an output, and submits the wiring", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal();
+
+    await user.click(screen.getByTestId("add-input-row"));
+
+    const row = screen.getByTestId("input-row-0");
+    await user.type(within(row).getByLabelText("Input name"), "After PD");
+
+    // Step 1: pick the playbook.
+    await user.selectOptions(
+      within(row).getByLabelText("From playbook"),
+      "pb-presales",
+    );
+    // Step 2: pick the output.
+    await user.selectOptions(within(row).getByLabelText("Output"), "po-1");
+
+    // Wired chip appears with × clear.
+    expect(within(row).getByTestId("input-wiring-chip")).toHaveTextContent(
+      /Presales.*report/,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Save playbook/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0][0] as {
+      inputs: WorkflowInput[];
+    };
+    expect(submitted.inputs).toHaveLength(1);
+    expect(submitted.inputs[0]).toMatchObject({
+      name: "After PD",
+      linkMode: "linked",
+      upstreamOutputId: "po-1",
+    });
+  });
+
+  it("clearing the wiring resets upstreamOutputId to null while preserving the row", async () => {
+    const user = userEvent.setup();
+    const wired: WorkflowInput[] = [
+      {
+        id: "in-1",
+        name: "After PD",
+        linkMode: "linked",
+        upstreamTaskRef: "task-a",
+        upstreamOutputId: "po-1",
+      },
+    ];
+    const { onSubmit } = renderModal({ initial: { playbookId: "pb-presales", inputs: wired } });
+
+    const row = screen.getByTestId("input-row-0");
+    expect(within(row).getByTestId("input-wiring-chip")).toBeInTheDocument();
+
+    await user.click(within(row).getByLabelText("Clear wiring"));
+
+    // Chip is gone; the From-playbook select reappears.
+    expect(within(row).queryByTestId("input-wiring-chip")).toBeNull();
+    expect(within(row).getByLabelText("From playbook")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Save playbook/i }));
+    const submitted = onSubmit.mock.calls[0][0] as { inputs: WorkflowInput[] };
+    expect(submitted.inputs[0].upstreamOutputId).toBeNull();
+    expect(submitted.inputs[0].upstreamTaskRef).toBe("task-a");
+  });
+
+  it("renders the (no output wired) hint when only an upstream task is selected", () => {
+    const partial: WorkflowInput[] = [
+      {
+        id: "in-1",
+        name: "After PD",
+        linkMode: "linked",
+        upstreamTaskRef: "task-a",
+        upstreamOutputId: null,
+      },
+    ];
+    renderModal({ initial: { playbookId: "pb-presales", inputs: partial } });
+    expect(screen.getByText("(no output wired)")).toBeInTheDocument();
+  });
+
+  it("renders the Declare-an-output CTA when the chosen playbook has zero outputs", async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByTestId("add-input-row"));
+    const row = screen.getByTestId("input-row-0");
+    await user.selectOptions(within(row).getByLabelText("From playbook"), "pb-empty");
+    expect(within(row).getByText(/Declare an output on this playbook/i)).toBeInTheDocument();
+  });
+});

--- a/products/dashboard/__tests__/lib/workflows/repository.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/repository.test.ts
@@ -475,6 +475,52 @@ describe("workflow repository", () => {
       });
     });
 
+    it("round-trips inputs[].upstreamOutputId through update + createInstance", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+
+      await repo.updateTemplate("client-delivery", {
+        taskTemplates: [
+          {
+            id: "tt-a",
+            skillId: "sales-ops",
+            stageId: "pre-sales",
+            playbookId: "presales-qualification",
+            notes: "",
+            inputs: [],
+          },
+          {
+            id: "tt-b",
+            skillId: "pm",
+            stageId: "validation",
+            playbookId: "pdr-review",
+            notes: "",
+            checkpoint: true,
+            inputs: [
+              {
+                id: "in-1",
+                name: "After PD",
+                linkMode: "linked",
+                upstreamTaskRef: "tt-a",
+                upstreamOutputId: "po-1",
+              },
+            ],
+          },
+        ],
+      });
+
+      const instance = await repo.createInstance("client-delivery", "Acme");
+      const downstream = instance.tasks.find((t) => t.skillId === "pm");
+      expect(downstream?.inputs).toEqual([
+        {
+          id: "in-1",
+          name: "After PD",
+          linkMode: "linked",
+          upstreamTaskRef: "tt-a",
+          upstreamOutputId: "po-1",
+        },
+      ]);
+    });
+
     it("throws when updateTemplate receives an empty patch", async () => {
       const repo = createWorkflowRepository(makeFakeClient(store));
 
@@ -783,6 +829,85 @@ describe("workflow repository", () => {
           created_at: "2026-04-19T12:00:00Z",
         },
       ];
+    });
+
+    describe("listOutputsForTemplate", () => {
+      it("returns outputs grouped per attached playbook, sorted by playbook name", async () => {
+        store.workflow_templates.push({
+          id: "tpl-wired",
+          label: "Wired Template",
+          color: "#fff",
+          multi_instance: false,
+          stages: [],
+          skills: [],
+          task_templates: [
+            {
+              id: "t1",
+              skillId: "sk-pm",
+              stageId: "s1",
+              playbookId: "pb-presales",
+              notes: "",
+              inputs: [],
+            },
+            {
+              id: "t2",
+              skillId: "sk-pm",
+              stageId: "s2",
+              playbookId: "pb-empty",
+              notes: "",
+              inputs: [],
+            },
+          ],
+          created_at: "2026-04-19T12:00:00Z",
+          updated_at: "2026-04-19T12:00:00Z",
+        });
+        store.framework_items.push({
+          id: "pb-empty",
+          type: "playbook",
+          name: "ada-onboard",
+          description: "",
+          icon: null,
+          color: null,
+          content: "",
+          created_at: "2026-04-19T12:00:00Z",
+          updated_at: "2026-04-19T12:00:00Z",
+        });
+
+        const repo = createWorkflowRepository(makeFakeClient(store));
+        const groups = await repo.listOutputsForTemplate("tpl-wired");
+
+        expect(groups.map((g) => g.playbookName)).toEqual([
+          "ada-onboard",
+          "presales-qualification",
+        ]);
+        const presales = groups.find((g) => g.playbookId === "pb-presales");
+        expect(presales?.outputs.map((o) => o.name)).toEqual(["report", "deck"]);
+        const empty = groups.find((g) => g.playbookId === "pb-empty");
+        expect(empty?.outputs).toEqual([]);
+      });
+
+      it("returns an empty list when the template has no playbooks attached", async () => {
+        store.workflow_templates.push({
+          id: "tpl-bare",
+          label: "Bare",
+          color: "#fff",
+          multi_instance: false,
+          stages: [],
+          skills: [],
+          task_templates: [{ id: "t1", skillId: "sk-pm", stageId: "s1", playbookId: null, notes: "", inputs: [] }],
+          created_at: "2026-04-19T12:00:00Z",
+          updated_at: "2026-04-19T12:00:00Z",
+        });
+        const repo = createWorkflowRepository(makeFakeClient(store));
+        const groups = await repo.listOutputsForTemplate("tpl-bare");
+        expect(groups).toEqual([]);
+      });
+
+      it("returns an empty list when the template id is unknown", async () => {
+        const repo = createWorkflowRepository(makeFakeClient(store));
+        const groups = await repo.listOutputsForTemplate("nope");
+        expect(groups).toEqual([]);
+      });
     });
 
     it("listPlaybookOutputs returns rows for the playbook ordered by position", async () => {

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 
 import { captureError } from "@/lib/monitoring";
 import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
+import { WorkflowRepositoryError } from "@/lib/workflows/repository";
 import {
   pickPendingCheckpoints,
   type PendingCheckpoint,
@@ -13,11 +14,13 @@ import type {
   OutputArtifact,
   TaskInputState,
   TaskOutput,
+  TemplateOutputGroup,
   WorkflowInput,
   WorkflowInstance,
   WorkflowTask,
   WorkflowTaskCreateInput,
   WorkflowTaskStatus,
+  WorkflowTaskTemplate,
   WorkflowTemplate,
 } from "@/lib/workflows/types";
 
@@ -826,12 +829,52 @@ function normalizeTemplateSkills(
     .filter((skill) => skill.id && skill.label);
 }
 
+const MAX_INPUT_NAME_LENGTH = 80;
+const MAX_INPUT_DESCRIPTION_LENGTH = 240;
+const MAX_INPUT_REF_LENGTH = 120;
+
+function normalizeTemplateInputs(inputs: unknown): WorkflowInput[] {
+  if (!Array.isArray(inputs)) return [];
+  const seenIds = new Set<string>();
+  const normalized: WorkflowInput[] = [];
+  for (const raw of inputs as WorkflowInput[]) {
+    if (!raw || typeof raw !== "object") continue;
+    const id = normalizeTaskField(raw.id ?? "", "input.id", MAX_INPUT_REF_LENGTH);
+    if (!id || seenIds.has(id)) continue;
+    seenIds.add(id);
+    const linkMode =
+      raw.linkMode === "manual" || raw.linkMode === "bypass" ? raw.linkMode : "linked";
+    const name =
+      normalizeTaskField(raw.name ?? "", "input.name", MAX_INPUT_NAME_LENGTH) || id;
+    const description =
+      typeof raw.description === "string" && raw.description.trim()
+        ? raw.description.trim().slice(0, MAX_INPUT_DESCRIPTION_LENGTH)
+        : undefined;
+    const upstreamTaskRef =
+      typeof raw.upstreamTaskRef === "string" && raw.upstreamTaskRef.trim()
+        ? raw.upstreamTaskRef.trim().slice(0, MAX_INPUT_REF_LENGTH)
+        : undefined;
+    const upstreamOutputId =
+      typeof raw.upstreamOutputId === "string" && raw.upstreamOutputId.trim()
+        ? raw.upstreamOutputId.trim().slice(0, MAX_INPUT_REF_LENGTH)
+        : null;
+    normalized.push({
+      id,
+      name,
+      description,
+      linkMode,
+      upstreamTaskRef,
+      upstreamOutputId,
+    });
+  }
+  return normalized;
+}
+
 function normalizeTemplateTaskTemplates(
   taskTemplates: WorkflowTemplate["taskTemplates"],
-): WorkflowTemplate["taskTemplates"] {
+): WorkflowTaskTemplate[] {
   return taskTemplates
-    .map((task) => ({
-      ...task,
+    .map<WorkflowTaskTemplate>((task) => ({
       id: normalizeTaskField(task.id ?? "", "taskTemplate.id", 120),
       skillId: normalizeTaskField(task.skillId, "taskTemplate.skillId", 80),
       stageId: normalizeTaskField(task.stageId, "taskTemplate.stageId", 80),
@@ -839,11 +882,57 @@ function normalizeTemplateTaskTemplates(
         ? normalizeTaskField(task.playbookId, "taskTemplate.playbookId", MAX_PLAYBOOK_LENGTH)
         : null,
       notes: normalizeTaskField(task.notes ?? "", "taskTemplate.notes", MAX_NOTES_LENGTH),
-      inputs: task.inputs ?? [],
+      inputs: normalizeTemplateInputs(task.inputs),
       checkpoint: Boolean(task.checkpoint),
       owners: normalizeOwnerList(task.owners) ?? [],
     }))
     .filter((task) => task.id && task.skillId && task.stageId);
+}
+
+/**
+ * Cross-check `upstreamOutputId`s on the normalized task templates against
+ * the playbooks attached to the same template. Throws a friendly error if
+ * any wired output id no longer belongs to one of the template's playbooks
+ * (the picker showed it once but the underlying output was deleted or
+ * moved). The client refetches `listOutputsForTemplateAction` and retries.
+ */
+async function assertWiredOutputsBelongToTemplate(
+  taskTemplates: WorkflowTaskTemplate[],
+): Promise<void> {
+  const wiredIds = Array.from(
+    new Set(
+      taskTemplates.flatMap((task) =>
+        (task.inputs ?? [])
+          .map((input) => input.upstreamOutputId)
+          .filter((id): id is string => typeof id === "string" && id.trim().length > 0),
+      ),
+    ),
+  );
+  if (wiredIds.length === 0) return;
+
+  const allowedPlaybookIds = new Set(
+    taskTemplates
+      .map((task) => task.playbookId)
+      .filter((id): id is string => typeof id === "string" && id.trim().length > 0),
+  );
+
+  const repo = await getServerWorkflowRepository();
+  const groups = new Map<string, string>();
+  for (const id of allowedPlaybookIds) {
+    const outputs = await repo.listPlaybookOutputs(id);
+    for (const output of outputs) groups.set(output.id, id);
+  }
+
+  for (const id of wiredIds) {
+    const owner = groups.get(id);
+    if (!owner || !allowedPlaybookIds.has(owner)) {
+      throw new WorkflowRepositoryError(
+        "That wired output is no longer available on this template — please re-pick.",
+        null,
+        { code: "stale_output_ref" },
+      );
+    }
+  }
 }
 
 export async function updateTemplateAction(
@@ -858,19 +947,40 @@ export async function updateTemplateAction(
     throw new Error("updateTemplateAction: template label is required");
   }
 
+  const normalizedTaskTemplates = normalizeTemplateTaskTemplates(template.taskTemplates);
+  await assertWiredOutputsBelongToTemplate(normalizedTaskTemplates);
+
   const repo = await getServerWorkflowRepository();
   const updatedTemplate = await repo.updateTemplate(trimmedTemplateId, {
     label: trimTemplateLabel(template.label),
     color: normalizeTemplateColor(template.color),
     stages: normalizeTemplateStages(template.stages),
     skills: normalizeTemplateSkills(template.skills),
-    taskTemplates: normalizeTemplateTaskTemplates(template.taskTemplates),
+    taskTemplates: normalizedTaskTemplates,
   });
 
   revalidatePath("/", "layout");
   revalidatePath(`/workflows/templates/${trimmedTemplateId}/edit`);
 
   return { template: updatedTemplate };
+}
+
+/**
+ * Outputs grouped per playbook attached to the given template — drives the
+ * input-wiring picker in the template editor. The picker scope is limited
+ * to the template's own playbooks so wiring stays visually local; a
+ * downstream task can only reference outputs from another task already on
+ * the same template (per AEL-64 spec).
+ */
+export async function listOutputsForTemplateAction(
+  templateId: string,
+): Promise<TemplateOutputGroup[]> {
+  const trimmedTemplateId = normalizeTaskField(templateId, "templateId", 120);
+  if (!trimmedTemplateId) {
+    throw new Error("listOutputsForTemplateAction: templateId is required");
+  }
+  const repo = await getServerWorkflowRepository();
+  return repo.listOutputsForTemplate(trimmedTemplateId);
 }
 
 export async function renameTemplateAction(

--- a/products/dashboard/components/workflows/add-playbook-modal.tsx
+++ b/products/dashboard/components/workflows/add-playbook-modal.tsx
@@ -2,13 +2,18 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Search, SearchX } from "lucide-react";
+import { Plus, Search, SearchX, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { ItemAvatar } from "@/components/framework/item-avatar";
 import { OwnerPicker } from "@/components/framework/owner-picker";
 import { resolveItemColor } from "@/lib/workflows/skill-colors";
-import type { FrameworkItem } from "@/lib/workflows/types";
+import { InputOutputPicker } from "@/components/workflows/input-output-picker";
+import type {
+  FrameworkItem,
+  TemplateOutputGroup,
+  WorkflowInput,
+} from "@/lib/workflows/types";
 
 interface AddPlaybookModalProps {
   mode?: "create" | "edit";
@@ -23,9 +28,29 @@ interface AddPlaybookModalProps {
     playbookId?: string | null;
     notes?: string;
     owners?: readonly string[];
+    inputs?: readonly WorkflowInput[];
   };
+  /** Other tasks in the same template — populates the upstream-task select. */
+  upstreamTaskOptions?: { id: string; label: string }[];
+  /** Outputs grouped per attached playbook — populates the wiring picker. */
+  outputGroups?: TemplateOutputGroup[];
+  /** Called by the picker when it wants the parent to refetch (e.g. a
+   *  stale-ref save error has fired and the user is reopening the modal). */
+  onRefetchOutputs?: () => void | Promise<void>;
   onClose: () => void;
-  onSubmit: (input: { playbookId: string; notes: string; owners: string[] }) => void;
+  onSubmit: (input: {
+    playbookId: string;
+    notes: string;
+    owners: string[];
+    inputs: WorkflowInput[];
+  }) => void;
+}
+
+function createInputId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `inp-${crypto.randomUUID()}`;
+  }
+  return `inp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
 export function AddPlaybookModal({
@@ -35,6 +60,9 @@ export function AddPlaybookModal({
   stageName,
   playbooks,
   initial,
+  upstreamTaskOptions = [],
+  outputGroups = [],
+  onRefetchOutputs,
   onClose,
   onSubmit,
 }: AddPlaybookModalProps) {
@@ -42,6 +70,9 @@ export function AddPlaybookModal({
   const [notes, setNotes] = useState(initial?.notes ?? "");
   const [owners, setOwners] = useState<string[]>(
     initial?.owners ? [...initial.owners] : [],
+  );
+  const [inputs, setInputs] = useState<WorkflowInput[]>(() =>
+    initial?.inputs ? initial.inputs.map((i) => ({ ...i })) : [],
   );
   const [query, setQuery] = useState("");
 
@@ -83,7 +114,7 @@ export function AddPlaybookModal({
         onSubmit={(event) => {
           event.preventDefault();
           if (!canSubmit) return;
-          onSubmit({ playbookId: selectedId, notes, owners });
+          onSubmit({ playbookId: selectedId, notes, owners, inputs });
         }}
         className="w-full max-w-[520px] rounded-[14px] border border-border-hi bg-bg-2 p-7 shadow-[var(--shadow-canvas)]"
         role="dialog"
@@ -203,6 +234,122 @@ export function AddPlaybookModal({
                 placeholder="Pick a person or AI agent"
                 ariaLabel="Owners"
               />
+            </div>
+
+            <div className="mb-5">
+              <div className="mb-1.5 flex items-center justify-between">
+                <label className="block text-[11px] font-medium text-t2">
+                  Inputs <span className="font-normal text-t3">(optional)</span>
+                </label>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setInputs((current) => [
+                      ...current,
+                      {
+                        id: createInputId(),
+                        name: "",
+                        linkMode: "linked",
+                        upstreamTaskRef: undefined,
+                        upstreamOutputId: null,
+                      },
+                    ]);
+                    void onRefetchOutputs?.();
+                  }}
+                  className="inline-flex items-center gap-1 rounded-md border border-border bg-bg-3 px-2 py-1 text-[11px] text-t2 transition hover:bg-bg-4 hover:text-t1"
+                  data-testid="add-input-row"
+                >
+                  <Plus className="h-3 w-3" /> Add input
+                </button>
+              </div>
+              {inputs.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border bg-bg-3 px-3 py-3 text-[11.5px] text-t3">
+                  No inputs declared. Add one to wire this task to an upstream
+                  output.
+                </div>
+              ) : (
+                <ul className="space-y-2">
+                  {inputs.map((input, index) => (
+                    <li
+                      key={input.id}
+                      className="rounded-lg border border-border bg-bg-3 p-2.5"
+                      data-testid={`input-row-${index}`}
+                    >
+                      <div className="flex items-start gap-2">
+                        <div className="flex-1 space-y-1.5">
+                          <div className="flex items-center gap-1.5">
+                            <input
+                              value={input.name}
+                              onChange={(event) => {
+                                const value = event.target.value;
+                                setInputs((current) =>
+                                  current.map((i, j) =>
+                                    j === index ? { ...i, name: value } : i,
+                                  ),
+                                );
+                              }}
+                              placeholder="Input name"
+                              aria-label="Input name"
+                              className="h-7 flex-1 rounded-md border border-border bg-bg-2 px-2 text-[12px] text-t1 placeholder:text-t3 focus:border-primary focus:outline-none"
+                            />
+                            <select
+                              value={input.upstreamTaskRef ?? ""}
+                              onChange={(event) => {
+                                const value = event.target.value || undefined;
+                                setInputs((current) =>
+                                  current.map((i, j) =>
+                                    j === index
+                                      ? { ...i, upstreamTaskRef: value }
+                                      : i,
+                                  ),
+                                );
+                              }}
+                              aria-label="Upstream task"
+                              className="h-7 rounded-md border border-border bg-bg-2 px-2 text-[11.5px] text-t2 focus:border-primary focus:outline-none"
+                            >
+                              <option value="">Upstream task…</option>
+                              {upstreamTaskOptions.map((opt) => (
+                                <option key={opt.id} value={opt.id}>
+                                  {opt.label}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <InputOutputPicker
+                            upstreamOutputId={input.upstreamOutputId ?? null}
+                            available={outputGroups}
+                            hasUpstreamTaskWithoutOutput={
+                              Boolean(input.upstreamTaskRef) &&
+                              !input.upstreamOutputId
+                            }
+                            onChange={(next) => {
+                              setInputs((current) =>
+                                current.map((i, j) =>
+                                  j === index
+                                    ? { ...i, upstreamOutputId: next }
+                                    : i,
+                                ),
+                              );
+                            }}
+                          />
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setInputs((current) =>
+                              current.filter((_, j) => j !== index),
+                            );
+                          }}
+                          aria-label="Remove input"
+                          className="rounded-md p-1 text-t3 transition hover:bg-bg-4 hover:text-t1"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
           </>
         )}

--- a/products/dashboard/components/workflows/input-output-picker.tsx
+++ b/products/dashboard/components/workflows/input-output-picker.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { TemplateOutputGroup } from "@/lib/workflows/types";
+
+interface InputOutputPickerProps {
+  /** Currently wired playbook output id, or null when unwired. */
+  upstreamOutputId: string | null;
+  /** Outputs grouped per playbook attached to the template. */
+  available: TemplateOutputGroup[];
+  /** True when the input has an upstreamTaskRef set but no output id. */
+  hasUpstreamTaskWithoutOutput?: boolean;
+  onChange: (next: string | null) => void;
+}
+
+/**
+ * Two-step "From playbook ▾ → Output ▾" picker for `WorkflowInput.upstreamOutputId`.
+ * Mirrors the existing dashboard select styling — no new design primitives.
+ */
+export function InputOutputPicker({
+  upstreamOutputId,
+  available,
+  hasUpstreamTaskWithoutOutput,
+  onChange,
+}: InputOutputPickerProps) {
+  const wiredGroup = upstreamOutputId
+    ? available.find((group) =>
+        group.outputs.some((output) => output.id === upstreamOutputId),
+      )
+    : null;
+  const wiredOutput = wiredGroup?.outputs.find((o) => o.id === upstreamOutputId) ?? null;
+
+  const [pendingPlaybookId, setPendingPlaybookId] = useState<string>(
+    wiredGroup?.playbookId ?? "",
+  );
+  const activePlaybookId = wiredGroup?.playbookId ?? pendingPlaybookId;
+  const activeGroup = available.find((g) => g.playbookId === activePlaybookId) ?? null;
+
+  if (wiredOutput && wiredGroup) {
+    return (
+      <div className="flex items-center gap-1.5">
+        <span
+          className="inline-flex items-center gap-1 rounded-md border border-border bg-bg-3 px-2 py-1 text-[11px] text-t2"
+          data-testid="input-wiring-chip"
+        >
+          <span className="font-medium text-t1">{wiredGroup.playbookName}</span>
+          <span className="text-t3">·</span>
+          <span>{wiredOutput.name}</span>
+          <button
+            type="button"
+            onClick={() => {
+              onChange(null);
+              setPendingPlaybookId("");
+            }}
+            aria-label="Clear wiring"
+            className="ml-0.5 rounded p-0.5 text-t3 transition hover:bg-bg-4 hover:text-t1"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <select
+          value={pendingPlaybookId}
+          onChange={(event) => setPendingPlaybookId(event.target.value)}
+          aria-label="From playbook"
+          className={cn(
+            "h-7 rounded-md border border-border bg-bg-3 px-2 text-[11.5px] text-t2",
+            "focus:border-primary focus:outline-none",
+          )}
+        >
+          <option value="">From playbook…</option>
+          {available.map((group) => (
+            <option key={group.playbookId} value={group.playbookId}>
+              {group.playbookName}
+            </option>
+          ))}
+        </select>
+        {activeGroup && activeGroup.outputs.length > 0 ? (
+          <select
+            value=""
+            onChange={(event) => {
+              if (event.target.value) onChange(event.target.value);
+            }}
+            aria-label="Output"
+            className={cn(
+              "h-7 rounded-md border border-border bg-bg-3 px-2 text-[11.5px] text-t2",
+              "focus:border-primary focus:outline-none",
+            )}
+          >
+            <option value="">Output…</option>
+            {activeGroup.outputs.map((output) => (
+              <option key={output.id} value={output.id}>
+                {output.name}
+              </option>
+            ))}
+          </select>
+        ) : null}
+        {hasUpstreamTaskWithoutOutput ? (
+          <span className="text-[11px] italic text-t3">(no output wired)</span>
+        ) : null}
+      </div>
+      {activeGroup && activeGroup.outputs.length === 0 ? (
+        <Link
+          href="/framework/playbooks"
+          className="text-[11px] text-accent hover:underline"
+        >
+          Declare an output on this playbook →
+        </Link>
+      ) : null}
+    </div>
+  );
+}

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -31,6 +31,7 @@ import { CSS } from "@dnd-kit/utilities";
 
 import {
   deleteTemplateAction,
+  listOutputsForTemplateAction,
   renameTemplateAction,
   updateTemplateAction,
 } from "@/app/(dashboard)/workflows/actions";
@@ -48,6 +49,8 @@ import { emitEvent } from "@/lib/events";
 import { resolveSkillColor } from "@/lib/workflows/skill-colors";
 import type {
   FrameworkItem,
+  TemplateOutputGroup,
+  WorkflowInput,
   WorkflowSkill,
   WorkflowStage,
   WorkflowTask,
@@ -290,10 +293,29 @@ export function TemplateEditorScreen({
       playbookId?: string | null;
       notes?: string;
       owners?: string[];
+      inputs?: WorkflowInput[];
     };
   } | null>(null);
   const [pending, startTransition] = useTransition();
   const dndContextId = useId();
+  const [outputGroups, setOutputGroups] = useState<TemplateOutputGroup[]>([]);
+
+  const refetchOutputGroups = useCallback(async () => {
+    try {
+      const groups = await listOutputsForTemplateAction(template.id);
+      setOutputGroups(groups);
+    } catch (err) {
+      captureError(err, {
+        feature: "workflows.template_editor",
+        action: "listOutputsForTemplate",
+        extra: { template_id: template.id },
+      });
+    }
+  }, [template.id]);
+
+  useEffect(() => {
+    void refetchOutputGroups();
+  }, [refetchOutputGroups]);
 
   const playbookById = useMemo(
     () => new Map(playbookOptions.map((pb) => [pb.id, pb])),
@@ -492,6 +514,9 @@ export function TemplateEditorScreen({
             ? err.message
             : "Could not save the workflow template.",
         );
+        // Refetch the picker source-of-truth so a stale `upstreamOutputId`
+        // resolves itself the next time the modal opens.
+        void refetchOutputGroups();
       }
     });
   }
@@ -889,6 +914,7 @@ export function TemplateEditorScreen({
                                 playbookId: templateTask.playbookId ?? null,
                                 notes: templateTask.notes ?? "",
                                 owners: templateTask.owners ?? [],
+                                inputs: templateTask.inputs ?? [],
                               },
                             })
                           }
@@ -986,6 +1012,22 @@ export function TemplateEditorScreen({
           stageName={addTaskFor.stageName}
           playbooks={playbookOptions}
           initial={addTaskFor.initial}
+          upstreamTaskOptions={draft.taskTemplates
+            .filter((t) => t.id && t.id !== addTaskFor.taskId)
+            .map((t) => {
+              const skill = draft.skills.find((s) => s.id === t.skillId);
+              const stage = draft.stages.find((s) => s.id === t.stageId);
+              const pb = t.playbookId ? playbookById.get(t.playbookId) : null;
+              const label = [
+                pb?.name ?? skill?.label ?? t.skillId,
+                stage?.label ?? t.stageId,
+              ]
+                .filter(Boolean)
+                .join(" · ");
+              return { id: t.id as string, label };
+            })}
+          outputGroups={outputGroups}
+          onRefetchOutputs={refetchOutputGroups}
           onClose={() => setAddTaskFor(null)}
           onSubmit={(input) => {
             setDraft((current) => {
@@ -999,6 +1041,7 @@ export function TemplateEditorScreen({
                           playbookId: input.playbookId,
                           notes: input.notes,
                           owners: input.owners,
+                          inputs: input.inputs,
                         }
                       : item,
                   ),
@@ -1015,8 +1058,7 @@ export function TemplateEditorScreen({
                     stageId: addTaskFor.stageId,
                     playbookId: input.playbookId,
                     notes: input.notes,
-                    triggers: [],
-                    gates: [],
+                    inputs: input.inputs,
                     owners: input.owners,
                   },
                 ],

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -26,6 +26,7 @@ import type {
   WorkflowTaskTemplate,
   WorkflowTemplatePatch,
   WorkflowTemplate,
+  TemplateOutputGroup,
 } from "./types";
 
 interface WorkflowTemplateRow {
@@ -414,7 +415,7 @@ function templatePatchToRow(
   return row;
 }
 
-export type WorkflowRepositoryErrorCode = "unique_name";
+export type WorkflowRepositoryErrorCode = "unique_name" | "stale_output_ref";
 
 export class WorkflowRepositoryError extends Error {
   readonly cause?: unknown;
@@ -1129,6 +1130,90 @@ export function createWorkflowRepository(
         .single();
 
       return mapTaskOutput(unwrap("produceOutput", data, error) as TaskOutputRow);
+    },
+
+    async listOutputsForTemplate(
+      templateId: string,
+    ): Promise<TemplateOutputGroup[]> {
+      const { data: templateRow, error: templateErr } = await client
+        .from("workflow_templates")
+        .select("task_templates")
+        .eq("id", templateId)
+        .maybeSingle();
+      if (templateErr) {
+        throw new WorkflowRepositoryError(
+          "listOutputsForTemplate template lookup failed",
+          templateErr,
+        );
+      }
+      if (!templateRow) return [];
+
+      const taskTemplates = toJsonArray<{ playbookId?: unknown }>(
+        (templateRow as { task_templates: unknown }).task_templates,
+      );
+      const playbookIds = Array.from(
+        new Set(
+          taskTemplates
+            .map((task) =>
+              typeof task.playbookId === "string" && task.playbookId.trim()
+                ? task.playbookId.trim()
+                : null,
+            )
+            .filter((value): value is string => value !== null),
+        ),
+      );
+      if (playbookIds.length === 0) return [];
+
+      const [{ data: itemRows, error: itemErr }, { data: outputRows, error: outputErr }] =
+        await Promise.all([
+          client
+            .from("framework_items")
+            .select("id,name")
+            .in("id", playbookIds)
+            .eq("type", "playbook"),
+          client
+            .from("playbook_outputs")
+            .select("*")
+            .in("playbook_id", playbookIds)
+            .order("position", { ascending: true }),
+        ]);
+      if (itemErr) {
+        throw new WorkflowRepositoryError(
+          "listOutputsForTemplate framework_items lookup failed",
+          itemErr,
+        );
+      }
+      if (outputErr) {
+        throw new WorkflowRepositoryError(
+          "listOutputsForTemplate playbook_outputs lookup failed",
+          outputErr,
+        );
+      }
+
+      const nameById = new Map<string, string>();
+      for (const row of (itemRows ?? []) as { id: string; name: string }[]) {
+        nameById.set(row.id, row.name);
+      }
+      const outputsByPlaybook = new Map<string, PlaybookOutput[]>();
+      for (const row of (outputRows ?? []) as PlaybookOutputRow[]) {
+        const mapped = mapPlaybookOutput(row);
+        const list = outputsByPlaybook.get(row.playbook_id) ?? [];
+        list.push(mapped);
+        outputsByPlaybook.set(row.playbook_id, list);
+      }
+
+      return playbookIds
+        .filter((id) => nameById.has(id))
+        .map((id) => ({
+          playbookId: id,
+          playbookName: nameById.get(id) as string,
+          outputs: outputsByPlaybook.get(id) ?? [],
+        }))
+        .sort((a, b) =>
+          a.playbookName.localeCompare(b.playbookName, undefined, {
+            sensitivity: "base",
+          }),
+        );
     },
 
     async listPlaybookOutputs(playbookId: string): Promise<PlaybookOutput[]> {

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -147,6 +147,18 @@ export interface PlaybookOutput {
   createdAt: string;
 }
 
+/**
+ * One entry per playbook attached to a template, returned by
+ * `WorkflowRepository.listOutputsForTemplate`. `outputs` is sorted by
+ * `position` ascending and may be empty when the playbook has no
+ * declared outputs yet (the picker renders a "Declare an output" CTA).
+ */
+export interface TemplateOutputGroup {
+  playbookId: string;
+  playbookName: string;
+  outputs: PlaybookOutput[];
+}
+
 export type TaskOutputStatus = "pending" | "produced" | "failed" | "skipped";
 
 export interface TaskOutput {
@@ -361,6 +373,17 @@ export interface WorkflowRepository {
   ): Promise<TaskOutput>;
   /** List declared outputs for a Playbook, sorted by `position` ascending. */
   listPlaybookOutputs(playbookId: string): Promise<PlaybookOutput[]>;
+  /**
+   * Outputs grouped per playbook for every playbook attached to the given
+   * template (via `taskTemplates[].playbookId`). Drives the input-wiring
+   * picker in the template editor: founders can only wire a downstream
+   * `linked` input to outputs from playbooks already on the same template.
+   * Includes attached playbooks with zero declared outputs so the picker
+   * can render an empty-state CTA. Outputs are sorted by `position` asc.
+   */
+  listOutputsForTemplate(
+    templateId: string,
+  ): Promise<TemplateOutputGroup[]>;
   /** Insert a new playbook output. If `position` is omitted, the row is
    *  appended after the highest existing position for the same playbook.
    *  Throws `WorkflowRepositoryError` with `code: 'unique_name'` when the


### PR DESCRIPTION
Linear: [AEL-64](https://linear.app/aelizondo/issue/AEL-64)
Parent: [AEL-58](https://linear.app/aelizondo/issue/AEL-58)

## Summary
- Adds `listOutputsForTemplate` to `WorkflowRepository` + `listOutputsForTemplateAction` so the editor can scope the picker to playbooks attached to the current template.
- New `InputOutputPicker` (two `<select>`s, no new design primitives): step 1 picks a playbook, step 2 picks an output. Wired state collapses to a `Wired: <playbook> · <output>` chip with `×` clear. Empty-state shows a `Declare an output on this playbook →` deep-link.
- `AddPlaybookModal` now hosts a per-task linked-inputs editor (name + upstream-task select + the picker + remove). Filling the editor was the missing precursor — there was no UI for editing per-task `inputs[]` before this PR.
- Server action saves: `normalizeTemplateTaskTemplates` now defensively normalizes each input row (trimming, empty-string→null on the two ref fields, default `linkMode: 'linked'`); `assertWiredOutputsBelongToTemplate` rejects stale `upstreamOutputId`s with a friendly error and the editor refetches the picker source-of-truth.
- Stale `triggers/gates` keys removed from the create-task-template path in `template-editor-screen` (left over from PR 1).
- Tests: repo unit tests for `listOutputsForTemplate` (happy path with two playbooks one with outputs / one empty, empty-template, unknown-id), an update-then-createInstance round-trip for `inputs[].upstreamOutputId`, and a new `add-playbook-modal.test.tsx` exercising the picker (add row, two-step pick, wired chip, × clear, no-output hint, declare-an-output CTA).

## Notes
- The "Declare an output" link routes to `/framework/playbooks` because `framework-screen` has no public deep-link API yet — open to a follow-up if a query-param selector is wanted.
- Only the 7 pre-existing typecheck errors in `__tests__/auth/*` and `top-bar.test.tsx` remain (unchanged in this PR).

## Test plan
- [ ] CI green: `npm test`, `npm run lint`, `npx tsc --noEmit`.
- [ ] In a template with two tasks (P1 → P2), open task B, declare a linked input, pick `From playbook: P1` then `Output: O1`, save.
- [ ] DB sanity: `workflow_templates.task_templates[B].inputs[0].upstreamOutputId` matches the picked id.
- [ ] Create a new instance → matrix shows ⤴ on B; produce O1 in A's drawer → ⤴ disappears (auto-satisfy trigger fires).
- [ ] `×` clears wiring back to null; matrix falls back to "any output of upstream task" semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)