### PR TITLE
feat(dashboard): focus-on-active matrix + wiring polish + drawer status menu (AEL-66)

### DIFF
--- a/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
@@ -155,7 +155,7 @@ describe("ProcessMatrix", () => {
         skillId: "pm",
         stageId: "validation",
         playbookId: "pdr-review",
-        status: "complete",
+        status: "in_progress",
       }),
     ]);
 

--- a/products/dashboard/__tests__/lib/workflows/active-flow.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/active-flow.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  activeStageIds,
+  classifyEdge,
+  isTaskActive,
+  seedCollapsedSkills,
+  seedCollapsedStages,
+} from "@/lib/workflows/active-flow";
+import type {
+  TaskIOSummary,
+  WorkflowSkill,
+  WorkflowStage,
+  WorkflowTask,
+} from "@/lib/workflows/types";
+
+function task(over: Partial<WorkflowTask>): WorkflowTask {
+  return {
+    id: "t",
+    instanceId: "i",
+    skillId: "sk",
+    stageId: "st",
+    notes: "",
+    status: "not_started",
+    substatus: "",
+    checkpoint: false,
+    inputs: [],
+    playbookId: null,
+    owners: [],
+    createdAt: "2026-04-19T12:00:00Z",
+    updatedAt: "2026-04-19T12:00:00Z",
+    ...over,
+  };
+}
+
+function io(taskId: string, hasUnmet = false): TaskIOSummary {
+  return { taskId, outputs: [], hasUnmetLinkedInput: hasUnmet };
+}
+
+const STAGES: WorkflowStage[] = [
+  { id: "s1", label: "S1" },
+  { id: "s2", label: "S2" },
+  { id: "s3", label: "S3" },
+];
+const SKILLS: WorkflowSkill[] = [
+  { id: "k1", label: "K1", owners: [] },
+  { id: "k2", label: "K2", owners: [] },
+];
+
+describe("isTaskActive", () => {
+  it("treats in_progress and running as active regardless of IO", () => {
+    expect(isTaskActive(task({ status: "in_progress" }))).toBe(true);
+    expect(isTaskActive(task({ status: "running" }))).toBe(true);
+  });
+
+  it("treats not_started/waiting with met inputs as active (next-up)", () => {
+    expect(isTaskActive(task({ status: "not_started" }), io("t", false))).toBe(true);
+    expect(isTaskActive(task({ status: "waiting" }), io("t", false))).toBe(true);
+  });
+
+  it("treats not_started with unmet inputs as inactive", () => {
+    expect(isTaskActive(task({ status: "not_started" }), io("t", true))).toBe(false);
+  });
+
+  it("treats complete/paused/failed as inactive", () => {
+    expect(isTaskActive(task({ status: "complete" }))).toBe(false);
+    expect(isTaskActive(task({ status: "paused" }))).toBe(false);
+    expect(isTaskActive(task({ status: "failed" }))).toBe(false);
+  });
+});
+
+describe("classifyEdge", () => {
+  const from = task({ id: "a" });
+  const to = task({ id: "b" });
+  it("next when upstream complete and downstream ready not-started", () => {
+    expect(
+      classifyEdge(
+        { ...from, status: "complete" },
+        { ...to, status: "not_started" },
+        io("b", false),
+      ),
+    ).toBe("next");
+  });
+  it("current when upstream complete and downstream in_progress", () => {
+    expect(
+      classifyEdge(
+        { ...from, status: "complete" },
+        { ...to, status: "in_progress" },
+      ),
+    ).toBe("current");
+  });
+  it("producing when upstream is in_progress", () => {
+    expect(
+      classifyEdge(
+        { ...from, status: "in_progress" },
+        { ...to, status: "not_started" },
+        io("b", true),
+      ),
+    ).toBe("producing");
+  });
+  it("settled when both complete", () => {
+    expect(
+      classifyEdge(
+        { ...from, status: "complete" },
+        { ...to, status: "complete" },
+      ),
+    ).toBe("settled");
+  });
+  it("dormant when nothing's moving", () => {
+    expect(
+      classifyEdge(
+        { ...from, status: "not_started" },
+        { ...to, status: "not_started" },
+        io("b", true),
+      ),
+    ).toBe("dormant");
+  });
+});
+
+describe("seedCollapsedStages", () => {
+  it("collapses every stage except the one with an active task", () => {
+    const tasks = [
+      task({ id: "t1", stageId: "s2", status: "in_progress" }),
+      task({ id: "t2", stageId: "s3", status: "complete" }),
+    ];
+    const result = seedCollapsedStages(tasks, [io("t1"), io("t2")], STAGES);
+    expect([...result].sort()).toEqual(["s1", "s3"]);
+  });
+
+  it("collapses every stage when every task is complete (review mode)", () => {
+    const tasks = [
+      task({ id: "t1", stageId: "s1", status: "complete" }),
+      task({ id: "t2", stageId: "s2", status: "complete" }),
+    ];
+    const result = seedCollapsedStages(tasks, [io("t1"), io("t2")], STAGES);
+    expect([...result].sort()).toEqual(["s1", "s2", "s3"]);
+  });
+
+  it("collapses everything except the first stage in kickoff (all not_started, inputs unmet)", () => {
+    const tasks = [
+      task({ id: "t1", stageId: "s2", status: "not_started" }),
+      task({ id: "t2", stageId: "s3", status: "not_started" }),
+    ];
+    const result = seedCollapsedStages(
+      tasks,
+      [io("t1", true), io("t2", true)],
+      STAGES,
+    );
+    expect([...result].sort()).toEqual(["s2", "s3"]);
+  });
+});
+
+describe("seedCollapsedSkills", () => {
+  it("collapses skills with no active task", () => {
+    const tasks = [
+      task({ id: "t1", skillId: "k1", status: "in_progress" }),
+      task({ id: "t2", skillId: "k2", status: "complete" }),
+    ];
+    const result = seedCollapsedSkills(tasks, [io("t1"), io("t2")], SKILLS);
+    expect([...result]).toEqual(["k2"]);
+  });
+
+  it("collapses every skill when every task is complete (review mode)", () => {
+    const tasks = [
+      task({ id: "t1", skillId: "k1", status: "complete" }),
+      task({ id: "t2", skillId: "k2", status: "complete" }),
+    ];
+    const result = seedCollapsedSkills(tasks, [io("t1"), io("t2")], SKILLS);
+    expect([...result].sort()).toEqual(["k1", "k2"]);
+  });
+
+  it("leaves skills expanded in kickoff (no active, not all complete)", () => {
+    const tasks = [task({ id: "t1", skillId: "k1", status: "not_started" })];
+    const result = seedCollapsedSkills(tasks, [io("t1", true)], SKILLS);
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("activeStageIds", () => {
+  it("dedupes stages across tasks", () => {
+    const tasks = [
+      task({ id: "t1", stageId: "s1", status: "in_progress" }),
+      task({ id: "t2", stageId: "s1", status: "running" }),
+      task({ id: "t3", stageId: "s2", status: "complete" }),
+    ];
+    const result = activeStageIds(tasks, [io("t1"), io("t2"), io("t3")]);
+    expect([...result]).toEqual(["s1"]);
+  });
+});

--- a/products/dashboard/app/(dashboard)/workflows/[instanceId]/page.tsx
+++ b/products/dashboard/app/(dashboard)/workflows/[instanceId]/page.tsx
@@ -52,6 +52,9 @@ export default async function WorkflowInstancePage({
   }
 
   const template = await repo.getTemplate(instance.templateId);
+  // Outputs are loaded so the wiring overlay can resolve `upstreamTaskRef`
+  // for inputs that were saved with only `upstreamOutputId`.
+  const outputGroups = await repo.listOutputsForTemplate(instance.templateId);
 
   return (
     <>
@@ -71,6 +74,7 @@ export default async function WorkflowInstancePage({
           editMode={editMode}
           skillOptions={skills}
           playbookOptions={playbooks}
+          outputGroups={outputGroups}
         />
       </div>
     </>

--- a/products/dashboard/components/workflows/add-playbook-modal.tsx
+++ b/products/dashboard/components/workflows/add-playbook-modal.tsx
@@ -31,7 +31,7 @@ interface AddPlaybookModalProps {
     inputs?: readonly WorkflowInput[];
   };
   /** Other tasks in the same template — populates the upstream-task select. */
-  upstreamTaskOptions?: { id: string; label: string }[];
+  upstreamTaskOptions?: { id: string; label: string; playbookId?: string | null }[];
   /** Outputs grouped per attached playbook — populates the wiring picker. */
   outputGroups?: TemplateOutputGroup[];
   /** Called by the picker when it wants the parent to refetch (e.g. a
@@ -334,11 +334,28 @@ export function AddPlaybookModal({
                             }
                             onChange={(next) => {
                               setInputs((current) =>
-                                current.map((i, j) =>
-                                  j === index
-                                    ? { ...i, upstreamOutputId: next }
-                                    : i,
-                                ),
+                                current.map((i, j) => {
+                                  if (j !== index) return i;
+                                  if (next === null) {
+                                    return { ...i, upstreamOutputId: null };
+                                  }
+                                  // Auto-stamp `upstreamTaskRef` from the
+                                  // chosen output's playbook, so downstream
+                                  // consumers (wiring overlay, instance
+                                  // remap) don't have to re-resolve it.
+                                  // Preserve any prior explicit task ref —
+                                  // the upstream-task select above takes
+                                  // precedence when the user has picked it.
+                                  const derivedRef = upstreamTaskOptions.find(
+                                    (opt) => opt.playbookId === next.playbookId,
+                                  )?.id;
+                                  return {
+                                    ...i,
+                                    upstreamOutputId: next.outputId,
+                                    upstreamTaskRef:
+                                      i.upstreamTaskRef ?? derivedRef,
+                                  };
+                                }),
                               );
                             }}
                           />

--- a/products/dashboard/components/workflows/input-output-picker.tsx
+++ b/products/dashboard/components/workflows/input-output-picker.tsx
@@ -14,7 +14,12 @@ interface InputOutputPickerProps {
   available: TemplateOutputGroup[];
   /** True when the input has an upstreamTaskRef set but no output id. */
   hasUpstreamTaskWithoutOutput?: boolean;
-  onChange: (next: string | null) => void;
+  /**
+   * Called when the user picks or clears an output. The `playbookId` is
+   * supplied so callers can stamp `upstreamTaskRef` alongside
+   * `upstreamOutputId` without having to re-resolve it themselves.
+   */
+  onChange: (next: { outputId: string; playbookId: string } | null) => void;
 }
 
 /**
@@ -90,7 +95,11 @@ export function InputOutputPicker({
           <select
             value=""
             onChange={(event) => {
-              if (event.target.value) onChange(event.target.value);
+              if (event.target.value)
+                onChange({
+                  outputId: event.target.value,
+                  playbookId: activeGroup.playbookId,
+                });
             }}
             aria-label="Output"
             className={cn(

--- a/products/dashboard/components/workflows/playbook-drawer/drawer-header.tsx
+++ b/products/dashboard/components/workflows/playbook-drawer/drawer-header.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import type { ButtonHTMLAttributes } from "react";
 import { MoreVertical, X } from "lucide-react";
 
 import { OwnerAvatarStack } from "@/components/framework/owner-avatar-stack";
+import { StatusBadgePopover } from "@/components/workflows/task-card";
 import { cn } from "@/lib/utils";
 import {
   TASK_STATUS_LABEL,
@@ -34,6 +36,7 @@ export interface DrawerHeaderProps {
   skills: WorkflowSkill[];
   playbookOptions: FrameworkItem[];
   onClose: () => void;
+  onStatusChange?: (next: WorkflowTaskStatus) => void;
 }
 
 export function DrawerHeader({
@@ -42,6 +45,7 @@ export function DrawerHeader({
   skills,
   playbookOptions,
   onClose,
+  onStatusChange,
 }: DrawerHeaderProps) {
   const skill = skills.find((s) => s.id === task.skillId);
   const playbook = task.playbookId
@@ -105,14 +109,41 @@ export function DrawerHeader({
         </div>
       </div>
       <div className="pb-drawer-context__footer">
-        <span
-          className={cn("pb-drawer-status-pill", TASK_STATUS_PILL_CLASS[task.status])}
-          data-status={task.status}
-          data-testid="pb-drawer-status-pill"
-        >
-          <span className="pb-drawer-status-pill__dot" aria-hidden />
-          {TASK_STATUS_LABEL[task.status]}
-        </span>
+        {onStatusChange ? (
+          <StatusBadgePopover
+            status={task.status}
+            taskId={`pb-drawer-${task.id}`}
+            onChange={onStatusChange}
+            triggerClassName={cn(
+              "pb-drawer-status-pill",
+              TASK_STATUS_PILL_CLASS[task.status],
+            )}
+            triggerContent={
+              <>
+                <span className="pb-drawer-status-pill__dot" aria-hidden />
+                {TASK_STATUS_LABEL[task.status]}
+              </>
+            }
+            triggerProps={
+              {
+                "data-testid": "pb-drawer-status-pill",
+                "data-status": task.status,
+              } as ButtonHTMLAttributes<HTMLButtonElement>
+            }
+          />
+        ) : (
+          <span
+            className={cn(
+              "pb-drawer-status-pill",
+              TASK_STATUS_PILL_CLASS[task.status],
+            )}
+            data-status={task.status}
+            data-testid="pb-drawer-status-pill"
+          >
+            <span className="pb-drawer-status-pill__dot" aria-hidden />
+            {TASK_STATUS_LABEL[task.status]}
+          </span>
+        )}
         <div className="pb-drawer-context__owners" data-testid="pb-drawer-owners">
           <span className="pb-drawer-context__owners-lbl">Owners</span>
           <OwnerAvatarStack labels={task.owners} size="xs" testIdSuffix="pb-drawer" />

--- a/products/dashboard/components/workflows/playbook-drawer/index.tsx
+++ b/products/dashboard/components/workflows/playbook-drawer/index.tsx
@@ -9,6 +9,7 @@ import {
   refinePlaybookAction,
   resumeTaskAction,
   retryBlockedTaskAction,
+  setTaskStatusAction,
   startTaskAction,
 } from "@/app/(dashboard)/workflows/actions";
 import { captureError } from "@/lib/monitoring";
@@ -19,6 +20,7 @@ import type {
   WorkflowInstanceDetail,
   WorkflowSkill,
   WorkflowTask,
+  WorkflowTaskStatus,
   WorkflowTemplate,
 } from "@/lib/workflows/types";
 
@@ -176,6 +178,11 @@ export function PlaybookDrawer({
     const id = task.id;
     runAction("playbook-drawer.retry", () => retryBlockedTaskAction(id));
   }
+  function handleStatusChange(next: WorkflowTaskStatus) {
+    if (!task) return;
+    const id = task.id;
+    runAction("playbook-drawer.status_change", () => setTaskStatusAction(id, next));
+  }
   function handleMarkReceived(inputId: string) {
     if (!task) return;
     startTransition(async () => {
@@ -265,6 +272,7 @@ export function PlaybookDrawer({
           skills={skills}
           playbookOptions={playbookOptions}
           onClose={onClose}
+          onStatusChange={handleStatusChange}
         />
         <ActionBar
           status={task.status}

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -53,10 +53,17 @@ import { useUnsavedChangesGuard } from "@/lib/use-unsaved-changes-guard";
 import { cn } from "@/lib/utils";
 import { barClass, canStart } from "@/lib/workflows/matrix";
 import { resolveSkillColor } from "@/lib/workflows/skill-colors";
+import {
+  activeSkillIds,
+  activeStageIds,
+  seedCollapsedSkills,
+  seedCollapsedStages,
+} from "@/lib/workflows/active-flow";
 import { ItemAvatar } from "@/components/framework/item-avatar";
 import type {
   FrameworkItem,
   TaskIOSummary,
+  TemplateOutputGroup,
   WorkflowInstanceDetail,
   WorkflowSkill,
   WorkflowStage,
@@ -82,6 +89,7 @@ interface Props {
   editMode?: boolean;
   skillOptions?: FrameworkItem[];
   playbookOptions?: FrameworkItem[];
+  outputGroups?: TemplateOutputGroup[];
 }
 
 export function ProcessMatrix({
@@ -90,15 +98,34 @@ export function ProcessMatrix({
   editMode = false,
   skillOptions = [],
   playbookOptions = [],
+  outputGroups = [],
 }: Props) {
   const { setConfig } = useDashboardTopBar();
   const { success: toastSuccess, error: toastError } = useToast();
+  // Stages/skills derivation has to happen here (before the collapse state)
+  // so the lazy useState initializers can seed from the active flow.
+  const seedStages: WorkflowStage[] =
+    instance.stages && instance.stages.length > 0
+      ? instance.stages
+      : template?.stages ?? [];
+  const seedSkills: WorkflowSkill[] =
+    instance.skills && instance.skills.length > 0
+      ? instance.skills
+      : template?.skills ?? [];
   const [collapsed, setCollapsed] = useState(false);
+  // Edit mode opens the matrix fully expanded so the user can author every
+  // cell; the focus-on-active seed applies only to read-only viewing.
   const [collapsedStageIds, setCollapsedStageIds] = useState<Set<string>>(
-    () => new Set(),
+    () =>
+      editMode
+        ? new Set()
+        : seedCollapsedStages(instance.tasks, instance.taskIO, seedStages),
   );
   const [collapsedSkillIds, setCollapsedSkillIds] = useState<Set<string>>(
-    () => new Set(),
+    () =>
+      editMode
+        ? new Set()
+        : seedCollapsedSkills(instance.tasks, instance.taskIO, seedSkills),
   );
 
   const toggleStageCollapsed = useCallback((stageId: string) => {
@@ -122,15 +149,10 @@ export function ProcessMatrix({
   // Stages and skills are snapshotted onto the instance at create time so
   // template edits do not mutate or orphan tasks on existing instances.
   // Fall back to the template only for legacy instances persisted before
-  // the snapshot column existed.
-  const stages: WorkflowStage[] =
-    instance.stages && instance.stages.length > 0
-      ? instance.stages
-      : template?.stages ?? [];
-  const skills: WorkflowSkill[] =
-    instance.skills && instance.skills.length > 0
-      ? instance.skills
-      : template?.skills ?? [];
+  // the snapshot column existed. Reuse the values computed for the lazy
+  // collapse-state seeds above — same source, same derivation.
+  const stages: WorkflowStage[] = seedStages;
+  const skills: WorkflowSkill[] = seedSkills;
   const allCollapsed =
     collapsed &&
     stages.length > 0 &&
@@ -224,6 +246,54 @@ export function ProcessMatrix({
     setLocalTasks(instance.tasks);
     setLastSavedTasks(instance.tasks);
   }, [instance.tasks, editMode]);
+
+  // Auto-expand stages/skills as work flows. When a task's status flips or
+  // an upstream output unblocks a downstream input, the formerly-dormant
+  // region becomes "active" and we want it visible without the user needing
+  // to refresh. We track the previously-active sets and only act on what's
+  // newly added — manual collapses on already-active regions are preserved.
+  const prevActiveRef = useRef<{ stages: Set<string>; skills: Set<string> }>({
+    stages: activeStageIds(instance.tasks, instance.taskIO),
+    skills: activeSkillIds(instance.tasks, instance.taskIO),
+  });
+  useEffect(() => {
+    if (editMode) return;
+    const stages = activeStageIds(localTasks, instance.taskIO);
+    const skills = activeSkillIds(localTasks, instance.taskIO);
+    const newStages: string[] = [];
+    for (const id of stages) {
+      if (!prevActiveRef.current.stages.has(id)) newStages.push(id);
+    }
+    const newSkills: string[] = [];
+    for (const id of skills) {
+      if (!prevActiveRef.current.skills.has(id)) newSkills.push(id);
+    }
+    if (newStages.length > 0) {
+      setCollapsedStageIds((prev) => {
+        let next: Set<string> | null = null;
+        for (const id of newStages) {
+          if (prev.has(id)) {
+            if (!next) next = new Set(prev);
+            next.delete(id);
+          }
+        }
+        return next ?? prev;
+      });
+    }
+    if (newSkills.length > 0) {
+      setCollapsedSkillIds((prev) => {
+        let next: Set<string> | null = null;
+        for (const id of newSkills) {
+          if (prev.has(id)) {
+            if (!next) next = new Set(prev);
+            next.delete(id);
+          }
+        }
+        return next ?? prev;
+      });
+    }
+    prevActiveRef.current = { stages, skills };
+  }, [localTasks, instance.taskIO, editMode]);
 
   const handleTaskUpdate = useCallback((updated: WorkflowTask) => {
     setLocalTasks((prev) => prev.map((task) => (task.id === updated.id ? updated : task)));
@@ -959,6 +1029,8 @@ export function ProcessMatrix({
               containerRef={matrixWrapRef}
               tasks={localTasks}
               hoveredTaskId={hoveredTaskId}
+              outputGroups={outputGroups}
+              taskIO={instance.taskIO}
             />
           ) : null}
         </div>

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
   AlertTriangle,
   Check,
@@ -343,15 +344,94 @@ function StatusBadgePopover({
   taskId: string;
 }) {
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
   const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
   useDismissPopover(rootRef, open, setOpen);
+  useDismissPopover(popoverRef, open, setOpen);
 
   const statusClass = TASK_STATUS_PILL_CLASS[status];
   const statusLabel = TASK_STATUS_LABEL[status];
 
+  // Position the portaled popover above the trigger using viewport coords.
+  // The trigger's position is captured once on open and on scroll/resize so
+  // the popover follows when the matrix scrolls underneath it.
+  useLayoutEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return undefined;
+    }
+    function measure() {
+      const trigger = triggerRef.current;
+      const popover = popoverRef.current;
+      if (!trigger) return;
+      const rect = trigger.getBoundingClientRect();
+      const popoverHeight = popover?.getBoundingClientRect().height ?? 220;
+      setPosition({
+        left: rect.left,
+        top: rect.top - popoverHeight - 6,
+      });
+    }
+    measure();
+    window.addEventListener("scroll", measure, true);
+    window.addEventListener("resize", measure);
+    return () => {
+      window.removeEventListener("scroll", measure, true);
+      window.removeEventListener("resize", measure);
+    };
+  }, [open]);
+
+  const popoverNode =
+    open && typeof document !== "undefined" ? (
+      <div
+        ref={popoverRef}
+        className="tc-popover tc-popover-status"
+        role="listbox"
+        aria-label="Set status"
+        onClick={(event) => event.stopPropagation()}
+        style={
+          position
+            ? {
+                position: "fixed",
+                left: position.left,
+                top: position.top,
+                bottom: "auto",
+              }
+            : { position: "fixed", visibility: "hidden" }
+        }
+      >
+        {TASK_STATUS_ORDER.map((option) => {
+          const selected = option === status;
+          return (
+            <button
+              key={option}
+              type="button"
+              role="option"
+              aria-selected={selected}
+              className={cn("tc-popover-item", selected && "is-selected")}
+              onClick={(event) => {
+                event.stopPropagation();
+                setOpen(false);
+                if (!selected) onChange(option);
+              }}
+            >
+              <span
+                className="tc-popover-dot"
+                aria-hidden
+                style={{ background: TASK_STATUS_VAR[option] }}
+              />
+              <span className="tc-popover-text">{TASK_STATUS_LABEL[option]}</span>
+            </button>
+          );
+        })}
+      </div>
+    ) : null;
+
   return (
     <div ref={rootRef} className="tc-status-wrap">
       <button
+        ref={triggerRef}
         type="button"
         className={cn("s-pill tc-status-trigger", statusClass)}
         data-testid={`task-status-${taskId}`}
@@ -365,39 +445,7 @@ function StatusBadgePopover({
       >
         <span className="s-text">{statusLabel}</span>
       </button>
-      {open ? (
-        <div
-          className="tc-popover tc-popover-status"
-          role="listbox"
-          aria-label="Set status"
-          onClick={(event) => event.stopPropagation()}
-        >
-          {TASK_STATUS_ORDER.map((option) => {
-            const selected = option === status;
-            return (
-              <button
-                key={option}
-                type="button"
-                role="option"
-                aria-selected={selected}
-                className={cn("tc-popover-item", selected && "is-selected")}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  setOpen(false);
-                  if (!selected) onChange(option);
-                }}
-              >
-                <span
-                  className="tc-popover-dot"
-                  aria-hidden
-                  style={{ background: TASK_STATUS_VAR[option] }}
-                />
-                <span className="tc-popover-text">{TASK_STATUS_LABEL[option]}</span>
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
+      {popoverNode ? createPortal(popoverNode, document.body) : null}
     </div>
   );
 }

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   AlertTriangle,
@@ -312,15 +312,25 @@ function InfoBadge({
   );
 }
 
+/**
+ * Closes the popover when the user clicks outside any of the given refs
+ * (trigger wrapper + portaled popover panel). Accepting a list of refs is
+ * what makes portaled popovers work — a single ref would dismiss on every
+ * click in the panel since the panel lives outside the React tree.
+ */
 function useDismissPopover(
-  rootRef: React.RefObject<HTMLDivElement | null>,
+  refs: React.RefObject<HTMLElement | null>[],
   open: boolean,
   setOpen: (next: boolean) => void,
 ) {
   useEffect(() => {
     if (!open) return;
     function handlePointerDown(event: MouseEvent) {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+      const target = event.target as Node;
+      for (const ref of refs) {
+        if (ref.current?.contains(target)) return;
+      }
+      setOpen(false);
     }
     function handleKey(event: KeyboardEvent) {
       if (event.key === "Escape") setOpen(false);
@@ -331,25 +341,41 @@ function useDismissPopover(
       document.removeEventListener("mousedown", handlePointerDown);
       document.removeEventListener("keydown", handleKey);
     };
-  }, [open, rootRef, setOpen]);
+  }, [open, refs, setOpen]);
 }
 
-function StatusBadgePopover({
+export function StatusBadgePopover({
   status,
   onChange,
   taskId,
+  triggerClassName,
+  triggerContent,
+  triggerProps,
 }: {
   status: WorkflowTaskStatus;
   onChange: (next: WorkflowTaskStatus) => void;
   taskId: string;
+  /** Override the trigger button's class list. Defaults to the matrix
+   * card's pill styling; the drawer passes its own `pb-drawer-status-pill`
+   * class so the popover blends with the drawer header.
+   */
+  triggerClassName?: string;
+  /** Optional override for the trigger's children. Defaults to the
+   * status label text.
+   */
+  triggerContent?: React.ReactNode;
+  /** Extra attributes for the trigger button — e.g. a custom `data-testid`
+   * or `data-status` for callers that need to assert against them. The
+   * default `task-status-${taskId}` testid is preserved if not overridden.
+   */
+  triggerProps?: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }) {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const [open, setOpen] = useState(false);
   const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
-  useDismissPopover(rootRef, open, setOpen);
-  useDismissPopover(popoverRef, open, setOpen);
+  useDismissPopover(useMemo(() => [rootRef, popoverRef], []), open, setOpen);
 
   const statusClass = TASK_STATUS_PILL_CLASS[status];
   const statusLabel = TASK_STATUS_LABEL[status];
@@ -433,8 +459,9 @@ function StatusBadgePopover({
       <button
         ref={triggerRef}
         type="button"
-        className={cn("s-pill tc-status-trigger", statusClass)}
         data-testid={`task-status-${taskId}`}
+        {...triggerProps}
+        className={triggerClassName ?? cn("s-pill tc-status-trigger", statusClass)}
         aria-haspopup="listbox"
         aria-expanded={open}
         onClick={(event) => {
@@ -443,7 +470,7 @@ function StatusBadgePopover({
         }}
         title="Change status"
       >
-        <span className="s-text">{statusLabel}</span>
+        {triggerContent ?? <span className="s-text">{statusLabel}</span>}
       </button>
       {popoverNode ? createPortal(popoverNode, document.body) : null}
     </div>

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -1026,7 +1026,11 @@ export function TemplateEditorScreen({
               ]
                 .filter(Boolean)
                 .join(" · ");
-              return { id: t.id as string, label };
+              return {
+                id: t.id as string,
+                label,
+                playbookId: t.playbookId ?? null,
+              };
             })}
           outputGroups={outputGroups}
           onRefetchOutputs={refetchOutputGroups}

--- a/products/dashboard/components/workflows/wiring-overlay.tsx
+++ b/products/dashboard/components/workflows/wiring-overlay.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useState } from "react";
 import type { RefObject } from "react";
 
-import type { WorkflowTask } from "@/lib/workflows/types";
+import { classifyEdge, type EdgeFlowState } from "@/lib/workflows/active-flow";
+import type {
+  TaskIOSummary,
+  TemplateOutputGroup,
+  WorkflowTask,
+} from "@/lib/workflows/types";
 
 interface WiringOverlayProps {
   /** The wrapping element that hosts the SVG layer (must be position:relative). */
@@ -12,6 +17,15 @@ interface WiringOverlayProps {
   tasks: WorkflowTask[];
   /** Task currently under the cursor, or null. */
   hoveredTaskId: string | null;
+  /**
+   * Optional playbook → outputs grouping. When an input has `upstreamOutputId`
+   * set but `upstreamTaskRef` is missing (older instance data wired before the
+   * field was stamped on save), we fall back to resolving the producer by
+   * matching the output's playbookId against a task's `playbookId`.
+   */
+  outputGroups?: TemplateOutputGroup[];
+  /** Per-task IO summary, used to classify each edge as next/current/etc. */
+  taskIO?: TaskIOSummary[];
 }
 
 interface WiringPair {
@@ -19,38 +33,101 @@ interface WiringPair {
   from: string;
   /** Downstream task id (the consumer). */
   to: string;
+  flow: EdgeFlowState;
 }
 
 interface ResolvedPath {
   key: string;
   d: string;
-  emphasized: boolean;
+  flow: EdgeFlowState;
+  hovered: boolean;
+}
+
+interface PathStyle {
+  opacity: number;
+  width: number;
+  glow: boolean;
+}
+
+const FLOW_STYLE: Record<EdgeFlowState, PathStyle> = {
+  // Visual hierarchy:
+  //   next      — "do this!" — brightest, glowing
+  //   current   — "in flight" — clearly present but no glow
+  //   producing — "upstream working" — secondary
+  //   settled   — "done" — ghosted
+  //   dormant   — "nothing's moving" — hidden until hover
+  next: { opacity: 0.95, width: 1.5, glow: true },
+  current: { opacity: 0.7, width: 1.25, glow: false },
+  producing: { opacity: 0.6, width: 1.25, glow: false },
+  settled: { opacity: 0.1, width: 1.0, glow: false },
+  dormant: { opacity: 0, width: 1.0, glow: false },
+};
+
+function resolveStyle(flow: EdgeFlowState, hovered: boolean): PathStyle {
+  const base = FLOW_STYLE[flow];
+  if (!hovered) return base;
+  // Hover always reveals; dormant edges peek at 0.5, others lift to 0.95.
+  if (flow === "dormant") return { opacity: 0.5, width: 1.25, glow: false };
+  return { ...base, opacity: 0.95 };
 }
 
 /**
- * Renders a faint SVG overlay connecting linked tasks on the matrix. Paths
- * appear only while the cursor is over one of the two endpoints and the
- * other endpoint is visible (not collapsed). The layer never intercepts
- * pointer events so drag-drop and clicks pass through unchanged.
+ * Renders the SVG wiring layer beneath the matrix. Edges are classified by
+ * their endpoints' statuses — only the "active flow" (next / current /
+ * producing) reads brightly; settled edges ghost; dormant edges hide unless
+ * hovered. The layer never intercepts pointer events so drag-drop and clicks
+ * pass through unchanged.
  */
 export function WiringOverlay({
   containerRef,
   tasks,
   hoveredTaskId,
+  outputGroups,
+  taskIO,
 }: WiringOverlayProps) {
+  const glowFilterId = useId();
   const pairs = useMemo<WiringPair[]>(() => {
     const taskIds = new Set(tasks.map((t) => t.id));
+    const taskById = new Map(tasks.map((t) => [t.id, t]));
+    const ioByTaskId = new Map(
+      (taskIO ?? []).map((s) => [s.taskId, s] as const),
+    );
+    // outputId → playbookId, used to back-fill `upstreamTaskRef` for inputs
+    // saved before the picker started stamping it.
+    const outputToPlaybookId = new Map<string, string>();
+    for (const group of outputGroups ?? []) {
+      for (const output of group.outputs) {
+        outputToPlaybookId.set(output.id, group.playbookId);
+      }
+    }
+    // playbookId → first task id producing it. If multiple tasks share a
+    // playbookId we can't disambiguate without explicit `upstreamTaskRef`,
+    // so we accept the first match as a best-effort fallback.
+    const playbookIdToTaskId = new Map<string, string>();
+    for (const task of tasks) {
+      if (task.playbookId && !playbookIdToTaskId.has(task.playbookId)) {
+        playbookIdToTaskId.set(task.playbookId, task.id);
+      }
+    }
+
     const result: WiringPair[] = [];
     for (const task of tasks) {
       for (const input of task.inputs ?? []) {
         if (input.linkMode !== "linked") continue;
-        const upstream = input.upstreamTaskRef;
+        let upstream = input.upstreamTaskRef;
+        if (!upstream && input.upstreamOutputId) {
+          const pb = outputToPlaybookId.get(input.upstreamOutputId);
+          if (pb) upstream = playbookIdToTaskId.get(pb);
+        }
         if (!upstream || !taskIds.has(upstream)) continue;
-        result.push({ from: upstream, to: task.id });
+        const fromTask = taskById.get(upstream);
+        if (!fromTask) continue;
+        const flow = classifyEdge(fromTask, task, ioByTaskId.get(task.id));
+        result.push({ from: upstream, to: task.id, flow });
       }
     }
     return result;
-  }, [tasks]);
+  }, [tasks, outputGroups, taskIO]);
 
   const [size, setSize] = useState<{ width: number; height: number }>({
     width: 0,
@@ -64,21 +141,13 @@ export function WiringOverlay({
     const containerRect = container.getBoundingClientRect();
     setSize({ width: containerRect.width, height: containerRect.height });
 
-    if (!hoveredTaskId) {
-      setPaths([]);
-      return;
-    }
-
-    const visible = pairs.filter(
-      (pair) => pair.from === hoveredTaskId || pair.to === hoveredTaskId,
-    );
-    if (visible.length === 0) {
+    if (pairs.length === 0) {
       setPaths([]);
       return;
     }
 
     const next: ResolvedPath[] = [];
-    for (const pair of visible) {
+    for (const pair of pairs) {
       const fromEl = container.querySelector<HTMLElement>(
         `[data-task-id="${pair.from}"]`,
       );
@@ -94,45 +163,105 @@ export function WiringOverlay({
       if (fromRect.width === 0 || fromRect.height === 0) continue;
       if (toRect.width === 0 || toRect.height === 0) continue;
 
+      const fromCenterX = fromRect.left + fromRect.width / 2 - containerRect.left;
+      const toCenterX = toRect.left + toRect.width / 2 - containerRect.left;
       const fromCenterY = fromRect.top + fromRect.height / 2 - containerRect.top;
       const toCenterY = toRect.top + toRect.height / 2 - containerRect.top;
       const fromLeft = fromRect.left - containerRect.left;
       const fromRight = fromRect.right - containerRect.left;
+      const fromTop = fromRect.top - containerRect.top;
+      const fromBottom = fromRect.bottom - containerRect.top;
       const toLeft = toRect.left - containerRect.left;
       const toRight = toRect.right - containerRect.left;
+      const toTop = toRect.top - containerRect.top;
+      const toBottom = toRect.bottom - containerRect.top;
 
-      // Anchor on the facing edges when one card is clearly to the side of
-      // the other. When the columns overlap (same stage), fall back to
-      // center-to-center to keep the curve from doubling back.
+      // Routing axis:
+      //   - Different columns (horizontally separated) → original logic:
+      //     anchor on facing left/right edges, control handles along x.
+      //   - Same column, stacked (vertically separated only) → anchor on
+      //     facing top/bottom edges, control handles along y. Avoids the
+      //     sideways curl that center-to-center handles produced when the
+      //     two cards share an x-range.
+      //   - Sag is clamped so handles never overrun half the gap, which
+      //     prevents the curve from doubling back on close pairs.
       const upstreamLeftOfDownstream = fromRight <= toLeft;
       const upstreamRightOfDownstream = toRight <= fromLeft;
-      let x1: number;
-      let x2: number;
-      if (upstreamLeftOfDownstream) {
-        x1 = fromRight;
-        x2 = toLeft;
-      } else if (upstreamRightOfDownstream) {
-        x1 = fromLeft;
-        x2 = toRight;
-      } else {
-        x1 = fromLeft + fromRect.width / 2;
-        x2 = toLeft + toRect.width / 2;
-      }
-      const y1 = fromCenterY;
-      const y2 = toCenterY;
+      const horizontallySeparated =
+        upstreamLeftOfDownstream || upstreamRightOfDownstream;
+      const upstreamAboveDownstream = fromBottom <= toTop;
+      const upstreamBelowDownstream = toBottom <= fromTop;
+      const verticallySeparated =
+        upstreamAboveDownstream || upstreamBelowDownstream;
 
-      // Cubic bezier with horizontal sag — control points pulled along the
-      // x-axis by ~⅓ of the horizontal distance so the curve bows out
-      // gently rather than spiking vertically when y1 ≈ y2.
-      const dx = Math.abs(x2 - x1);
-      const sag = Math.max(24, Math.min(120, dx * 0.35));
-      const cx1 = upstreamLeftOfDownstream ? x1 + sag : x1 - sag;
-      const cx2 = upstreamLeftOfDownstream ? x2 - sag : x2 + sag;
-      const d = `M ${x1} ${y1} C ${cx1} ${y1}, ${cx2} ${y2}, ${x2} ${y2}`;
+      function clampSag(gap: number): number {
+        // ×0.45 keeps the handles inside the gap (monotonic curve); the 8px
+        // floor keeps a visible bow even when the cards are nearly flush.
+        return Math.max(8, Math.min(120, gap * 0.45));
+      }
+
+      let x1: number;
+      let y1: number;
+      let x2: number;
+      let y2: number;
+      let cx1: number;
+      let cy1: number;
+      let cx2: number;
+      let cy2: number;
+
+      if (horizontallySeparated) {
+        x1 = upstreamLeftOfDownstream ? fromRight : fromLeft;
+        x2 = upstreamLeftOfDownstream ? toLeft : toRight;
+        y1 = fromCenterY;
+        y2 = toCenterY;
+        const dx = Math.abs(x2 - x1);
+        const sag = clampSag(dx);
+        cx1 = upstreamLeftOfDownstream ? x1 + sag : x1 - sag;
+        cx2 = upstreamLeftOfDownstream ? x2 - sag : x2 + sag;
+        cy1 = y1;
+        cy2 = y2;
+      } else if (verticallySeparated) {
+        // Same column, stacked. Anchor on facing top/bottom edges, x-centered.
+        // The handles need both a y-component (sag — points into the gap so
+        // tangents emerge from the anchors along the direction of travel)
+        // AND an x-component (bow — pulls the curve sideways so it doesn't
+        // degenerate into a straight line that's visually indistinguishable
+        // against the cards). The result is a gentle "(" arc beside the
+        // column with the same smooth-curve character as the across-column
+        // connector rotated 90°.
+        x1 = fromCenterX;
+        x2 = toCenterX;
+        y1 = upstreamAboveDownstream ? fromBottom : fromTop;
+        y2 = upstreamAboveDownstream ? toTop : toBottom;
+        const dy = Math.abs(y2 - y1);
+        const sag = clampSag(dy);
+        const bow = Math.max(6, Math.min(22, dy * 0.18));
+        cx1 = x1 + bow;
+        cx2 = x2 + bow;
+        cy1 = upstreamAboveDownstream ? y1 + sag : y1 - sag;
+        cy2 = upstreamAboveDownstream ? y2 - sag : y2 + sag;
+      } else {
+        // Cards overlap on both axes (rare — same cell). Fall back to
+        // center-to-center with a horizontal bow so the curve at least
+        // renders as a visible arc rather than collapsing to a dot.
+        x1 = fromCenterX;
+        x2 = toCenterX;
+        y1 = fromCenterY;
+        y2 = toCenterY;
+        cx1 = x1 + 24;
+        cx2 = x2 + 24;
+        cy1 = y1;
+        cy2 = y2;
+      }
+      const d = `M ${x1} ${y1} C ${cx1} ${cy1}, ${cx2} ${cy2}, ${x2} ${y2}`;
+      const hovered =
+        hoveredTaskId !== null &&
+        (pair.from === hoveredTaskId || pair.to === hoveredTaskId);
       next.push({
         key: `${pair.from}->${pair.to}`,
         d,
-        emphasized: true,
+        flow: pair.flow,
+        hovered,
       });
     }
     setPaths(next);
@@ -173,20 +302,46 @@ export function WiringOverlay({
         inset: 0,
         pointerEvents: "none",
         overflow: "visible",
-        zIndex: 5,
+        // Above the task cards (which sit in the matrix grid's default
+        // stacking context) so vertical curves between stacked cards aren't
+        // painted over by the cards' opaque backgrounds. `pointer-events:
+        // none` keeps drag/click semantics untouched.
+        zIndex: 20,
       }}
     >
-      {paths.map((path) => (
-        <path
-          key={path.key}
-          d={path.d}
-          fill="none"
-          stroke="var(--accent)"
-          strokeOpacity={path.emphasized ? 0.85 : 0.35}
-          strokeWidth={1.25}
-          strokeLinecap="round"
-        />
-      ))}
+      <defs>
+        <filter
+          id={glowFilterId}
+          x="-50%"
+          y="-50%"
+          width="200%"
+          height="200%"
+        >
+          <feGaussianBlur stdDeviation="2" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
+      {paths.map((path) => {
+        const style = resolveStyle(path.flow, path.hovered);
+        if (style.opacity === 0) return null;
+        return (
+          <path
+            key={path.key}
+            data-flow={path.flow}
+            data-hovered={path.hovered ? "true" : undefined}
+            d={path.d}
+            fill="none"
+            stroke="var(--accent)"
+            strokeOpacity={style.opacity}
+            strokeWidth={style.width}
+            strokeLinecap="round"
+            filter={style.glow ? `url(#${glowFilterId})` : undefined}
+          />
+        );
+      })}
     </svg>
   );
 }

--- a/products/dashboard/lib/workflows/active-flow.ts
+++ b/products/dashboard/lib/workflows/active-flow.ts
@@ -1,0 +1,140 @@
+import type {
+  TaskIOSummary,
+  WorkflowSkill,
+  WorkflowStage,
+  WorkflowTask,
+} from "@/lib/workflows/types";
+
+/**
+ * Per-edge classification consumed by the wiring overlay to decide which
+ * paths are emphasized, ghosted, or hidden. Names map to UX intent rather
+ * than raw task status so the overlay never has to re-derive the rule.
+ */
+export type EdgeFlowState =
+  | "next"
+  | "current"
+  | "producing"
+  | "settled"
+  | "dormant";
+
+const ACTIVE_STATUSES = new Set<WorkflowTask["status"]>([
+  "in_progress",
+  "running",
+]);
+const PENDING_STATUSES = new Set<WorkflowTask["status"]>([
+  "not_started",
+  "waiting",
+]);
+
+/**
+ * "Active" = work happening now (in_progress/running) OR work the user could
+ * pick up next (a pending task whose linked inputs are all met). Drives the
+ * default-collapse seeding and the wire classification.
+ */
+export function isTaskActive(task: WorkflowTask, io?: TaskIOSummary): boolean {
+  if (ACTIVE_STATUSES.has(task.status)) return true;
+  if (PENDING_STATUSES.has(task.status)) {
+    return Boolean(io) && !io!.hasUnmetLinkedInput;
+  }
+  return false;
+}
+
+export function isTaskSettled(task: WorkflowTask): boolean {
+  return task.status === "complete";
+}
+
+function buildIoIndex(io: TaskIOSummary[]): Map<string, TaskIOSummary> {
+  return new Map(io.map((s) => [s.taskId, s]));
+}
+
+export function activeStageIds(
+  tasks: WorkflowTask[],
+  io: TaskIOSummary[],
+): Set<string> {
+  const idx = buildIoIndex(io);
+  const out = new Set<string>();
+  for (const t of tasks) {
+    if (isTaskActive(t, idx.get(t.id))) out.add(t.stageId);
+  }
+  return out;
+}
+
+export function activeSkillIds(
+  tasks: WorkflowTask[],
+  io: TaskIOSummary[],
+): Set<string> {
+  const idx = buildIoIndex(io);
+  const out = new Set<string>();
+  for (const t of tasks) {
+    if (isTaskActive(t, idx.get(t.id))) out.add(t.skillId);
+  }
+  return out;
+}
+
+export function classifyEdge(
+  from: WorkflowTask,
+  to: WorkflowTask,
+  toIO?: TaskIOSummary,
+): EdgeFlowState {
+  const fromComplete = from.status === "complete";
+  const toComplete = to.status === "complete";
+  const fromActive = ACTIVE_STATUSES.has(from.status);
+  const toActive = ACTIVE_STATUSES.has(to.status);
+  if (fromComplete && toComplete) return "settled";
+  if (fromComplete && toActive) return "current";
+  if (
+    fromComplete &&
+    PENDING_STATUSES.has(to.status) &&
+    toIO &&
+    !toIO.hasUnmetLinkedInput
+  ) {
+    return "next";
+  }
+  if (fromActive) return "producing";
+  return "dormant";
+}
+
+/**
+ * Seed the matrix's `collapsedStageIds` set on mount. Returns the set of
+ * stages that should start collapsed.
+ *   - any active work → collapse stages without active tasks
+ *   - all complete → collapse everything (review mode is fully folded)
+ *   - kickoff (nothing started) → collapse all but the first stage
+ */
+export function seedCollapsedStages(
+  tasks: WorkflowTask[],
+  io: TaskIOSummary[],
+  stages: WorkflowStage[],
+): Set<string> {
+  const active = activeStageIds(tasks, io);
+  if (active.size > 0) {
+    return new Set(stages.filter((s) => !active.has(s.id)).map((s) => s.id));
+  }
+  if (tasks.length > 0 && tasks.every(isTaskSettled)) {
+    return new Set(stages.map((s) => s.id));
+  }
+  if (stages.length <= 1) return new Set();
+  return new Set(stages.slice(1).map((s) => s.id));
+}
+
+/**
+ * Seed `collapsedSkillIds` on mount.
+ *   - any active work → collapse skills without active tasks
+ *   - all complete → collapse every skill (matches the fully-folded stages)
+ *   - kickoff → leave skills expanded so the focused first stage isn't
+ *     reduced to a single visible row
+ */
+export function seedCollapsedSkills(
+  tasks: WorkflowTask[],
+  io: TaskIOSummary[],
+  skills: WorkflowSkill[],
+): Set<string> {
+  const active = activeSkillIds(tasks, io);
+  if (active.size > 0) {
+    return new Set(skills.filter((s) => !active.has(s.id)).map((s) => s.id));
+  }
+  if (tasks.length > 0 && tasks.every(isTaskSettled)) {
+    return new Set(skills.map((s) => s.id));
+  }
+  return new Set();
+}


### PR DESCRIPTION
## Summary

PR 8 — closing PR for the [Playbook Drawer redesign](https://linear.app/aelizondo/issue/AEL-58) ([AEL-66](https://linear.app/aelizondo/issue/AEL-66)). Bug fixes uncovered post-PR-7 plus a substantial UX upgrade to the process matrix: a "focus-on-active" default view and a fully classified wiring overlay so the matrix communicates *where the flow is right now* without the user having to expand or read.

- **Linked-input back-fill** (resolves the missing wiring SVG bug from PR 7). The picker now stamps `upstreamTaskRef` alongside `upstreamOutputId`, and the overlay back-fills it from `outputId → playbookId → task.playbookId` for older instances. No data migration required.
- **Focus-on-active default view.** New `lib/workflows/active-flow.ts` helper aggregates active stages/skills and seeds collapse state on mount (kickoff = only first stage; all-complete = fully folded; in-flight = only the active region). An effect auto-expands newly-active regions one-way as work progresses — manual collapses survive.
- **Wiring overlay polish.** Each edge gets a flow class: `next` (glow), `current`, `producing`, `settled`, `dormant` (hidden until hover). Hierarchy makes the matrix-wide "do this!" handoff the only glowing wire.
- **Bezier routing fix.** Same-column stacked cards now render a visible subtle "(" arc instead of a hidden straight line; sag is clamped so close pairs no longer produce self-crossing curves.
- **Drawer status menu.** `StatusBadgePopover` extracted from `task-card.tsx` and reused in the drawer header. `PlaybookDrawer.handleStatusChange` calls `setTaskStatusAction`.
- **Status-popover click-through fix.** Collapsed two `useDismissPopover` calls (trigger wrapper + portaled panel) into a single hook that accepts multiple refs, so item clicks no longer dismiss before firing.

## Test plan

- [x] `npx tsc --noEmit` clean (pre-existing `__tests__/auth/*` + `top-bar.test.tsx` errors remain out of scope)
- [x] `npx vitest run __tests__/components/workflows __tests__/lib/workflows/active-flow.test.ts` — 89/89 pass
- [ ] Smoke: navigate `/workflows/<instanceId>` for an instance with mixed task states — only active region expanded, wires visible per flow class
- [ ] Smoke: change status from the drawer header → matrix updates optimistically + dependent stages auto-expand
- [ ] Smoke: hover a card → connected wires brighten incl. dormant ones
- [ ] Smoke: all-complete instance opens fully collapsed; kickoff opens with only first stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)