### PR TITLE
feat(dashboard): multi-card matrix cells + collapsed-row UX

### DIFF
--- a/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
@@ -276,7 +276,7 @@ describe("ProcessMatrix", () => {
     expect(within(cell).getByTestId("task-mini-k-1")).toBeInTheDocument();
   });
 
-  it("collapses an individual skill row and renders mini cells across the row", async () => {
+  it("collapses an individual skill row to compact cards, keeping the skill name visible", async () => {
     const inst = instance([
       task({ id: "k-1", skillId: "sales-ops", stageId: "pre-sales", status: "in_progress" }),
       task({ id: "k-2", skillId: "sales-ops", stageId: "validation", status: "complete" }),
@@ -292,12 +292,22 @@ describe("ProcessMatrix", () => {
 
     const row = screen.getByTestId("matrix-skill-row-sales-ops");
     expect(row).toHaveAttribute("data-collapsed", "true");
+    // Per-row collapse keeps the skill name visible (only the owners
+    // line is suppressed) so the row header still reads at a glance.
     expect(
-      screen.queryByTestId("matrix-skill-label-sales-ops"),
-    ).not.toBeInTheDocument();
-    expect(screen.getByTestId("task-mini-k-1")).toBeInTheDocument();
+      screen.getByTestId("matrix-skill-label-sales-ops"),
+    ).toBeInTheDocument();
+    // Single-task cell in a normal-width column swaps from the bare-
+    // avatar mini stack to a compact TaskCard with the playbook name —
+    // the collapsed row stays scannable without expanding it.
+    const cardK1 = screen.getByTestId("task-card-k-1");
+    expect(cardK1).toBeInTheDocument();
+    expect(cardK1).toHaveAttribute("data-variant", "compact");
+    // k-2 sits in the `validation` column, which the active-flow seed
+    // auto-collapses (no active task lives there), so the cell is
+    // narrow and the bare-avatar mini stack stays the right rendering.
     expect(screen.getByTestId("task-mini-k-2")).toBeInTheDocument();
-    // Other rows remain expanded.
+    // Other rows are unaffected by toggling sales-ops.
     expect(screen.getByTestId("task-card-k-3")).toBeInTheDocument();
   });
 

--- a/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
+++ b/products/dashboard/__tests__/components/workflows/process-matrix.test.tsx
@@ -58,9 +58,10 @@ vi.mock("@/app/(dashboard)/framework/actions", () => ({
   listPlaybookOutputsAction: vi.fn(async () => []),
 }));
 
-vi.mock("@/lib/monitoring", () => ({
-  captureError: mockCaptureError,
-}));
+vi.mock("@/lib/monitoring", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/monitoring")>();
+  return { ...actual, captureError: mockCaptureError };
+});
 
 const mockRouter = { replace: vi.fn(), push: vi.fn() };
 const mockSearchParams = new URLSearchParams("edit=1");
@@ -341,6 +342,121 @@ describe("ProcessMatrix", () => {
     expect(screen.getByRole("dialog", { name: "Add playbook" })).toBeInTheDocument();
     // No allowed playbooks → empty state. Use a stub task instead by mocking
     // out the playbook list path: skip until we have a populated picker.
+  });
+
+  it("renders two compact cards when a cell holds two tasks", () => {
+    const inst = instance([
+      task({ id: "k-1", playbookId: "pb-a", createdAt: "2026-04-19T12:00:00Z" }),
+      task({ id: "k-2", playbookId: "pb-b", createdAt: "2026-04-19T13:00:00Z" }),
+    ]);
+
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} />);
+
+    // Both cards render — vertically stacked — and start in the compact
+    // variant (the previous single-task lookup would have hidden one).
+    expect(screen.getByTestId("task-card-k-1")).toHaveAttribute(
+      "data-variant",
+      "compact",
+    );
+    expect(screen.getByTestId("task-card-k-2")).toHaveAttribute(
+      "data-variant",
+      "compact",
+    );
+  });
+
+  it("promotes a compact card to full when clicked, then opens the drawer on a second click", async () => {
+    const inst = instance([
+      task({ id: "k-1", playbookId: "pb-a", createdAt: "2026-04-19T12:00:00Z" }),
+      task({ id: "k-2", playbookId: "pb-b", createdAt: "2026-04-19T13:00:00Z" }),
+    ]);
+    const user = userEvent.setup();
+
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} />);
+
+    await user.click(screen.getByTestId("task-card-k-1"));
+
+    // After promotion the same DOM element switches `data-variant` —
+    // the root stays mounted so CSS can animate the height morph.
+    expect(screen.getByTestId("task-card-k-1")).toHaveAttribute(
+      "data-variant",
+      "full",
+    );
+    expect(screen.getByTestId("task-card-k-2")).toHaveAttribute(
+      "data-variant",
+      "compact",
+    );
+
+    // Second click on the promoted full card opens the playbook drawer.
+    await user.click(screen.getByTestId("task-card-k-1"));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("collapses a promoted card back to compact when the demote button is clicked", async () => {
+    const inst = instance([
+      task({ id: "k-1", playbookId: "pb-a", createdAt: "2026-04-19T12:00:00Z" }),
+      task({ id: "k-2", playbookId: "pb-b", createdAt: "2026-04-19T13:00:00Z" }),
+    ]);
+    const user = userEvent.setup();
+
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} />);
+
+    await user.click(screen.getByTestId("task-card-k-1"));
+    expect(screen.getByTestId("task-card-k-1")).toHaveAttribute(
+      "data-variant",
+      "full",
+    );
+
+    await user.click(screen.getByLabelText(/Collapse playbook card:/));
+    expect(screen.getByTestId("task-card-k-1")).toHaveAttribute(
+      "data-variant",
+      "compact",
+    );
+  });
+
+  it("exposes a hover-reveal 'Add another' affordance in occupied cells in edit mode", async () => {
+    const inst = instance([
+      task({ id: "k-1", playbookId: "pb-a", createdAt: "2026-04-19T12:00:00Z" }),
+    ]);
+    const user = userEvent.setup();
+
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} editMode />);
+
+    // The "Add another" affordance lives inside the occupied cell — it is
+    // CSS-hidden until the cell is hovered, but it is in the DOM and
+    // accessible by its testid, and clicking it should open the
+    // create-task drawer for the same (skill, stage) pair.
+    const addMore = screen.getByTestId("matrix-add-more-sales-ops-pre-sales");
+    await user.click(addMore);
+
+    expect(
+      screen.getByRole("dialog", { name: "Add playbook" }),
+    ).toBeInTheDocument();
+  });
+
+  it("collapses a multi-task mini cell to a single primary avatar with a +N badge", async () => {
+    const inst = instance([
+      task({ id: "k-1", playbookId: "pb-a", createdAt: "2026-04-19T12:00:00Z" }),
+      task({ id: "k-2", playbookId: "pb-b", createdAt: "2026-04-19T13:00:00Z" }),
+    ]);
+    const user = userEvent.setup();
+
+    renderWithTopBarProvider(<ProcessMatrix instance={inst} template={TEMPLATE} />);
+
+    await user.click(screen.getByTestId("matrix-skill-toggle-sales-ops"));
+
+    // Only the primary avatar is visible — the second task collapses
+    // into a hidden anchor (for wiring) and into the +N badge.
+    expect(screen.getByTestId("task-mini-k-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("task-mini-k-2")).not.toBeInTheDocument();
+    expect(
+      screen.getByLabelText("2 playbooks in this cell"),
+    ).toHaveTextContent("+1");
+
+    // Hidden ghost anchor for k-2 is in the DOM so the wiring overlay
+    // can still measure an endpoint for it.
+    expect(
+      document.querySelector('[data-task-id="k-2"][data-mini="true"]'),
+    ).not.toBeNull();
   });
 
   it("removes a task after confirm", async () => {

--- a/products/dashboard/app/styles/components/process-matrix.css
+++ b/products/dashboard/app/styles/components/process-matrix.css
@@ -1022,7 +1022,7 @@
 }
 
 .mx-stage-hd-collapsed {
-  width: 48px;
+  width: 56px;
   padding: 8px 4px 8px 4px;
   cursor: pointer;
 }
@@ -1109,9 +1109,9 @@
 
 .mx-body-row-collapsed .mx-task-cell,
 .mx-body-row-collapsed .mx-role-cell {
-  height: 48px;
+  height: 56px;
   /* Override the default `min-height: 136px` so collapsed rows can
-   * actually shrink to the 48px header strip. */
+   * actually shrink to the 56px header strip. */
   min-height: 0;
 }
 .mx-body-row-collapsed .mx-role-cell {
@@ -1148,13 +1148,13 @@
   align-items: center;
   justify-content: center;
 }
-/* Column-collapsed body cells: shrink to match the 48px header width.
+/* Column-collapsed body cells: shrink to match the 56px header width.
  * `.mx-task-cell-narrow` is stamped from React on every body cell whose
  * stage column is collapsed. Cells in non-collapsed columns keep their
  * normal 192px width even when the row is row-collapsed (mini display
  * doesn't imply narrow column). */
 .mx-task-cell-narrow {
-  width: 48px;
+  width: 56px;
   padding: 4px 2px;
 }
 
@@ -1170,7 +1170,7 @@
   cursor: pointer;
   position: relative;
 }
-/* Status halo. Sits behind the 32px ItemAvatar and glows in the task's
+/* Status halo. Sits behind the 40px ItemAvatar and glows in the task's
  * status color; absent for `not_started` (no `--status-color` set). The
  * `data-pulse` flag on `pending_approval` swaps in a slow pulsing variant
  * so a checkpoint that needs attention reads even at the mini scale. */
@@ -1179,8 +1179,8 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
   border-radius: 9999px;
   transform: translate(-50%, -50%);
   pointer-events: none;
@@ -1206,14 +1206,14 @@
     animation: none;
   }
 }
-/* Avatar-sized anchor inside the mini cell. Sized exactly to the md
- * avatar (32px) so the FloatingHoverTooltip — which anchors to its
+/* Avatar-sized anchor inside the mini cell. Sized exactly to the lg
+ * avatar (40px) so the FloatingHoverTooltip — which anchors to its
  * parent element — floats above the avatar rather than the full cell. */
 .mx-mini-cell-anchor {
   position: relative;
   display: inline-flex;
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
 }
 /* "In progress" wave on the mini avatar — mirrors the active task card's
  * shimmer (`ainative-card-wave`, defined in task-card.css). The alpha is
@@ -1340,11 +1340,11 @@
   height: 100%;
 }
 .mx-mini-stack .mx-mini-cell-btn {
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
   flex-shrink: 0;
 }
-/* Primary avatar wrapper. Sized explicitly to the 32px avatar so the
+/* Primary avatar wrapper. Sized explicitly to the 40px avatar so the
  * wiring overlay's `getBoundingClientRect()` reports the avatar's
  * footprint (and not the inline-flex parent's content-derived size,
  * which subtly varied across browser versions when the absolutely-
@@ -1355,8 +1355,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
 }
 /* Count badge: "+N" pill anchored to the primary avatar's top-right.
  * Sits above the avatar's status halo so the count stays legible.
@@ -1428,8 +1428,8 @@
   }
 }
 .mx-mini-stack-panel-item {
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/products/dashboard/app/styles/components/process-matrix.css
+++ b/products/dashboard/app/styles/components/process-matrix.css
@@ -1119,7 +1119,6 @@
   padding-bottom: 6px;
   padding-right: 6px;
 }
-.mx-body-row-collapsed .mx-role-name,
 .mx-body-row-collapsed .mx-role-owner {
   display: none;
 }

--- a/products/dashboard/app/styles/components/process-matrix.css
+++ b/products/dashboard/app/styles/components/process-matrix.css
@@ -1387,12 +1387,23 @@
   border: 1px solid var(--border-hi);
   z-index: 2;
 }
-/* Hidden anchors for non-primary tasks — they occupy the primary's
- * footprint so the wiring overlay can still measure them, but they
- * do not paint and do not intercept pointer events. */
+/* Hidden anchors for non-primary tasks. Pinned to the primary's
+ * 40×40 footprint at the mini-stack center so the wiring overlay's
+ * `getBoundingClientRect()` returns the avatar's rect (not the full
+ * cell rect). Without this, when a sibling card promoted to full
+ * grew the row tall, `inset: 0` made the ghost the full row's
+ * height, so wires targeting a ghost terminated at the cell edge —
+ * visually drifting away from the avatar. The mini-stack itself is
+ * `align-items: center; justify-content: center; height: 100%`, so
+ * a 40×40 box centered with `top/left 50% + translate(-50%, -50%)`
+ * lands exactly on the primary's footprint. */
 .mx-mini-stack-ghost {
   position: absolute;
-  inset: 0;
+  top: 50%;
+  left: 50%;
+  width: 40px;
+  height: 40px;
+  transform: translate(-50%, -50%);
   visibility: hidden;
   pointer-events: none;
 }

--- a/products/dashboard/app/styles/components/process-matrix.css
+++ b/products/dashboard/app/styles/components/process-matrix.css
@@ -497,15 +497,18 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  /* Locked height keeps the row stable while task cards are dragged in/out.
-   * Card height = 120px + cell padding (7×2) + breathing → 136px. */
-  height: 136px;
+  /* Floor matches a 1-card row (120px card + 7×2 cell padding + breathing
+   * → 136px). When the row grows because a body cell promotes / stacks
+   * 3+ cards, the row's flex layout stretches every sibling — including
+   * this role cell — to match. `min-height` is the floor; `height: auto`
+   * (the default) lets the cell follow the row's content-driven height. */
+  min-height: 136px;
   overflow: visible;
   /* Match the cell transition timing so role + body cells collapse together
    * (otherwise the row header lags and a 1-frame gap shows mid-collapse). */
   transition:
     width 0.22s cubic-bezier(0.16, 1, 0.3, 1),
-    height 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    min-height 0.22s cubic-bezier(0.16, 1, 0.3, 1),
     padding 0.22s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .mx-role-cell:hover,
@@ -624,18 +627,21 @@
   flex-shrink: 0;
   padding: 7px;
   border-right: 1px solid var(--border-2);
-  /* Locked height matches `.mx-role-cell` so the row stays a stable
-   * rectangle while task cards drag in/out. The card itself is 120px
-   * (set in task-card.css); cell padding 7×2 = 14, plus 2px breathing →
-   * 136px. */
-  height: 136px;
+  /* `min-height` (not `height`) so a cell with 3+ stacked compact cards
+   * — or one with promoted full cards alongside compacts — can grow
+   * vertically. The row's flex layout stretches every cell in the row
+   * to the tallest sibling, so one busy cell pulls its row taller in
+   * lockstep. Default 136px matches `.mx-role-cell` so the common 0-
+   * and 1-card cases sit on the same rectangle as before. */
+  min-height: 136px;
   background: var(--bg);
-  /* Animate height + width + padding so row/column collapse/expand reads
-   * as a smooth fold rather than an instant snap. Hover background keeps
-   * its faster timing so it doesn't lag behind the cursor. */
+  /* Animate min-height + width + padding so row/column collapse/expand
+   * and stack growth read as a smooth fold rather than an instant snap.
+   * Hover background keeps its faster timing so it doesn't lag behind
+   * the cursor. */
   transition:
     background 0.14s,
-    height 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+    min-height 0.22s cubic-bezier(0.16, 1, 0.3, 1),
     width 0.22s cubic-bezier(0.16, 1, 0.3, 1),
     padding 0.22s cubic-bezier(0.16, 1, 0.3, 1);
 }
@@ -1016,7 +1022,7 @@
 }
 
 .mx-stage-hd-collapsed {
-  width: 36px;
+  width: 48px;
   padding: 8px 4px 8px 4px;
   cursor: pointer;
 }
@@ -1103,7 +1109,10 @@
 
 .mx-body-row-collapsed .mx-task-cell,
 .mx-body-row-collapsed .mx-role-cell {
-  height: 36px;
+  height: 48px;
+  /* Override the default `min-height: 136px` so collapsed rows can
+   * actually shrink to the 48px header strip. */
+  min-height: 0;
 }
 .mx-body-row-collapsed .mx-role-cell {
   padding-top: 6px;
@@ -1139,13 +1148,13 @@
   align-items: center;
   justify-content: center;
 }
-/* Column-collapsed body cells: shrink to match the 36px header width.
+/* Column-collapsed body cells: shrink to match the 48px header width.
  * `.mx-task-cell-narrow` is stamped from React on every body cell whose
  * stage column is collapsed. Cells in non-collapsed columns keep their
  * normal 192px width even when the row is row-collapsed (mini display
  * doesn't imply narrow column). */
 .mx-task-cell-narrow {
-  width: 36px;
+  width: 48px;
   padding: 4px 2px;
 }
 
@@ -1161,7 +1170,7 @@
   cursor: pointer;
   position: relative;
 }
-/* Status halo. Sits behind the 22px ItemAvatar and glows in the task's
+/* Status halo. Sits behind the 32px ItemAvatar and glows in the task's
  * status color; absent for `not_started` (no `--status-color` set). The
  * `data-pulse` flag on `pending_approval` swaps in a slow pulsing variant
  * so a checkpoint that needs attention reads even at the mini scale. */
@@ -1170,8 +1179,8 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 22px;
-  height: 22px;
+  width: 32px;
+  height: 32px;
   border-radius: 9999px;
   transform: translate(-50%, -50%);
   pointer-events: none;
@@ -1197,14 +1206,14 @@
     animation: none;
   }
 }
-/* Avatar-sized anchor inside the mini cell. Sized exactly to the xs
- * avatar (22px) so the FloatingHoverTooltip — which anchors to its
+/* Avatar-sized anchor inside the mini cell. Sized exactly to the md
+ * avatar (32px) so the FloatingHoverTooltip — which anchors to its
  * parent element — floats above the avatar rather than the full cell. */
 .mx-mini-cell-anchor {
   position: relative;
   display: inline-flex;
-  width: 22px;
-  height: 22px;
+  width: 32px;
+  height: 32px;
 }
 /* "In progress" wave on the mini avatar — mirrors the active task card's
  * shimmer (`ainative-card-wave`, defined in task-card.css). The alpha is
@@ -1242,3 +1251,191 @@
   outline-offset: -2px;
 }
 
+/* ── Multi-card cells ──
+ * A cell can host N tasks (typically 0–1, sometimes 2–3). One task →
+ * full TaskCard, unchanged. Two or more → compact stack: each card is
+ * the one-row `.task-card-compact` variant (see task-card.css). The
+ * stack is a vertical flex so it fills the cell from top to bottom,
+ * and any card the user "promotes" (click) renders as a full TaskCard
+ * in-place, growing the cell (and therefore the row) as needed. */
+.mx-cell-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  min-height: 100%;
+}
+/* When a stack has 2+ cards we want the row to *not* jump from 1→2
+ * cards: two compacts (52px each) + 8px gap = 112px, plus the cell's
+ * 7+7 padding = 126px, which fits inside the 136px default. The
+ * `min-height: 0` on the stack is needed inside the flex parent so
+ * children measure naturally instead of inheriting `100%`. */
+.mx-cell-stack-multi {
+  min-height: 0;
+}
+
+/* ── Add another playbook ──
+ * Hover-reveal pill anchored at the bottom of an occupied cell in
+ * edit mode. Mirrors the empty-cell "+" treatment but as a wider,
+ * one-line affordance so it doesn't compete visually with a card. */
+.mx-add-more-btn {
+  align-self: stretch;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: 22px;
+  margin-top: auto;
+  padding: 0 8px;
+  border: 1px dashed transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--t3);
+  font-size: 10.5px;
+  font-weight: 500;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(4px);
+  transition:
+    opacity 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 0.18s,
+    color 0.18s,
+    background 0.18s;
+}
+.mx-task-cell:hover .mx-add-more-btn,
+.mx-task-cell:focus-within .mx-add-more-btn {
+  opacity: 1;
+  transform: translateY(0);
+}
+.mx-add-more-btn:hover {
+  color: var(--accent);
+  border-color: var(--border-hi);
+  background: rgba(129, 140, 248, 0.06);
+}
+.mx-add-more-btn:focus-visible {
+  opacity: 1;
+  transform: translateY(0);
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+/* During a drag, suppress the "+" affordance so it doesn't fight with
+ * the drop target's hover-reveal cues. */
+.matrix-wrap[data-dragging="true"] .mx-add-more-btn {
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── Mini stack (collapsed row / column) ──
+ * A single primary avatar always renders, even when the cell holds N
+ * tasks. With 2+ tasks the primary gets a `+N` badge so the cell never
+ * grows / overflows, and a hover panel (portaled) fans out the full
+ * list of avatars beside the cell. */
+.mx-mini-stack {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+.mx-mini-stack .mx-mini-cell-btn {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+}
+/* Primary avatar wrapper. Sized explicitly to the 32px avatar so the
+ * wiring overlay's `getBoundingClientRect()` reports the avatar's
+ * footprint (and not the inline-flex parent's content-derived size,
+ * which subtly varied across browser versions when the absolutely-
+ * positioned `+N` badge was the only other child). Wires now anchor
+ * dead-center on the avatar's edges. */
+.mx-mini-stack-primary {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+}
+/* Count badge: "+N" pill anchored to the primary avatar's top-right.
+ * Sits above the avatar's status halo so the count stays legible.
+ * Intentionally quiet — a neutral surface chip rather than the bright
+ * accent, since the badge is metadata, not a primary affordance.
+ * Flex centering + `line-height: 1` ensures the digits sit exactly on
+ * the badge's optical center (avoiding the slight low-baseline drift
+ * line-height: 13px caused with 8.5px text). */
+.mx-mini-stack-badge {
+  position: absolute;
+  top: -3px;
+  right: -7px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 4px;
+  border-radius: 9999px;
+  background: var(--bg-3);
+  color: var(--t2);
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+  pointer-events: none;
+  border: 1px solid var(--border-hi);
+  z-index: 2;
+}
+/* Hidden anchors for non-primary tasks — they occupy the primary's
+ * footprint so the wiring overlay can still measure them, but they
+ * do not paint and do not intercept pointer events. */
+.mx-mini-stack-ghost {
+  position: absolute;
+  inset: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+/* Hover panel: vertical strip of clickable avatars portaled to the
+ * document body so it floats above the matrix scroll wrap (which has
+ * overflow: auto and would otherwise clip the panel). Positioned with
+ * inline `top` / `left` from React using the anchor's getBoundingClientRect. */
+.mx-mini-stack-panel {
+  position: fixed;
+  z-index: 70;
+  /* `top` is anchored to the primary's vertical center; translate up by
+   * half the panel height so the panel floats centered on the avatar. */
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 6px;
+  border-radius: 8px;
+  border: 1px solid var(--border-hi);
+  background: var(--bg-2);
+  box-shadow: var(--shadow-canvas, var(--shadow));
+  animation: mx-mini-stack-panel-in 0.14s ease-out;
+}
+@keyframes mx-mini-stack-panel-in {
+  from {
+    opacity: 0;
+    transform: translate(-4px, -50%);
+  }
+  to {
+    opacity: 1;
+    transform: translate(0, -50%);
+  }
+}
+.mx-mini-stack-panel-item {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+@media (prefers-reduced-motion: reduce) {
+  .mx-mini-stack-panel {
+    animation: none;
+  }
+}

--- a/products/dashboard/app/styles/components/process-matrix.css
+++ b/products/dashboard/app/styles/components/process-matrix.css
@@ -1109,14 +1109,14 @@
 
 .mx-body-row-collapsed .mx-task-cell,
 .mx-body-row-collapsed .mx-role-cell {
-  height: 56px;
+  height: 48px;
   /* Override the default `min-height: 136px` so collapsed rows can
-   * actually shrink to the 56px header strip. */
+   * actually shrink to hug the 40px avatar (4px top/bottom padding). */
   min-height: 0;
 }
 .mx-body-row-collapsed .mx-role-cell {
-  padding-top: 6px;
-  padding-bottom: 6px;
+  padding-top: 4px;
+  padding-bottom: 4px;
   padding-right: 6px;
 }
 .mx-body-row-collapsed .mx-role-owner {
@@ -1142,7 +1142,11 @@
  * inside an expanded (140px) row keeps the cell tall and the avatar
  * floats vertically centered. */
 .mx-task-cell-mini {
-  padding: 4px;
+  /* Vertical padding stays tight so a 40px avatar / compact card fits
+   * inside the 48px collapsed row strip; horizontal padding matches the
+   * default cell's 7px so a compact-as-mini card has the same left/right
+   * margin as a card rendered in an expanded row of the same column. */
+  padding: 4px 7px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1261,6 +1265,11 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  /* Stretch in both axes so a compact-as-mini card (rendered through
+   * this stack inside an `mx-task-cell-mini` row with `justify-content:
+   * center`) still fills the cell's full inner width, matching the
+   * width of an expanded-row card in the same column. */
+  width: 100%;
   height: 100%;
   min-height: 100%;
 }

--- a/products/dashboard/app/styles/components/task-card.css
+++ b/products/dashboard/app/styles/components/task-card.css
@@ -806,16 +806,6 @@
 .tc-compact-status {
   flex-shrink: 0;
 }
-.tc-compact-actions {
-  flex-shrink: 0;
-  margin-left: -4px;
-  opacity: 0;
-  transition: opacity 0.15s;
-}
-.task-card.task-card-compact:hover .tc-compact-actions,
-.task-card.task-card-compact:focus-within .tc-compact-actions {
-  opacity: 1;
-}
 /* Info badges in compact mode — replace the status pill spot when the
  * task has any note / checkpoint / failure / completion signal. Slightly
  * smaller chips (18px instead of 22px) so a row of 2–3 badges still

--- a/products/dashboard/app/styles/components/task-card.css
+++ b/products/dashboard/app/styles/components/task-card.css
@@ -13,12 +13,56 @@
   border-radius: 7px;
   border: 1px solid var(--border);
   background: var(--bg-2);
-  transition: all 0.15s;
+  /* Hover-only properties keep the original snappy 0.15s timing. The
+   * compact↔full morph uses a longer 0.24s ease-out so the height,
+   * padding, and gap transitions read as a deliberate fold rather
+   * than a snap. `flex-direction` cannot transition (CSS spec) — its
+   * change is instant — so the children swap is masked by the
+   * container animation + the per-child fade-in keyframe below. */
+  transition:
+    height 0.24s cubic-bezier(0.16, 1, 0.3, 1),
+    padding 0.24s cubic-bezier(0.16, 1, 0.3, 1),
+    gap 0.24s cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 0.15s,
+    background 0.15s,
+    box-shadow 0.25s,
+    opacity 0.15s,
+    transform 0.15s;
   display: flex;
   flex-direction: column;
   gap: 4px;
   position: relative;
   overflow: visible;
+}
+/* Fresh children of a compact↔full swap fade in over the container
+ * morph. New DOM gets mounted whenever `variant` changes (the compact
+ * body and the full body share no elements), so the keyframe replays
+ * on every variant flip with no manual triggering. We target direct
+ * children only, so the `::before` accent bar — which persists across
+ * the morph — keeps its own transitions. */
+.task-card > * {
+  animation: tc-content-fade 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+}
+@keyframes tc-content-fade {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .task-card {
+    transition:
+      border-color 0.15s,
+      background 0.15s,
+      opacity 0.15s;
+  }
+  .task-card > * {
+    animation: none !important;
+  }
 }
 .task-card::before {
   content: "";
@@ -729,4 +773,97 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* ── Compact task card ──
+ * One-row variant used when a cell holds 2+ tasks. Same accent-bar +
+ * status-tint treatment as the full card so a compact card and a full
+ * card in the same cell read as the same family of state; the layout
+ * differs: avatar + truncated title + status pill in a single row.
+ * Designed so two compacts (52px each, 8px gap) fit inside the matrix
+ * cell's 136px default without growing the row. */
+.task-card.task-card-compact {
+  height: 52px;
+  padding: 8px 10px 8px 14px;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  /* Compact cards don't have a bottom row, so the gap defined on the
+   * full card root (`gap: 4px`) would push the avatar off-center.
+   * Explicit gap above takes over. */
+}
+.tc-compact-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--t1);
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tc-compact-status {
+  flex-shrink: 0;
+}
+.tc-compact-actions {
+  flex-shrink: 0;
+  margin-left: -4px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.task-card.task-card-compact:hover .tc-compact-actions,
+.task-card.task-card-compact:focus-within .tc-compact-actions {
+  opacity: 1;
+}
+
+/* ── Demote (collapse-to-compact) button ──
+ * Absolutely positioned in the top-right of a promoted full card. Only
+ * rendered when the parent passes `onDemote`, which happens exclusively
+ * for the promoted sibling in a multi-card cell — so the affordance
+ * naturally never appears on a 1-card cell or on a compact card.
+ * Hover-only on the card itself so it doesn't compete with the title
+ * or status pill at rest. */
+.tc-demote-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  background: var(--bg-2);
+  color: var(--t3);
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(-2px);
+  transition:
+    opacity 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    color 0.15s,
+    background 0.15s,
+    border-color 0.15s;
+  /* Float above the card's ::after shimmer + content so the hit target
+   * stays clickable on active cards. */
+  z-index: 3;
+}
+.task-card:hover > .tc-demote-btn,
+.task-card:focus-within > .tc-demote-btn {
+  opacity: 1;
+  transform: translateY(0);
+}
+.tc-demote-btn:hover {
+  color: var(--t1);
+  background: var(--bg-3);
+  border-color: var(--border-hi);
+}
+.tc-demote-btn:focus-visible {
+  opacity: 1;
+  transform: translateY(0);
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
 }

--- a/products/dashboard/app/styles/components/task-card.css
+++ b/products/dashboard/app/styles/components/task-card.css
@@ -824,21 +824,21 @@
 }
 
 /* ── Demote (collapse-to-compact) button ──
- * Absolutely positioned in the top-right of a promoted full card. Only
- * rendered when the parent passes `onDemote`, which happens exclusively
- * for the promoted sibling in a multi-card cell — so the affordance
- * naturally never appears on a 1-card cell or on a compact card.
- * Hover-only on the card itself so it doesn't compete with the title
- * or status pill at rest. */
+ * Absolutely positioned in the top-right of any full card that exposes
+ * `onDemote`. Right edge sits on the same 12px column as the info
+ * badges and the per-card actions in the rows below, so the three
+ * affordances read as a single right-edge stack rather than drifting
+ * across columns. Hover-only on the card itself so it doesn't compete
+ * with the title at rest. */
 .tc-demote-btn {
   position: absolute;
-  top: 6px;
-  right: 6px;
+  top: 8px;
+  right: 12px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
+  width: 22px;
+  height: 22px;
   padding: 0;
   border: 1px solid transparent;
   border-radius: 9999px;

--- a/products/dashboard/app/styles/components/task-card.css
+++ b/products/dashboard/app/styles/components/task-card.css
@@ -816,6 +816,22 @@
 .task-card.task-card-compact:focus-within .tc-compact-actions {
   opacity: 1;
 }
+/* Info badges in compact mode — replace the status pill spot when the
+ * task has any note / checkpoint / failure / completion signal. Slightly
+ * smaller chips (18px instead of 22px) so a row of 2–3 badges still
+ * fits inside the 52px card alongside the title. */
+.tc-compact-info-badges {
+  flex-shrink: 0;
+  gap: 3px;
+}
+.tc-compact-info-badges .tc-info-badge-icon {
+  width: 18px;
+  height: 18px;
+}
+.tc-compact-info-badges .tc-info-badge-icon > svg {
+  width: 10px;
+  height: 10px;
+}
 
 /* ── Demote (collapse-to-compact) button ──
  * Absolutely positioned in the top-right of a promoted full card. Only

--- a/products/dashboard/app/styles/components/task-card.css
+++ b/products/dashboard/app/styles/components/task-card.css
@@ -248,10 +248,27 @@
   opacity: 1;
 }
 .tc-title {
+  /* Flex container reserves the 2-line area but vertically centers
+   * whatever the inner span renders. Short (1-line) titles sit at the
+   * vertical middle of the area so the absolutely-positioned demote
+   * chevron at `top: 12px` lines up with the text. Long (2-line)
+   * titles fill the area edge-to-edge so the visual is the same as
+   * before for those. */
+  display: flex;
+  align-items: center;
+  /* Reserve two lines of vertical space so single-line titles don't
+   * pull the status pill upward — keeps the pill on a stable baseline. */
+  min-height: calc(1.3em * 2);
+  max-height: calc(1.3em * 2);
   font-size: 11.5px;
   font-weight: 600;
   color: var(--t1);
   line-height: 1.3;
+  /* Reserve the right-edge corner for the absolutely-positioned demote
+   * chevron so the title doesn't run under it on long playbook names. */
+  padding-right: 28px;
+}
+.tc-title > span {
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -259,13 +276,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   word-break: break-word;
-  /* Reserve two lines of vertical space so single-line titles don't pull
-   * the status pill upward — keeps the pill on a stable baseline. */
-  min-height: calc(1.3em * 2);
-  /* Cap at exactly two lines too, so `flex-direction: column` on the card
-   * can't stretch the box and let `-webkit-line-clamp`'d lines leak below
-   * the ellipsis. */
-  max-height: calc(1.3em * 2);
+  width: 100%;
 }
 /* Output pip rail (PR 4 / AEL-62). Renders inline next to the status pill
  * in the card's bottom row, or in the drawer's status section. One pip per
@@ -784,7 +795,10 @@
  * cell's 136px default without growing the row. */
 .task-card.task-card-compact {
   height: 52px;
-  padding: 8px 10px 8px 14px;
+  /* Right padding matches the full card (12px) so the expand chevron in
+   * compact mode sits on the same vertical column as the demote chevron
+   * + info badges + delete button in the full card. */
+  padding: 8px 12px 8px 14px;
   flex-direction: row;
   align-items: center;
   gap: 8px;
@@ -832,7 +846,10 @@
  * with the title at rest. */
 .tc-demote-btn {
   position: absolute;
-  top: 8px;
+  /* Card padding-top (8px) + half the 2-line title box (~15px) − half
+   * the button height (11px) ≈ 12px. Lands the button on the vertical
+   * center of the title area, matching the flex-centered title text. */
+  top: 12px;
   right: 12px;
   display: inline-flex;
   align-items: center;
@@ -840,8 +857,8 @@
   width: 22px;
   height: 22px;
   padding: 0;
-  border: 1px solid transparent;
-  border-radius: 9999px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
   background: var(--bg-2);
   color: var(--t3);
   cursor: pointer;
@@ -870,6 +887,39 @@
 .tc-demote-btn:focus-visible {
   opacity: 1;
   transform: translateY(0);
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* Compact-card expand chevron. Always visible (not hover-only) since
+ * it's the primary affordance on a compact card; lives at the right
+ * end of the flex row so info badges (if any) sit immediately to its
+ * left. Same square / 4px-radius chrome as the demote chevron and the
+ * matrix collapse buttons, just inline-positioned. */
+.tc-expand-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-2);
+  color: var(--t3);
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    background 0.15s,
+    border-color 0.15s;
+}
+.tc-expand-btn:hover {
+  color: var(--t1);
+  background: var(--bg-3);
+  border-color: var(--border-hi);
+}
+.tc-expand-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }

--- a/products/dashboard/app/styles/components/task-card.css
+++ b/products/dashboard/app/styles/components/task-card.css
@@ -791,14 +791,16 @@
  * status-tint treatment as the full card so a compact card and a full
  * card in the same cell read as the same family of state; the layout
  * differs: avatar + truncated title + status pill in a single row.
- * Designed so two compacts (52px each, 8px gap) fit inside the matrix
- * cell's 136px default without growing the row. */
+ * Default height matches the 40px `lg` avatar so a row-collapsed cell
+ * can render a single compact card in place of a bare avatar without
+ * growing taller. Two compacts (40px each + 8px gap = 88px) still fit
+ * inside the matrix cell's 136px default. */
 .task-card.task-card-compact {
-  height: 52px;
+  height: 40px;
   /* Right padding matches the full card (12px) so the expand chevron in
    * compact mode sits on the same vertical column as the demote chevron
    * + info badges + delete button in the full card. */
-  padding: 8px 12px 8px 14px;
+  padding: 0 12px 0 14px;
   flex-direction: row;
   align-items: center;
   gap: 8px;
@@ -823,7 +825,7 @@
 /* Info badges in compact mode — replace the status pill spot when the
  * task has any note / checkpoint / failure / completion signal. Slightly
  * smaller chips (18px instead of 22px) so a row of 2–3 badges still
- * fits inside the 52px card alongside the title. */
+ * fits inside the 40px card alongside the title. */
 .tc-compact-info-badges {
   flex-shrink: 0;
   gap: 3px;

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -1003,6 +1003,16 @@ export function ProcessMatrix({
                     const isStageCollapsed = collapsedStageIds.has(stage.id);
                     const isMini = isStageCollapsed || isSkillCollapsed;
                     const multiCard = cellTasks.length >= 2;
+                    // Row-collapsed single-task cell with a wide column: render
+                    // the compact TaskCard (avatar + playbook name) in place of
+                    // the bare-avatar MiniStackCellContent. Skipped when the
+                    // column is also narrow (no room) or the cell has 2+ tasks
+                    // (compacts stacked would overflow the avatar-height row).
+                    const useCompactAsMini =
+                      isMini &&
+                      isSkillCollapsed &&
+                      !isStageCollapsed &&
+                      cellTasks.length === 1;
 
                     return (
                       <DroppableTaskCell
@@ -1020,7 +1030,7 @@ export function ProcessMatrix({
                         stageCollapsed={isStageCollapsed}
                       >
                         {cellTasks.length > 0 ? (
-                          isMini ? (
+                          isMini && !useCompactAsMini ? (
                             <MiniStackCellContent
                               tasks={cellTasks}
                               playbookById={playbookById}
@@ -1055,13 +1065,14 @@ export function ProcessMatrix({
                                   ? playbookById.get(task.playbookId) ?? null
                                   : null;
                                 const renderCompact =
+                                  useCompactAsMini ||
                                   collapsedTaskIds.has(task.id) ||
                                   (!expandedTaskIds.has(task.id) && multiCard);
                                 return (
                                   <DraggableTaskCard
                                     key={task.id}
                                     taskId={task.id}
-                                    disabled={!editMode}
+                                    disabled={!editMode || useCompactAsMini}
                                     isActive={dragTaskId === task.id}
                                     dataTaskId={task.id}
                                     onHoverStart={() => setHoveredTaskId(task.id)}
@@ -1079,31 +1090,33 @@ export function ProcessMatrix({
                                         task,
                                         canStart(task, localTasks),
                                       )}
-                                      editMode={editMode}
+                                      editMode={editMode && !useCompactAsMini}
                                       ioState={ioByTaskId.get(task.id)}
                                       variant={renderCompact ? "compact" : "full"}
                                       onClick={
-                                        renderCompact
-                                          ? () => expandTask(task.id)
-                                          : editMode
-                                            ? () =>
-                                                setAddTaskFor({
-                                                  mode: "edit",
-                                                  taskId: task.id,
-                                                  skillId: skill.id,
-                                                  skillLabel: skill.label,
-                                                  stageId: stage.id,
-                                                  stageName: stage.label,
-                                                  initial: {
-                                                    playbookId:
-                                                      task.playbookId ?? null,
-                                                    notes: task.notes ?? "",
-                                                    owners: task.owners ?? [],
-                                                    inputs: task.inputs ?? [],
-                                                    outputs: task.outputs ?? [],
-                                                  },
-                                                })
-                                            : () => setSelectedTaskId(task.id)
+                                        useCompactAsMini
+                                          ? () => toggleSkillCollapsed(skill.id)
+                                          : renderCompact
+                                            ? () => expandTask(task.id)
+                                            : editMode
+                                              ? () =>
+                                                  setAddTaskFor({
+                                                    mode: "edit",
+                                                    taskId: task.id,
+                                                    skillId: skill.id,
+                                                    skillLabel: skill.label,
+                                                    stageId: stage.id,
+                                                    stageName: stage.label,
+                                                    initial: {
+                                                      playbookId:
+                                                        task.playbookId ?? null,
+                                                      notes: task.notes ?? "",
+                                                      owners: task.owners ?? [],
+                                                      inputs: task.inputs ?? [],
+                                                      outputs: task.outputs ?? [],
+                                                    },
+                                                  })
+                                              : () => setSelectedTaskId(task.id)
                                       }
                                       onStatusChange={
                                         renderCompact || editMode
@@ -1112,7 +1125,7 @@ export function ProcessMatrix({
                                               handleStatusChange(task.id, next)
                                       }
                                       onRemove={
-                                        editMode
+                                        editMode && !useCompactAsMini
                                           ? () => setConfirmDeleteTask(task)
                                           : undefined
                                       }
@@ -1125,7 +1138,7 @@ export function ProcessMatrix({
                                   </DraggableTaskCard>
                                 );
                               })}
-                              {editMode ? (
+                              {editMode && !useCompactAsMini ? (
                                 <button
                                   type="button"
                                   className="mx-add-more-btn"

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -1184,7 +1184,7 @@ export function ProcessMatrix({
             hoveredTaskId={hoveredTaskId}
             outputGroups={outputGroups}
             taskIO={instance.taskIO}
-            collapseKey={`${collapsed ? "1" : "0"}|${[...collapsedStageIds].sort().join(",")}|${[...collapsedSkillIds].sort().join(",")}`}
+            collapseKey={`${collapsed ? "1" : "0"}|${[...collapsedStageIds].sort().join(",")}|${[...collapsedSkillIds].sort().join(",")}|${[...expandedTaskIds].sort().join(",")}|${[...collapsedTaskIds].sort().join(",")}`}
           />
         </div>
       </div>

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -178,20 +178,42 @@ export function ProcessMatrix({
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [dragTaskId, setDragTaskId] = useState<string | null>(null);
   const [hoveredTaskId, setHoveredTaskId] = useState<string | null>(null);
-  // Per-task "promoted" flag for compact cards in multi-card cells. When a
-  // user clicks a compact card it expands to the full TaskCard in-place;
-  // clicking the demote affordance on the full card collapses it back.
-  // Multiple cards in the same cell can be promoted simultaneously — the
-  // row simply grows. Not persisted: an instance reload resets the view
-  // to the "compact-when-2+" default.
-  const [promotedTaskIds, setPromotedTaskIds] = useState<Set<string>>(
+  // Per-task expand / collapse overrides. The default sizing rule is
+  // "compact when the cell has 2+ tasks, full otherwise" — but the user
+  // can collapse a single-card cell to free vertical space, or expand a
+  // multi-card cell's compact siblings to inspect them. The two sets are
+  // mutually exclusive (adding to one removes from the other) so the
+  // toggle handlers stay symmetric. Not persisted: an instance reload
+  // resets the view to the default rule.
+  const [expandedTaskIds, setExpandedTaskIds] = useState<Set<string>>(
     () => new Set(),
   );
-  const togglePromoted = useCallback((taskId: string) => {
-    setPromotedTaskIds((prev) => {
+  const [collapsedTaskIds, setCollapsedTaskIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const expandTask = useCallback((taskId: string) => {
+    setExpandedTaskIds((prev) => {
       const next = new Set(prev);
-      if (next.has(taskId)) next.delete(taskId);
-      else next.add(taskId);
+      next.add(taskId);
+      return next;
+    });
+    setCollapsedTaskIds((prev) => {
+      if (!prev.has(taskId)) return prev;
+      const next = new Set(prev);
+      next.delete(taskId);
+      return next;
+    });
+  }, []);
+  const collapseTask = useCallback((taskId: string) => {
+    setCollapsedTaskIds((prev) => {
+      const next = new Set(prev);
+      next.add(taskId);
+      return next;
+    });
+    setExpandedTaskIds((prev) => {
+      if (!prev.has(taskId)) return prev;
+      const next = new Set(prev);
+      next.delete(taskId);
       return next;
     });
   }, []);
@@ -1033,7 +1055,8 @@ export function ProcessMatrix({
                                   ? playbookById.get(task.playbookId) ?? null
                                   : null;
                                 const renderCompact =
-                                  multiCard && !promotedTaskIds.has(task.id);
+                                  collapsedTaskIds.has(task.id) ||
+                                  (!expandedTaskIds.has(task.id) && multiCard);
                                 return (
                                   <DraggableTaskCard
                                     key={task.id}
@@ -1061,7 +1084,7 @@ export function ProcessMatrix({
                                       variant={renderCompact ? "compact" : "full"}
                                       onClick={
                                         renderCompact
-                                          ? () => togglePromoted(task.id)
+                                          ? () => expandTask(task.id)
                                           : editMode
                                             ? () =>
                                                 setAddTaskFor({
@@ -1094,11 +1117,9 @@ export function ProcessMatrix({
                                           : undefined
                                       }
                                       onDemote={
-                                        !renderCompact &&
-                                        multiCard &&
-                                        promotedTaskIds.has(task.id)
-                                          ? () => togglePromoted(task.id)
-                                          : undefined
+                                        renderCompact
+                                          ? undefined
+                                          : () => collapseTask(task.id)
                                       }
                                     />
                                   </DraggableTaskCard>

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -178,6 +178,23 @@ export function ProcessMatrix({
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [dragTaskId, setDragTaskId] = useState<string | null>(null);
   const [hoveredTaskId, setHoveredTaskId] = useState<string | null>(null);
+  // Per-task "promoted" flag for compact cards in multi-card cells. When a
+  // user clicks a compact card it expands to the full TaskCard in-place;
+  // clicking the demote affordance on the full card collapses it back.
+  // Multiple cards in the same cell can be promoted simultaneously — the
+  // row simply grows. Not persisted: an instance reload resets the view
+  // to the "compact-when-2+" default.
+  const [promotedTaskIds, setPromotedTaskIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const togglePromoted = useCallback((taskId: string) => {
+    setPromotedTaskIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(taskId)) next.delete(taskId);
+      else next.add(taskId);
+      return next;
+    });
+  }, []);
   const matrixWrapRef = useRef<HTMLDivElement | null>(null);
   const [addTaskFor, setAddTaskFor] = useState<{
     mode: "create" | "edit";
@@ -367,10 +384,23 @@ export function ProcessMatrix({
     proceed();
   }, [lastSavedTasks, pendingNavigation, savedLabel]);
 
+  // A cell can hold N tasks (typically 0–1, sometimes 2–3). Order is
+  // stable by `createdAt` ascending so the stack doesn't reshuffle
+  // across optimistic updates, and the compact-vs-full layout choice
+  // is deterministic per task position.
   const tasksByCell = useMemo(() => {
-    const map = new Map<string, WorkflowTask>();
+    const map = new Map<string, WorkflowTask[]>();
     for (const task of localTasks) {
-      map.set(`${task.skillId}::${task.stageId}`, task);
+      const key = `${task.skillId}::${task.stageId}`;
+      const bucket = map.get(key);
+      if (bucket) bucket.push(task);
+      else map.set(key, [task]);
+    }
+    for (const bucket of map.values()) {
+      bucket.sort((a, b) => {
+        if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+        return a.id < b.id ? -1 : 1;
+      });
     }
     return map;
   }, [localTasks]);
@@ -582,10 +612,8 @@ export function ProcessMatrix({
       const dragged = localTasks.find((t) => t.id === draggedId);
       if (!dragged) return;
       if (dragged.skillId === targetSkillId && dragged.stageId === targetStageId) return;
-      const occupied = localTasks.some(
-        (t) => t.skillId === targetSkillId && t.stageId === targetStageId,
-      );
-      if (occupied) return;
+      // Multi-card cells: drops onto an already-occupied cell are allowed
+      // and the card joins the stack. The old `occupied` guard is gone.
       // Constrain skill-row moves to the playbook's allowed skills.
       const playbook = dragged.playbookId ? playbookById.get(dragged.playbookId) : null;
       if (
@@ -873,7 +901,7 @@ export function ProcessMatrix({
                         emoji={frameworkSkill?.icon ?? "•"}
                         color={skillColor}
                         label={skill.label}
-                        size={labelHidden ? "xs" : "sm"}
+                        size="md"
                       />
                       {labelHidden ? (
                         <FloatingHoverTooltip
@@ -945,17 +973,18 @@ export function ProcessMatrix({
                   </div>
 
                   {stages.map((stage) => {
-                    const task = tasksByCell.get(`${skill.id}::${stage.id}`);
-                    const playbook = task?.playbookId ? playbookById.get(task.playbookId) ?? null : null;
+                    const cellTasks =
+                      tasksByCell.get(`${skill.id}::${stage.id}`) ?? [];
                     const isStageCollapsed = collapsedStageIds.has(stage.id);
                     const isMini = isStageCollapsed || isSkillCollapsed;
+                    const multiCard = cellTasks.length >= 2;
 
                     return (
                       <DroppableTaskCell
                         key={`${skill.id}-${stage.id}`}
                         skillId={skill.id}
                         stageId={stage.id}
-                        hasTask={Boolean(task)}
+                        hasTask={cellTasks.length > 0}
                         editMode={editMode && !isMini}
                         dragActive={Boolean(dragTaskId)}
                         dropAllowed={
@@ -965,93 +994,138 @@ export function ProcessMatrix({
                         mini={isMini}
                         stageCollapsed={isStageCollapsed}
                       >
-                        {task ? (
+                        {cellTasks.length > 0 ? (
                           isMini ? (
-                            <div
-                              data-task-id={task.id}
-                              data-mini="true"
-                              onMouseEnter={() => setHoveredTaskId(task.id)}
-                              onMouseLeave={() =>
-                                setHoveredTaskId((current) =>
-                                  current === task.id ? null : current,
-                                )
-                              }
-                            >
-                              <MiniTaskCell
-                                task={task}
-                                playbook={playbook}
-                                skillColor={skillColor}
-                                onClick={
-                                  editMode
-                                    ? undefined
-                                    : () => {
-                                        // Mini cells live in collapsed rows or
-                                        // columns. Clicking the avatar expands
-                                        // them back to full size first; the
-                                        // user has to click again on the full
-                                        // card to open the drawer. Avoids the
-                                        // surprise of a drawer popping over a
-                                        // collapsed row/column.
-                                        if (isSkillCollapsed) {
-                                          toggleSkillCollapsed(skill.id);
-                                        }
-                                        if (isStageCollapsed) {
-                                          toggleStageCollapsed(stage.id);
-                                        }
+                            <MiniStackCellContent
+                              tasks={cellTasks}
+                              playbookById={playbookById}
+                              skillColor={skillColor}
+                              onHoverTask={setHoveredTaskId}
+                              onPickTask={
+                                editMode
+                                  ? undefined
+                                  : () => {
+                                      // Mini cells live in collapsed rows or
+                                      // columns. Picking any task from the
+                                      // mini stack expands them back to their
+                                      // compact/full layout first; a second
+                                      // click on the expanded card opens the
+                                      // drawer. Avoids a drawer popping over
+                                      // a collapsed row/column.
+                                      if (isSkillCollapsed) {
+                                        toggleSkillCollapsed(skill.id);
                                       }
-                                }
-                              />
-                            </div>
-                          ) : (
-                            <DraggableTaskCard
-                              taskId={task.id}
-                              disabled={!editMode}
-                              isActive={dragTaskId === task.id}
-                              dataTaskId={task.id}
-                              onHoverStart={() => setHoveredTaskId(task.id)}
-                              onHoverEnd={() =>
-                                setHoveredTaskId((current) =>
-                                  current === task.id ? null : current,
-                                )
+                                      if (isStageCollapsed) {
+                                        toggleStageCollapsed(stage.id);
+                                      }
+                                    }
                               }
+                            />
+                          ) : (
+                            <div
+                              className={cn(
+                                "mx-cell-stack",
+                                multiCard && "mx-cell-stack-multi",
+                              )}
                             >
-                              <TaskCard
-                                task={task}
-                                playbook={playbook}
-                                skillColor={skillColor}
-                                barState={barClass(task, canStart(task, localTasks))}
-                                editMode={editMode}
-                                ioState={ioByTaskId.get(task.id)}
-                                onClick={
-                                  editMode
-                                    ? () =>
-                                        setAddTaskFor({
-                                          mode: "edit",
-                                          taskId: task.id,
-                                          skillId: skill.id,
-                                          skillLabel: skill.label,
-                                          stageId: stage.id,
-                                          stageName: stage.label,
-                                          initial: {
-                                            playbookId: task.playbookId ?? null,
-                                            notes: task.notes ?? "",
-                                            owners: task.owners ?? [],
-                                            inputs: task.inputs ?? [],
-                                            outputs: task.outputs ?? [],
-                                          },
-                                        })
-                                    : () => setSelectedTaskId(task.id)
-                                }
-                                onStatusChange={
-                                  editMode
-                                    ? undefined
-                                    : (next) => handleStatusChange(task.id, next)
-                                }
-                                onRemove={
-                                  editMode ? () => setConfirmDeleteTask(task) : undefined
-                                }
-                              />
-                            </DraggableTaskCard>
+                              {cellTasks.map((task) => {
+                                const playbook = task.playbookId
+                                  ? playbookById.get(task.playbookId) ?? null
+                                  : null;
+                                const renderCompact =
+                                  multiCard && !promotedTaskIds.has(task.id);
+                                return (
+                                  <DraggableTaskCard
+                                    key={task.id}
+                                    taskId={task.id}
+                                    disabled={!editMode}
+                                    isActive={dragTaskId === task.id}
+                                    dataTaskId={task.id}
+                                    onHoverStart={() => setHoveredTaskId(task.id)}
+                                    onHoverEnd={() =>
+                                      setHoveredTaskId((current) =>
+                                        current === task.id ? null : current,
+                                      )
+                                    }
+                                  >
+                                    <TaskCard
+                                      task={task}
+                                      playbook={playbook}
+                                      skillColor={skillColor}
+                                      barState={barClass(
+                                        task,
+                                        canStart(task, localTasks),
+                                      )}
+                                      editMode={editMode}
+                                      ioState={ioByTaskId.get(task.id)}
+                                      variant={renderCompact ? "compact" : "full"}
+                                      onClick={
+                                        renderCompact
+                                          ? () => togglePromoted(task.id)
+                                          : editMode
+                                            ? () =>
+                                                setAddTaskFor({
+                                                  mode: "edit",
+                                                  taskId: task.id,
+                                                  skillId: skill.id,
+                                                  skillLabel: skill.label,
+                                                  stageId: stage.id,
+                                                  stageName: stage.label,
+                                                  initial: {
+                                                    playbookId:
+                                                      task.playbookId ?? null,
+                                                    notes: task.notes ?? "",
+                                                    owners: task.owners ?? [],
+                                                    inputs: task.inputs ?? [],
+                                                    outputs: task.outputs ?? [],
+                                                  },
+                                                })
+                                            : () => setSelectedTaskId(task.id)
+                                      }
+                                      onStatusChange={
+                                        renderCompact || editMode
+                                          ? undefined
+                                          : (next) =>
+                                              handleStatusChange(task.id, next)
+                                      }
+                                      onRemove={
+                                        editMode
+                                          ? () => setConfirmDeleteTask(task)
+                                          : undefined
+                                      }
+                                      onDemote={
+                                        !renderCompact &&
+                                        multiCard &&
+                                        promotedTaskIds.has(task.id)
+                                          ? () => togglePromoted(task.id)
+                                          : undefined
+                                      }
+                                    />
+                                  </DraggableTaskCard>
+                                );
+                              })}
+                              {editMode ? (
+                                <button
+                                  type="button"
+                                  className="mx-add-more-btn"
+                                  data-testid={`matrix-add-more-${skill.id}-${stage.id}`}
+                                  aria-label={`Add another playbook for ${skill.label} in ${stage.label}`}
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    setAddTaskFor({
+                                      mode: "create",
+                                      skillId: skill.id,
+                                      skillLabel: skill.label,
+                                      stageId: stage.id,
+                                      stageName: stage.label,
+                                    });
+                                  }}
+                                >
+                                  <Plus aria-hidden className="h-3 w-3" />
+                                  <span>Add another</span>
+                                </button>
+                              ) : null}
+                            </div>
                           )
                         ) : editMode && !isMini ? (
                           <div
@@ -1289,9 +1363,12 @@ function DroppableTaskCell({
   stageCollapsed?: boolean;
   children: React.ReactNode;
 }) {
+  // `hasTask` no longer disables the droppable — multi-card cells accept
+  // drops on top of existing cards. `dropAllowed` (skill compatibility)
+  // and `editMode` still gate it.
   const { setNodeRef, isOver } = useDroppable({
     id: `cell::${skillId}::${stageId}`,
-    disabled: !editMode || hasTask || !dropAllowed,
+    disabled: !editMode || !dropAllowed,
   });
 
   return (
@@ -1306,8 +1383,8 @@ function DroppableTaskCell({
         mini && "mx-task-cell-mini",
         stageCollapsed && "mx-task-cell-narrow",
         hasTask && "has-task",
-        editMode && dragActive && !hasTask && dropAllowed && isOver && "drag-over-cell",
-        editMode && dragActive && !hasTask && !dropAllowed && "drag-disallowed-cell",
+        editMode && dragActive && dropAllowed && isOver && "drag-over-cell",
+        editMode && dragActive && !dropAllowed && "drag-disallowed-cell",
       )}
     >
       {children}
@@ -1386,7 +1463,7 @@ function MiniTaskCell({
             ) : undefined
           }
           label={title}
-          size="xs"
+          size="md"
         />
         <FloatingHoverTooltip
           name={title}
@@ -1396,6 +1473,164 @@ function MiniTaskCell({
         />
       </span>
     </button>
+  );
+}
+
+/**
+ * Mini-stack cell: one or more tasks rendered inside a collapsed row /
+ * column. With a single task this is just a `MiniTaskCell` (the existing
+ * 22px avatar). With 2+ tasks we show ONE primary avatar plus a `+N`
+ * count badge so the cell never overflows — and on hover we float a
+ * vertical panel of all avatars so the user can see and click each
+ * individual task. Hidden sibling anchors keep the wiring overlay
+ * happy: every task in the cell still has a measurable `data-task-id`
+ * element, they just collapse to the primary's position so wiring
+ * curves converge cleanly into the cell.
+ */
+function MiniStackCellContent({
+  tasks,
+  playbookById,
+  skillColor,
+  onHoverTask,
+  onPickTask,
+}: {
+  tasks: WorkflowTask[];
+  playbookById: Map<string, FrameworkItem>;
+  skillColor: string;
+  onHoverTask: (taskId: string | null) => void;
+  /** Called when the user clicks an avatar — picks that task. Pass
+   *  `undefined` to disable clicks (edit mode). */
+  onPickTask?: (taskId: string) => void;
+}) {
+  const primary = tasks[0]!;
+  const siblings = tasks.slice(1);
+  const isMulti = tasks.length > 1;
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const [panelPos, setPanelPos] = useState<{ top: number; left: number } | null>(
+    null,
+  );
+  const [panelOpen, setPanelOpen] = useState(false);
+  const closeTimerRef = useRef<number | null>(null);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+  // Small grace period so moving the cursor from the anchor to the
+  // portaled panel doesn't drop the hover state mid-traversal.
+  const scheduleClose = useCallback(() => {
+    cancelClose();
+    closeTimerRef.current = window.setTimeout(() => setPanelOpen(false), 100);
+  }, [cancelClose]);
+  useEffect(() => () => cancelClose(), [cancelClose]);
+
+  const openPanel = useCallback(() => {
+    cancelClose();
+    if (!isMulti) return;
+    const anchor = anchorRef.current;
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    setPanelPos({
+      top: rect.top + rect.height / 2,
+      left: rect.right + 6,
+    });
+    setPanelOpen(true);
+  }, [cancelClose, isMulti]);
+
+  const primaryPlaybook = primary.playbookId
+    ? playbookById.get(primary.playbookId) ?? null
+    : null;
+
+  return (
+    <div
+      ref={anchorRef}
+      className={cn("mx-mini-stack", isMulti && "mx-mini-stack-multi")}
+      onMouseEnter={() => {
+        onHoverTask(primary.id);
+        openPanel();
+      }}
+      onMouseLeave={() => {
+        onHoverTask(null);
+        scheduleClose();
+      }}
+    >
+      <div
+        data-task-id={primary.id}
+        data-mini="true"
+        className="mx-mini-stack-primary"
+      >
+        <MiniTaskCell
+          task={primary}
+          playbook={primaryPlaybook}
+          skillColor={skillColor}
+          onClick={onPickTask ? () => onPickTask(primary.id) : undefined}
+        />
+        {isMulti ? (
+          <span
+            className="mx-mini-stack-badge"
+            aria-label={`${tasks.length} playbooks in this cell`}
+          >
+            +{siblings.length}
+          </span>
+        ) : null}
+      </div>
+      {/* Hidden anchors for the non-primary tasks. They occupy the
+       *  primary's footprint (visibility: hidden, no layout shift) but
+       *  keep their `data-task-id` so the wiring overlay can resolve
+       *  endpoints for every task in the cell. */}
+      {siblings.map((task) => (
+        <span
+          key={task.id}
+          data-task-id={task.id}
+          data-mini="true"
+          aria-hidden
+          className="mx-mini-stack-ghost"
+        />
+      ))}
+      {panelOpen && panelPos && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              role="menu"
+              aria-label="Playbooks in this cell"
+              className="mx-mini-stack-panel"
+              style={{ top: panelPos.top, left: panelPos.left }}
+              onMouseEnter={cancelClose}
+              onMouseLeave={scheduleClose}
+            >
+              {tasks.map((task) => {
+                const pb = task.playbookId
+                  ? playbookById.get(task.playbookId) ?? null
+                  : null;
+                return (
+                  <div
+                    key={task.id}
+                    className="mx-mini-stack-panel-item"
+                    onMouseEnter={() => onHoverTask(task.id)}
+                    onMouseLeave={() => onHoverTask(null)}
+                  >
+                    <MiniTaskCell
+                      task={task}
+                      playbook={pb}
+                      skillColor={skillColor}
+                      onClick={
+                        onPickTask
+                          ? () => {
+                              setPanelOpen(false);
+                              onPickTask(task.id);
+                            }
+                          : undefined
+                      }
+                    />
+                  </div>
+                );
+              })}
+            </div>,
+            document.body,
+          )
+        : null}
+    </div>
   );
 }
 

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -901,7 +901,7 @@ export function ProcessMatrix({
                         emoji={frameworkSkill?.icon ?? "•"}
                         color={skillColor}
                         label={skill.label}
-                        size="md"
+                        size="lg"
                       />
                       {labelHidden ? (
                         <FloatingHoverTooltip
@@ -1463,7 +1463,7 @@ function MiniTaskCell({
             ) : undefined
           }
           label={title}
-          size="md"
+          size="lg"
         />
         <FloatingHoverTooltip
           name={title}

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -859,7 +859,8 @@ export function ProcessMatrix({
                 (item) => item.id === skill.id,
               );
               const isSkillCollapsed = collapsedSkillIds.has(skill.id);
-              const labelHidden = collapsed || isSkillCollapsed;
+              const labelHidden = collapsed;
+              const ownersHidden = collapsed || isSkillCollapsed;
               // Derive the row's owner stack from the cards currently in
               // this skill row (deduped, order-preserved). Owners live on
               // each task now, so the same playbook can carry different
@@ -943,16 +944,18 @@ export function ProcessMatrix({
                         data-testid={`matrix-skill-label-${skill.id}`}
                       >
                         <div className="mx-role-name">{skill.label}</div>
-                        <div
-                          className={cn(
-                            "mx-role-owner",
-                            rowOwners.length > 0 && "mx-role-owner-plain",
-                          )}
-                        >
-                          {rowOwners.length > 0
-                            ? rowOwners.join(", ")
-                            : "No owner"}
-                        </div>
+                        {!ownersHidden ? (
+                          <div
+                            className={cn(
+                              "mx-role-owner",
+                              rowOwners.length > 0 && "mx-role-owner-plain",
+                            )}
+                          >
+                            {rowOwners.length > 0
+                              ? rowOwners.join(", ")
+                              : "No owner"}
+                          </div>
+                        ) : null}
                       </div>
                     ) : null}
                     {(
@@ -1023,25 +1026,22 @@ export function ProcessMatrix({
                               playbookById={playbookById}
                               skillColor={skillColor}
                               onHoverTask={setHoveredTaskId}
-                              onPickTask={
-                                editMode
-                                  ? undefined
-                                  : () => {
-                                      // Mini cells live in collapsed rows or
-                                      // columns. Picking any task from the
-                                      // mini stack expands them back to their
-                                      // compact/full layout first; a second
-                                      // click on the expanded card opens the
-                                      // drawer. Avoids a drawer popping over
-                                      // a collapsed row/column.
-                                      if (isSkillCollapsed) {
-                                        toggleSkillCollapsed(skill.id);
-                                      }
-                                      if (isStageCollapsed) {
-                                        toggleStageCollapsed(stage.id);
-                                      }
-                                    }
-                              }
+                              onPickTask={() => {
+                                // Mini cells live in collapsed rows or
+                                // columns. Picking any task from the mini
+                                // stack expands them back to their
+                                // compact/full layout first; a second click
+                                // on the expanded card opens the drawer (or
+                                // the edit modal in edit mode). Avoids a
+                                // drawer/modal popping over a collapsed
+                                // row/column.
+                                if (isSkillCollapsed) {
+                                  toggleSkillCollapsed(skill.id);
+                                }
+                                if (isStageCollapsed) {
+                                  toggleStageCollapsed(stage.id);
+                                }
+                              }}
                             />
                           ) : (
                             <div

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -207,14 +207,7 @@ export function TaskCard({
             >
               {infoBadgeNodes}
             </div>
-          ) : (
-            <div
-              className={cn("s-pill", statusClass, "tc-compact-status")}
-              data-testid={`task-status-${task.id}`}
-            >
-              <span className="s-text">{statusLabel}</span>
-            </div>
-          )}
+          ) : null}
           {showActions && onRemove ? (
             <div className="tc-compact-actions mx-entity-actions mx-entity-actions-group">
               <button

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -6,6 +6,7 @@ import {
   AlertTriangle,
   Check,
   ChevronsDownUp,
+  ChevronsUpDown,
   CircleAlert,
   StickyNote,
   Trash2,
@@ -208,6 +209,20 @@ export function TaskCard({
               {infoBadgeNodes}
             </div>
           ) : null}
+          {onClick ? (
+            <button
+              type="button"
+              className="tc-expand-btn"
+              aria-label={`Expand playbook card: ${title}`}
+              title="Expand card"
+              onClick={(event) => {
+                event.stopPropagation();
+                onClick();
+              }}
+            >
+              <ChevronsUpDown aria-hidden size={11} strokeWidth={2.1} />
+            </button>
+          ) : null}
         </>
       ) : (
         <FullTaskCardBody
@@ -257,7 +272,9 @@ function FullTaskCardBody({
 }: FullTaskCardBodyProps) {
   return (
     <>
-      <div className="tc-title">{title}</div>
+      <div className="tc-title">
+        <span>{title}</span>
+      </div>
       <div className="tc-status-row">
         <div
           className="tc-owners"

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -87,6 +87,62 @@ export function TaskCard({
   const owners = task.owners ?? [];
   const showActions = editMode && Boolean(onRemove);
   const isCompact = variant === "compact";
+
+  // Info badges — note / checkpoint / failure / completion. Centralised
+  // here so the compact variant can swap the status pill for these
+  // icons when any exist (a row of 22px hover-tooltipped chips carries
+  // more actionable signal than a generic "Failed" pill at compact
+  // scale). The full variant renders the same list in its status row.
+  const infoBadgeNodes: React.ReactNode[] = [];
+  if (task.notes) {
+    infoBadgeNodes.push(
+      <InfoBadge
+        key="note"
+        tone="note"
+        icon={StickyNote}
+        header="Note"
+        body={task.notes}
+        testId={`task-note-${task.id}`}
+      />,
+    );
+  }
+  if (task.checkpoint) {
+    infoBadgeNodes.push(
+      <InfoBadge
+        key="warning"
+        tone="warning"
+        icon={AlertTriangle}
+        header="Warning"
+        body="This task requires a checkpoint approval before it can complete."
+        testId={`task-checkpoint-${task.id}`}
+      />,
+    );
+  }
+  if (!templateView && task.status === "failed") {
+    infoBadgeNodes.push(
+      <InfoBadge
+        key="error"
+        tone="error"
+        icon={CircleAlert}
+        header="Error"
+        body={task.substatus || "This task failed and needs attention."}
+        testId={`task-error-${task.id}`}
+      />,
+    );
+  }
+  if (!templateView && task.status === "complete") {
+    infoBadgeNodes.push(
+      <InfoBadge
+        key="success"
+        tone="success"
+        icon={Check}
+        header="Completed"
+        body={formatCompletionTimestamp(task.updatedAt)}
+        testId={`task-complete-${task.id}`}
+      />,
+    );
+  }
+  const hasInfoBadges = infoBadgeNodes.length > 0;
   const ariaLabel = isCompact
     ? onClick
       ? `Expand playbook card: ${title}`
@@ -144,12 +200,21 @@ export function TaskCard({
           <div className="tc-compact-title" title={title}>
             {title}
           </div>
-          <div
-            className={cn("s-pill", statusClass, "tc-compact-status")}
-            data-testid={`task-status-${task.id}`}
-          >
-            <span className="s-text">{statusLabel}</span>
-          </div>
+          {hasInfoBadges ? (
+            <div
+              className="tc-info-badges tc-compact-info-badges"
+              data-testid={`task-info-badges-${task.id}`}
+            >
+              {infoBadgeNodes}
+            </div>
+          ) : (
+            <div
+              className={cn("s-pill", statusClass, "tc-compact-status")}
+              data-testid={`task-status-${task.id}`}
+            >
+              <span className="s-text">{statusLabel}</span>
+            </div>
+          )}
           {showActions && onRemove ? (
             <div className="tc-compact-actions mx-entity-actions mx-entity-actions-group">
               <button
@@ -179,6 +244,7 @@ export function TaskCard({
           ioState={ioState}
           showActions={showActions}
           onRemove={onRemove}
+          infoBadgeNodes={infoBadgeNodes}
         />
       )}
     </div>
@@ -196,6 +262,7 @@ interface FullTaskCardBodyProps {
   ioState?: TaskIOSummary;
   showActions: boolean;
   onRemove?: () => void;
+  infoBadgeNodes: React.ReactNode[];
 }
 
 function FullTaskCardBody({
@@ -209,6 +276,7 @@ function FullTaskCardBody({
   ioState,
   showActions,
   onRemove,
+  infoBadgeNodes,
 }: FullTaskCardBodyProps) {
   return (
     <>
@@ -228,44 +296,7 @@ function FullTaskCardBody({
             <EmptyOwnerAvatar taskId={task.id} />
           )}
         </div>
-        <div className="tc-info-badges">
-          {task.notes ? (
-            <InfoBadge
-              tone="note"
-              icon={StickyNote}
-              header="Note"
-              body={task.notes}
-              testId={`task-note-${task.id}`}
-            />
-          ) : null}
-          {task.checkpoint ? (
-            <InfoBadge
-              tone="warning"
-              icon={AlertTriangle}
-              header="Warning"
-              body="This task requires a checkpoint approval before it can complete."
-              testId={`task-checkpoint-${task.id}`}
-            />
-          ) : null}
-          {!templateView && task.status === "failed" ? (
-            <InfoBadge
-              tone="error"
-              icon={CircleAlert}
-              header="Error"
-              body={task.substatus || "This task failed and needs attention."}
-              testId={`task-error-${task.id}`}
-            />
-          ) : null}
-          {!templateView && task.status === "complete" ? (
-            <InfoBadge
-              tone="success"
-              icon={Check}
-              header="Completed"
-              body={formatCompletionTimestamp(task.updatedAt)}
-              testId={`task-complete-${task.id}`}
-            />
-          ) : null}
-        </div>
+        <div className="tc-info-badges">{infoBadgeNodes}</div>
       </div>
       <div className="tc-bottom">
         <div

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -208,22 +208,6 @@ export function TaskCard({
               {infoBadgeNodes}
             </div>
           ) : null}
-          {showActions && onRemove ? (
-            <div className="tc-compact-actions mx-entity-actions mx-entity-actions-group">
-              <button
-                type="button"
-                className="mx-entity-action mx-entity-action-danger"
-                aria-label={`Remove playbook: ${title}`}
-                title={`Delete ${title}`}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onRemove();
-                }}
-              >
-                <Trash2 aria-hidden size={11} strokeWidth={2.1} />
-              </button>
-            </div>
-          ) : null}
         </>
       ) : (
         <FullTaskCardBody

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import {
   AlertTriangle,
   Check,
+  ChevronsDownUp,
   CircleAlert,
   StickyNote,
   Trash2,
@@ -53,6 +54,16 @@ export interface TaskCardProps {
    *  unmet-linked-input glyph. Omit (e.g. on the template editor) to
    *  suppress both affordances. */
   ioState?: TaskIOSummary;
+  /** When set, the card is currently the "promoted" sibling in a
+   *  multi-card cell — render a small collapse affordance in the top
+   *  corner so the user can demote it back to a compact card without
+   *  opening the drawer. */
+  onDemote?: () => void;
+  /** Layout variant. `"full"` (default) is the 120px three-row layout.
+   *  `"compact"` is the 52px one-row layout used when a cell holds
+   *  multiple tasks. The root element is the same in both cases so the
+   *  height / padding / flex-direction transitions animate the morph. */
+  variant?: "full" | "compact";
 }
 
 export function TaskCard({
@@ -66,6 +77,8 @@ export function TaskCard({
   templateView = false,
   onStatusChange,
   ioState,
+  onDemote,
+  variant = "full",
 }: TaskCardProps) {
   const statusClass = TASK_STATUS_PILL_CLASS[task.status];
   const statusLabel = TASK_STATUS_LABEL[task.status];
@@ -73,17 +86,27 @@ export function TaskCard({
   const title = playbook?.name ?? (task.playbookId ? "Playbook removed" : "No playbook");
   const owners = task.owners ?? [];
   const showActions = editMode && Boolean(onRemove);
+  const isCompact = variant === "compact";
+  const ariaLabel = isCompact
+    ? onClick
+      ? `Expand playbook card: ${title}`
+      : undefined
+    : onClick
+      ? `Open playbook: ${title}`
+      : undefined;
 
   return (
     <div
       data-testid={`task-card-${task.id}`}
       data-bar={barState}
       data-status={task.status}
+      data-variant={variant}
       className={cn(
         "task-card",
         statusClass,
         barState,
         templateView && "task-card-default",
+        isCompact && "task-card-compact",
         onClick && "cursor-pointer",
       )}
       style={{ "--role-color": skillColor } as React.CSSProperties}
@@ -100,8 +123,95 @@ export function TaskCard({
             }
           : undefined
       }
-      aria-label={onClick ? `Open playbook: ${title}` : undefined}
+      aria-label={ariaLabel}
     >
+      {!isCompact && onDemote ? (
+        <button
+          type="button"
+          className="tc-demote-btn"
+          aria-label={`Collapse playbook card: ${title}`}
+          title="Collapse card"
+          onClick={(event) => {
+            event.stopPropagation();
+            onDemote();
+          }}
+        >
+          <ChevronsDownUp aria-hidden size={11} strokeWidth={2.1} />
+        </button>
+      ) : null}
+      {isCompact ? (
+        <>
+          <div className="tc-compact-title" title={title}>
+            {title}
+          </div>
+          <div
+            className={cn("s-pill", statusClass, "tc-compact-status")}
+            data-testid={`task-status-${task.id}`}
+          >
+            <span className="s-text">{statusLabel}</span>
+          </div>
+          {showActions && onRemove ? (
+            <div className="tc-compact-actions mx-entity-actions mx-entity-actions-group">
+              <button
+                type="button"
+                className="mx-entity-action mx-entity-action-danger"
+                aria-label={`Remove playbook: ${title}`}
+                title={`Delete ${title}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onRemove();
+                }}
+              >
+                <Trash2 aria-hidden size={11} strokeWidth={2.1} />
+              </button>
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <FullTaskCardBody
+          task={task}
+          title={title}
+          owners={owners}
+          templateView={templateView}
+          onStatusChange={onStatusChange}
+          statusClass={statusClass}
+          statusLabel={statusLabel}
+          ioState={ioState}
+          showActions={showActions}
+          onRemove={onRemove}
+        />
+      )}
+    </div>
+  );
+}
+
+interface FullTaskCardBodyProps {
+  task: WorkflowTask;
+  title: string;
+  owners: string[];
+  templateView: boolean;
+  onStatusChange?: (next: WorkflowTaskStatus) => void;
+  statusClass: string;
+  statusLabel: string;
+  ioState?: TaskIOSummary;
+  showActions: boolean;
+  onRemove?: () => void;
+}
+
+function FullTaskCardBody({
+  task,
+  title,
+  owners,
+  templateView,
+  onStatusChange,
+  statusClass,
+  statusLabel,
+  ioState,
+  showActions,
+  onRemove,
+}: FullTaskCardBodyProps) {
+  return (
+    <>
       <div className="tc-title">{title}</div>
       <div className="tc-status-row">
         <div
@@ -205,7 +315,7 @@ export function TaskCard({
           ) : null}
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/products/dashboard/components/workflows/task-card.tsx
+++ b/products/dashboard/components/workflows/task-card.tsx
@@ -316,11 +316,17 @@ function FullTaskCardBody({
           )}
         </div>
         <div className="tc-bottom-right">
-          <PipRail
-            outputs={ioState?.outputs ?? []}
-            testIdPrefix={`task-pip-${task.id}`}
-            railTestId={`task-pip-rail-${task.id}`}
-          />
+          {/* Output pip rail is a runtime affordance — each pip flips
+           * green/red as `task_outputs` rows land. Templates have no
+           * runtime, so every pip would render as a static "pending"
+           * dot, which reads as noise. Suppress in template view. */}
+          {templateView ? null : (
+            <PipRail
+              outputs={ioState?.outputs ?? []}
+              testIdPrefix={`task-pip-${task.id}`}
+              railTestId={`task-pip-rail-${task.id}`}
+            />
+          )}
           {showActions && onRemove ? (
             <div className="tc-actions mx-entity-actions mx-entity-actions-group">
               <button

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -1105,6 +1105,7 @@ export function TemplateEditorScreen({
             tasks={derivedWiringTasks}
             hoveredTaskId={hoveredTaskId}
             outputGroups={outputGroups}
+            collapseKey={`${[...expandedTaskIds].sort().join(",")}|${[...collapsedTaskIds].sort().join(",")}`}
           />
         </div>
         </DndContext>

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -335,18 +335,40 @@ export function TemplateEditorScreen({
   const [dragTaskId, setDragTaskId] = useState<string | null>(null);
   const [hoveredTaskId, setHoveredTaskId] = useState<string | null>(null);
   const matrixRef = useRef<HTMLDivElement | null>(null);
-  // Per-task "promoted" flag for compact cards in multi-card cells —
-  // mirrors the instance matrix' behavior so a clicked compact card
-  // expands to full in-place. Reset only when the user reloads the
-  // template; survives normal draft edits.
-  const [promotedTaskIds, setPromotedTaskIds] = useState<Set<string>>(
+  // Per-task expand / collapse overrides — mirrors the instance matrix.
+  // Default sizing is "compact when cell has 2+ tasks, full otherwise";
+  // either set overrides that default for the listed task ids. The two
+  // sets stay mutually exclusive (adding to one removes from the other).
+  // Reset only when the user reloads the template; survives draft edits.
+  const [expandedTaskIds, setExpandedTaskIds] = useState<Set<string>>(
     () => new Set(),
   );
-  const togglePromoted = useCallback((taskId: string) => {
-    setPromotedTaskIds((prev) => {
+  const [collapsedTaskIds, setCollapsedTaskIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const expandTask = useCallback((taskId: string) => {
+    setExpandedTaskIds((prev) => {
       const next = new Set(prev);
-      if (next.has(taskId)) next.delete(taskId);
-      else next.add(taskId);
+      next.add(taskId);
+      return next;
+    });
+    setCollapsedTaskIds((prev) => {
+      if (!prev.has(taskId)) return prev;
+      const next = new Set(prev);
+      next.delete(taskId);
+      return next;
+    });
+  }, []);
+  const collapseTask = useCallback((taskId: string) => {
+    setCollapsedTaskIds((prev) => {
+      const next = new Set(prev);
+      next.add(taskId);
+      return next;
+    });
+    setExpandedTaskIds((prev) => {
+      if (!prev.has(taskId)) return prev;
+      const next = new Set(prev);
+      next.delete(taskId);
       return next;
     });
   }, []);
@@ -945,7 +967,8 @@ export function TemplateEditorScreen({
                             : null;
                           const taskId = templateTask.id ?? task.id;
                           const renderCompact =
-                            multiCard && !promotedTaskIds.has(taskId);
+                            collapsedTaskIds.has(taskId) ||
+                            (!expandedTaskIds.has(taskId) && multiCard);
                           return (
                             <DraggableTemplateTask
                               key={taskId}
@@ -983,7 +1006,7 @@ export function TemplateEditorScreen({
                                 }}
                                 onClick={
                                   renderCompact
-                                    ? () => togglePromoted(taskId)
+                                    ? () => expandTask(taskId)
                                     : () =>
                                         setAddTaskFor({
                                           mode: "edit",
@@ -1018,11 +1041,9 @@ export function TemplateEditorScreen({
                                   })
                                 }
                                 onDemote={
-                                  !renderCompact &&
-                                  multiCard &&
-                                  promotedTaskIds.has(taskId)
-                                    ? () => togglePromoted(taskId)
-                                    : undefined
+                                  renderCompact
+                                    ? undefined
+                                    : () => collapseTask(taskId)
                                 }
                               />
                             </DraggableTemplateTask>

--- a/products/dashboard/components/workflows/template-editor-screen.tsx
+++ b/products/dashboard/components/workflows/template-editor-screen.tsx
@@ -335,6 +335,36 @@ export function TemplateEditorScreen({
   const [dragTaskId, setDragTaskId] = useState<string | null>(null);
   const [hoveredTaskId, setHoveredTaskId] = useState<string | null>(null);
   const matrixRef = useRef<HTMLDivElement | null>(null);
+  // Per-task "promoted" flag for compact cards in multi-card cells —
+  // mirrors the instance matrix' behavior so a clicked compact card
+  // expands to full in-place. Reset only when the user reloads the
+  // template; survives normal draft edits.
+  const [promotedTaskIds, setPromotedTaskIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const togglePromoted = useCallback((taskId: string) => {
+    setPromotedTaskIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(taskId)) next.delete(taskId);
+      else next.add(taskId);
+      return next;
+    });
+  }, []);
+
+  // Group template tasks by their (skillId, stageId) cell so the matrix
+  // can render multiple cards per cell. Array order follows insertion
+  // order in `draft.taskTemplates` — templates have no createdAt, and
+  // preserving array order keeps the stack stable across edits.
+  const taskTemplatesByCell = useMemo(() => {
+    const map = new Map<string, WorkflowTaskTemplate[]>();
+    for (const task of draft.taskTemplates) {
+      const key = `${task.skillId}::${task.stageId}`;
+      const bucket = map.get(key);
+      if (bucket) bucket.push(task);
+      else map.set(key, [task]);
+    }
+    return map;
+  }, [draft.taskTemplates]);
 
   // Synthetic WorkflowTask[] for the wiring overlay. The overlay reads only
   // `id`, `inputs[]`, and `playbookId` to derive edges; in templates every
@@ -406,12 +436,16 @@ export function TemplateEditorScreen({
       if (!targetSkillId || !targetStageId) return;
       const taskId = activeId.slice("task::".length);
       setDraft((current) => {
-        const occupied = current.taskTemplates.some(
-          (t) => t.skillId === targetSkillId && t.stageId === targetStageId,
-        );
-        if (occupied) return current;
         const dragged = current.taskTemplates.find((t) => t.id === taskId);
         if (!dragged) return current;
+        // Multi-card cells: dropping onto an occupied cell joins the
+        // stack rather than being blocked, matching the instance matrix.
+        if (
+          dragged.skillId === targetSkillId &&
+          dragged.stageId === targetStageId
+        ) {
+          return current;
+        }
         if (dragged.skillId !== targetSkillId && dragged.playbookId) {
           const playbook = playbookById.get(dragged.playbookId);
           if (playbook && !(playbook.allowedSkillIds ?? []).includes(targetSkillId)) {
@@ -881,96 +915,139 @@ export function TemplateEditorScreen({
                       </div>
 
                       {draft.stages.map((stage) => {
-                const templateTask = draft.taskTemplates.find(
-                  (task) => task.skillId === skill.id && task.stageId === stage.id,
-                );
-                const task = templateTask ? templateTaskToCard(templateTask) : null;
-                const playbook = templateTask?.playbookId
-                  ? playbookById.get(templateTask.playbookId) ?? null
-                  : null;
+                const cellTemplateTasks =
+                  taskTemplatesByCell.get(`${skill.id}::${stage.id}`) ?? [];
+                const multiCard = cellTemplateTasks.length >= 2;
 
                 return (
                   <DroppableTemplateCell
                     key={`${skill.id}-${stage.id}`}
                     skillId={skill.id}
                     stageId={stage.id}
-                    hasTask={Boolean(task)}
+                    hasTask={cellTemplateTasks.length > 0}
                     dragActive={Boolean(dragTaskId)}
                     dropAllowed={
                       dragAllowedSkillIds === null ||
                       dragAllowedSkillIds.has(skill.id)
                     }
                   >
-                    {task && templateTask ? (
-                      <DraggableTemplateTask
-                        taskId={`task::${templateTask.id ?? task.id}`}
-                        isActive={dragTaskId === `task::${templateTask.id ?? task.id}`}
-                        dataTaskId={templateTask.id ?? task.id}
-                        onHoverStart={() =>
-                          setHoveredTaskId(templateTask.id ?? task.id)
-                        }
-                        onHoverEnd={() =>
-                          setHoveredTaskId((current) =>
-                            current === (templateTask.id ?? task.id) ? null : current,
-                          )
-                        }
+                    {cellTemplateTasks.length > 0 ? (
+                      <div
+                        className={cn(
+                          "mx-cell-stack",
+                          multiCard && "mx-cell-stack-multi",
+                        )}
                       >
-                        <TaskCard
-                          task={task}
-                          playbook={playbook}
-                          skillColor={resolveSkillColor(skill.id, skillOptions)}
-                          barState="bar-ready"
-                          editMode
-                          templateView
-                          ioState={{
-                            taskId: task.id,
-                            outputs: (
-                              outputGroups.find(
-                                (g) => g.playbookId === templateTask.playbookId,
-                              )?.outputs ?? []
-                            ).map((o) => ({
-                              id: o.id,
-                              position: o.position,
-                              status: "pending",
-                              name: o.name,
-                            })),
-                            hasUnmetLinkedInput: false,
-                          }}
-                          onClick={() =>
+                        {cellTemplateTasks.map((templateTask) => {
+                          const task = templateTaskToCard(templateTask);
+                          const playbook = templateTask.playbookId
+                            ? playbookById.get(templateTask.playbookId) ?? null
+                            : null;
+                          const taskId = templateTask.id ?? task.id;
+                          const renderCompact =
+                            multiCard && !promotedTaskIds.has(taskId);
+                          return (
+                            <DraggableTemplateTask
+                              key={taskId}
+                              taskId={`task::${taskId}`}
+                              isActive={dragTaskId === `task::${taskId}`}
+                              dataTaskId={taskId}
+                              onHoverStart={() => setHoveredTaskId(taskId)}
+                              onHoverEnd={() =>
+                                setHoveredTaskId((current) =>
+                                  current === taskId ? null : current,
+                                )
+                              }
+                            >
+                              <TaskCard
+                                task={task}
+                                playbook={playbook}
+                                skillColor={resolveSkillColor(skill.id, skillOptions)}
+                                barState="bar-ready"
+                                editMode
+                                templateView
+                                variant={renderCompact ? "compact" : "full"}
+                                ioState={{
+                                  taskId: task.id,
+                                  outputs: (
+                                    outputGroups.find(
+                                      (g) => g.playbookId === templateTask.playbookId,
+                                    )?.outputs ?? []
+                                  ).map((o) => ({
+                                    id: o.id,
+                                    position: o.position,
+                                    status: "pending",
+                                    name: o.name,
+                                  })),
+                                  hasUnmetLinkedInput: false,
+                                }}
+                                onClick={
+                                  renderCompact
+                                    ? () => togglePromoted(taskId)
+                                    : () =>
+                                        setAddTaskFor({
+                                          mode: "edit",
+                                          taskId: templateTask.id,
+                                          skillId: skill.id,
+                                          skillLabel: skill.label,
+                                          stageId: stage.id,
+                                          stageName: stage.label,
+                                          initial: {
+                                            playbookId: templateTask.playbookId ?? null,
+                                            notes: templateTask.notes ?? "",
+                                            owners: templateTask.owners ?? [],
+                                            inputs: templateTask.inputs ?? [],
+                                            outputs: templateTask.outputs ?? [],
+                                          },
+                                        })
+                                }
+                                onRemove={() =>
+                                  setConfirmState({
+                                    title: `Delete playbook?`,
+                                    description:
+                                      "This playbook and its default configuration will be removed from the template.",
+                                    onConfirm: () => {
+                                      setDraft((current) => ({
+                                        ...current,
+                                        taskTemplates: current.taskTemplates.filter(
+                                          (item) => item.id !== templateTask.id,
+                                        ),
+                                      }));
+                                      setConfirmState(null);
+                                    },
+                                  })
+                                }
+                                onDemote={
+                                  !renderCompact &&
+                                  multiCard &&
+                                  promotedTaskIds.has(taskId)
+                                    ? () => togglePromoted(taskId)
+                                    : undefined
+                                }
+                              />
+                            </DraggableTemplateTask>
+                          );
+                        })}
+                        <button
+                          type="button"
+                          className="mx-add-more-btn"
+                          data-testid={`matrix-add-more-${skill.id}-${stage.id}`}
+                          aria-label={`Add another playbook for ${skill.label} in ${stage.label}`}
+                          onClick={(event) => {
+                            event.stopPropagation();
                             setAddTaskFor({
-                              mode: "edit",
-                              taskId: templateTask.id,
+                              mode: "create",
                               skillId: skill.id,
                               skillLabel: skill.label,
                               stageId: stage.id,
                               stageName: stage.label,
-                              initial: {
-                                playbookId: templateTask.playbookId ?? null,
-                                notes: templateTask.notes ?? "",
-                                owners: templateTask.owners ?? [],
-                                inputs: templateTask.inputs ?? [],
-                                outputs: templateTask.outputs ?? [],
-                              },
-                            })
-                          }
-                          onRemove={() =>
-                            setConfirmState({
-                              title: `Delete playbook?`,
-                              description:
-                                "This playbook and its default configuration will be removed from the template.",
-                              onConfirm: () => {
-                                setDraft((current) => ({
-                                  ...current,
-                                  taskTemplates: current.taskTemplates.filter(
-                                    (item) => item.id !== templateTask.id,
-                                  ),
-                                }));
-                                setConfirmState(null);
-                              },
-                            })
-                          }
-                        />
-                      </DraggableTemplateTask>
+                            });
+                          }}
+                        >
+                          <Plus aria-hidden className="h-3 w-3" />
+                          <span>Add another</span>
+                        </button>
+                      </div>
                     ) : (
                       <div
                         className="mx-empty-cell"
@@ -1199,9 +1276,12 @@ function DroppableTemplateCell({
   dropAllowed: boolean;
   children: React.ReactNode;
 }) {
+  // `hasTask` no longer disables the droppable — multi-card cells accept
+  // drops on top of existing cards. `dropAllowed` (skill compatibility)
+  // still gates it.
   const { setNodeRef, isOver } = useDroppable({
     id: `cell::${skillId}::${stageId}`,
-    disabled: hasTask || !dropAllowed,
+    disabled: !dropAllowed,
   });
 
   return (
@@ -1210,8 +1290,8 @@ function DroppableTemplateCell({
       className={cn(
         "mx-task-cell",
         hasTask && "has-task",
-        dragActive && !hasTask && dropAllowed && isOver && "drag-over-cell",
-        dragActive && !hasTask && !dropAllowed && "drag-disallowed-cell",
+        dragActive && dropAllowed && isOver && "drag-over-cell",
+        dragActive && !dropAllowed && "drag-disallowed-cell",
       )}
     >
       {children}

--- a/products/dashboard/components/workflows/wiring-overlay.tsx
+++ b/products/dashboard/components/workflows/wiring-overlay.tsx
@@ -280,17 +280,16 @@ export function WiringOverlay({
         cy1 = upstreamAboveDownstream ? y1 + sag : y1 - sag;
         cy2 = upstreamAboveDownstream ? y2 - sag : y2 + sag;
       } else {
-        // Cards overlap on both axes (rare — same cell). Fall back to
-        // center-to-center with a horizontal bow so the curve at least
-        // renders as a visible arc rather than collapsing to a dot.
-        x1 = fromCenterX;
-        x2 = toCenterX;
-        y1 = fromCenterY;
-        y2 = toCenterY;
-        cx1 = x1 + 24;
-        cx2 = x2 + 24;
-        cy1 = y1;
-        cy2 = y2;
+        // Endpoints overlap on both axes — predictable when two tasks
+        // share a mini cell. The mini stack collapses to a single
+        // visible primary avatar, and the non-primary tasks render as
+        // `inset: 0` ghost anchors so they keep a `data-task-id` for
+        // wiring; that geometry makes the primary's rect sit fully
+        // inside each ghost's rect. Drawing a wire here produced a
+        // small horizontal bow that read as a stray squiggle beside
+        // the +N badge. Same-cell dependencies are implicit by
+        // sharing the cell, so skip the wire entirely.
+        continue;
       }
       const d = `M ${x1} ${y1} C ${cx1} ${cy1}, ${cx2} ${cy2}, ${x2} ${y2}`;
       const hovered =


### PR DESCRIPTION
## Summary

Adds support for multiple playbooks per matrix cell and a series of UX
improvements around how cells render at the various collapse levels
(per-row, per-column, per-card).

Highlights:

- Multi-card cells in both the instance matrix and the template editor.
- Mini-stack rendering (one primary avatar + `+N` badge) for cells in
  collapsed rows/columns, with a hover panel listing every task.
- Demote-to-compact chevron on full cards + explicit expand chevron on
  compact cards, with both buttons sharing the same right-edge column.
- Compact card slimmed to 40px (matches the `lg` avatar) so a
  row-collapsed cell with a single task renders the compact card in
  place of a bare avatar — collapsed row strip drops to 48px.
- Per-row-collapsed rows now keep the skill name visible (only owners
  hide); clicking a mini avatar expands the row/column in edit mode
  the same way it already did in view mode.
- Status pill swapped for info badges on compact cards when relevant;
  output pip rail hidden in template view; wiring overlay re-measures
  through compact↔full morphs.

## Test plan

- [ ] Open an instance with multi-task cells; verify cards stack as
      compact and the mini-stack renders correctly in collapsed rows.
- [ ] Toggle per-row collapse — skill name stays visible, owners hide,
      single-task cells show a compact card, multi-task cells show the
      mini stack.
- [ ] Toggle per-column collapse — column shrinks to the chevron strip,
      cells show centered avatars.
- [ ] In edit mode, click a mini avatar in a collapsed row → row
      expands. Repeat for a collapsed column.
- [ ] Demote a full card via the chevron, then expand it back.
- [ ] Hover the mini-stack badge — panel opens and lists every task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)