### PR TITLE
feat(dashboard): playbook outputs as right-side metadata dock

### DIFF
--- a/products/dashboard/__tests__/components/framework/playbook-outputs-dock.test.tsx
+++ b/products/dashboard/__tests__/components/framework/playbook-outputs-dock.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { PlaybookOutputsEditor } from "@/components/framework/playbook-outputs-editor";
+import { PlaybookOutputsDock } from "@/components/framework/playbook-outputs-dock";
 import { renderWithToast } from "@/tests/test-utils";
 import type { PlaybookOutput } from "@/lib/workflows/types";
 
@@ -42,7 +42,7 @@ async function focusName(user: ReturnType<typeof userEvent.setup>, rowId: string
   return within(row).getByLabelText("Output name") as HTMLInputElement;
 }
 
-describe("PlaybookOutputsEditor", () => {
+describe("PlaybookOutputsDock", () => {
   beforeEach(() => {
     listMock.mockReset();
     createMock.mockReset();
@@ -54,7 +54,7 @@ describe("PlaybookOutputsEditor", () => {
 
   it("renders existing outputs from initialOutputs", () => {
     renderWithToast(
-      <PlaybookOutputsEditor
+      <PlaybookOutputsDock
         playbookId="pb-presales"
         initialOutputs={[
           fixture(),
@@ -71,7 +71,7 @@ describe("PlaybookOutputsEditor", () => {
   it("loads outputs on mount when initialOutputs is omitted", async () => {
     listMock.mockResolvedValueOnce([fixture()]);
 
-    renderWithToast(<PlaybookOutputsEditor playbookId="pb-presales" />);
+    renderWithToast(<PlaybookOutputsDock playbookId="pb-presales" />);
 
     await waitFor(() => expect(listMock).toHaveBeenCalledWith("pb-presales"));
     expect(await screen.findByText("report")).toBeInTheDocument();
@@ -84,7 +84,7 @@ describe("PlaybookOutputsEditor", () => {
     );
 
     renderWithToast(
-      <PlaybookOutputsEditor playbookId="pb-presales" initialOutputs={[fixture()]} />,
+      <PlaybookOutputsDock playbookId="pb-presales" initialOutputs={[fixture()]} />,
     );
 
     await user.click(screen.getByTestId("playbook-outputs-add"));
@@ -104,7 +104,7 @@ describe("PlaybookOutputsEditor", () => {
       within(newRow).getByRole("option", { name: /manual/i }),
     );
 
-    await user.click(within(newRow).getByRole("button", { name: "Add" }));
+    await user.click(within(newRow).getByRole("button", { name: "Save" }));
 
     await waitFor(() =>
       expect(createMock).toHaveBeenCalledWith({
@@ -122,7 +122,7 @@ describe("PlaybookOutputsEditor", () => {
     updateMock.mockResolvedValueOnce(fixture({ name: "report-v2" }));
 
     renderWithToast(
-      <PlaybookOutputsEditor playbookId="pb-presales" initialOutputs={[fixture()]} />,
+      <PlaybookOutputsDock playbookId="pb-presales" initialOutputs={[fixture()]} />,
     );
 
     const nameInput = await focusName(user, "po-1");
@@ -146,7 +146,7 @@ describe("PlaybookOutputsEditor", () => {
     const user = userEvent.setup();
 
     renderWithToast(
-      <PlaybookOutputsEditor
+      <PlaybookOutputsDock
         playbookId="pb-presales"
         initialOutputs={[fixture(), fixture({ id: "po-2", name: "deck", position: 1 })]}
       />,
@@ -171,7 +171,7 @@ describe("PlaybookOutputsEditor", () => {
     countMock.mockResolvedValueOnce(3);
 
     renderWithToast(
-      <PlaybookOutputsEditor playbookId="pb-presales" initialOutputs={[fixture()]} />,
+      <PlaybookOutputsDock playbookId="pb-presales" initialOutputs={[fixture()]} />,
     );
 
     await user.click(screen.getByTestId("playbook-output-delete-po-1"));
@@ -185,7 +185,7 @@ describe("PlaybookOutputsEditor", () => {
     const user = userEvent.setup();
 
     renderWithToast(
-      <PlaybookOutputsEditor playbookId="pb-presales" initialOutputs={[fixture()]} />,
+      <PlaybookOutputsDock playbookId="pb-presales" initialOutputs={[fixture()]} />,
     );
 
     await user.click(screen.getByTestId("playbook-outputs-add"));

--- a/products/dashboard/__tests__/lib/workflows/repository.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/repository.test.ts
@@ -786,7 +786,7 @@ describe("workflow repository", () => {
 
   // The in-memory fake doesn't enforce the (playbook_id, name) UNIQUE
   // constraint. We cover the friendly-error path for unique-name conflicts
-  // in the playbook-outputs-editor component test instead.
+  // in the playbook-outputs-dock component test instead.
   describe("playbook outputs", () => {
     beforeEach(() => {
       store.playbook_outputs = [

--- a/products/dashboard/app/styles/components/process-matrix.css
+++ b/products/dashboard/app/styles/components/process-matrix.css
@@ -622,6 +622,25 @@
   outline: 2px solid rgba(248, 113, 113, 0.85);
   outline-offset: 2px;
 }
+.mx-entity-action-success {
+  color: #6ee7b7;
+}
+.mx-entity-action-success:hover {
+  background: linear-gradient(180deg, #10b981, #059669);
+  color: #ecfdf5;
+}
+.mx-entity-action-success:focus-visible {
+  outline: 2px solid rgba(52, 211, 153, 0.85);
+  outline-offset: 2px;
+}
+.mx-entity-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.mx-entity-action:disabled:hover {
+  background: transparent;
+  color: inherit;
+}
 .mx-task-cell {
   width: 232px;
   flex-shrink: 0;

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -22,6 +22,7 @@ import {
   Link2,
   List,
   ListOrdered,
+  PanelRight,
   Pencil,
   Plus,
   Search,
@@ -45,7 +46,7 @@ import { CompactEmojiPicker } from "@/components/framework/compact-emoji-picker"
 import { FrameworkHeaderActionsMenu } from "@/components/framework/framework-header-actions-menu";
 import { FrameworkItemModal } from "@/components/framework/framework-item-modal";
 import { ItemAvatar } from "@/components/framework/item-avatar";
-import { PlaybookOutputsEditor } from "@/components/framework/playbook-outputs-editor";
+import { PlaybookOutputsDock } from "@/components/framework/playbook-outputs-dock";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { InlineEditableText } from "@/components/ui/inline-editable-text";
 import { useAnalytics } from "@/lib/analytics/events";
@@ -162,6 +163,7 @@ export function FrameworkScreen({
   const [draftItem, setDraftItem] = useState<FrameworkItem | null>(null);
   const [lastSavedItem, setLastSavedItem] = useState<FrameworkItem | null>(null);
   const [editorView, setEditorView] = useState<EditorViewMode>("markdown");
+  const [outputsMobileOpen, setOutputsMobileOpen] = useState(false);
   const [itemModalState, setItemModalState] = useState<FrameworkItemModalState>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [deletingItemId, setDeletingItemId] = useState<string | null>(null);
@@ -712,7 +714,8 @@ export function FrameworkScreen({
 
       <div className="flex min-h-0 flex-1 overflow-hidden bg-bg-2">
         {draftItem ? (
-          <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
+          <div className="flex h-full min-h-0 min-w-0 flex-1 flex-row">
+            <div className="flex min-w-0 flex-1 flex-col">
             <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-bg px-6 py-3">
               <div className="flex min-w-0 items-center gap-2">
                 {type === "playbook" ? (
@@ -741,6 +744,19 @@ export function FrameworkScreen({
               </div>
 
               <div className="flex items-center gap-2">
+                {type === "playbook" ? (
+                  <button
+                    type="button"
+                    onClick={() => setOutputsMobileOpen(true)}
+                    aria-label="Open outputs panel"
+                    title="Outputs"
+                    data-testid="framework-outputs-toggle"
+                    className="flex h-8 items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 text-[12px] font-medium text-t2 transition hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent lg:hidden"
+                  >
+                    <PanelRight className="h-3.5 w-3.5" />
+                    Outputs
+                  </button>
+                ) : null}
                 <div
                   className="inline-flex h-8 w-fit items-center rounded-lg border border-border bg-bg-2 p-0.5"
                   role="tablist"
@@ -879,9 +895,6 @@ export function FrameworkScreen({
                           {draftItem.content || "_No content yet._"}
                         </ReactMarkdown>
                         </div>
-                        {type === "playbook" ? (
-                          <PlaybookOutputsEditor playbookId={draftItem.id} />
-                        ) : null}
                       </div>
                     </div>
                   ) : (
@@ -957,6 +970,14 @@ export function FrameworkScreen({
                 </div>
               </div>
             </div>
+            </div>
+            {type === "playbook" ? (
+              <PlaybookOutputsDock
+                playbookId={draftItem.id}
+                mobileOpen={outputsMobileOpen}
+                onMobileClose={() => setOutputsMobileOpen(false)}
+              />
+            ) : null}
           </div>
         ) : (
           <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">

--- a/products/dashboard/components/framework/playbook-outputs-dock.tsx
+++ b/products/dashboard/components/framework/playbook-outputs-dock.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useId, useMemo, useRef, useState, useTransition } from "react";
-import { ChevronDown, GripVertical, Plus, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { ChevronDown, ChevronRight, GripVertical, Plus, Save, Trash2, Undo2, X } from "lucide-react";
 import {
   DndContext,
   KeyboardSensor,
@@ -32,50 +32,49 @@ import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { InlineEditableText } from "@/components/ui/inline-editable-text";
 import { ItemAvatar } from "@/components/framework/item-avatar";
 import { useToast } from "@/lib/toast";
+import { OUTPUT_KIND_AVATAR, outputKindAvatar } from "@/lib/workflows/output-kind";
 import type { PlaybookOutput, PlaybookOutputKind } from "@/lib/workflows/types";
 import { cn } from "@/lib/utils";
 
-/** Visual encoding per output kind: emoji + ring color the picker uses
- *  in place of a text dropdown. Mirrors the drawer's avatar palette so
- *  the same kind reads the same way across both surfaces. */
-const KIND_OPTIONS: ReadonlyArray<{
+/** Picker options. Colors + emoji come from the shared palette
+ *  (`OUTPUT_KIND_AVATAR`) so the dock matches the workflow drawer's
+ *  avatar treatment one-to-one. Labels are dock-local. */
+const KIND_PICKER_OPTIONS: ReadonlyArray<{
   value: PlaybookOutputKind;
   label: string;
-  emoji: string;
-  color: string;
 }> = [
-  { value: "file", label: "File", emoji: "📎", color: "var(--pill-active-d)" },
-  { value: "media", label: "Media", emoji: "🎬", color: "var(--pill-active-d)" },
-  { value: "link", label: "Link", emoji: "🔗", color: "var(--pill-active-d)" },
-  { value: "api", label: "API", emoji: "🔌", color: "var(--pill-complete-d)" },
-  { value: "manual", label: "Manual", emoji: "✏️", color: "var(--t3)" },
+  { value: "file", label: "File" },
+  { value: "media", label: "Media" },
+  { value: "link", label: "Link" },
+  { value: "api", label: "API" },
+  { value: "manual", label: "Manual" },
 ];
 
-function kindOption(kind: PlaybookOutputKind) {
-  return KIND_OPTIONS.find((opt) => opt.value === kind) ?? KIND_OPTIONS[0];
+function kindLabel(kind: PlaybookOutputKind): string {
+  return KIND_PICKER_OPTIONS.find((opt) => opt.value === kind)?.label ?? "Manual";
 }
 
 const NAME_MAX = 80;
 
 interface DraftRow {
-  /** Stable client id; equals the server id once persisted. */
   id: string;
-  /** True until the row has been persisted (post-create). New rows live in
-   *  client-only state so the user can fill in name/kind before the first
-   *  server round-trip. */
   isPending: boolean;
   name: string;
   description: string;
   kind: PlaybookOutputKind;
   apiCheck: string;
-  /** Server-side persisted snapshot, used to detect dirty state and surface
-   *  unique-name errors only after a real change. */
   saved: PlaybookOutput | null;
 }
 
-interface PlaybookOutputsEditorProps {
+export interface PlaybookOutputsDockProps {
   playbookId: string;
   initialOutputs?: PlaybookOutput[];
+  /** When true on `<lg` screens, the dock slides in as an overlay drawer.
+   *  At `lg+` the dock is always rendered as a persistent right column and
+   *  this prop is ignored. */
+  mobileOpen?: boolean;
+  /** Backdrop click / Escape handler for the mobile overlay. */
+  onMobileClose?: () => void;
 }
 
 function fromServer(output: PlaybookOutput): DraftRow {
@@ -110,7 +109,9 @@ function isDirty(row: DraftRow): boolean {
   );
 }
 
-function parseApiCheck(value: string): { ok: true; value: Record<string, unknown> | null } | { ok: false; error: string } {
+function parseApiCheck(
+  value: string,
+): { ok: true; value: Record<string, unknown> | null } | { ok: false; error: string } {
   const trimmed = value.trim();
   if (!trimmed) return { ok: true, value: null };
   try {
@@ -136,11 +137,12 @@ function isUniqueNameConflict(
   );
 }
 
-export function PlaybookOutputsEditor({
+export function PlaybookOutputsDock({
   playbookId,
   initialOutputs,
-}: PlaybookOutputsEditorProps) {
-  const headingId = useId();
+  mobileOpen = false,
+  onMobileClose,
+}: PlaybookOutputsDockProps) {
   const { success: toastSuccess, error: toastError } = useToast();
   const [rows, setRows] = useState<DraftRow[]>(
     () => (initialOutputs ?? []).map(fromServer),
@@ -148,9 +150,9 @@ export function PlaybookOutputsEditor({
   const [loaded, setLoaded] = useState(initialOutputs !== undefined);
   const [rowErrors, setRowErrors] = useState<Record<string, string | undefined>>({});
   const [savingIds, setSavingIds] = useState<Set<string>>(new Set());
+  const [collapsed, setCollapsed] = useState(false);
   const [, startTransition] = useTransition();
 
-  // Confirm-delete state
   const [pendingDelete, setPendingDelete] = useState<{
     id: string;
     isPending: boolean;
@@ -170,15 +172,23 @@ export function PlaybookOutputsEditor({
       })
       .catch((err) => {
         if (!active) return;
-        toastError(
-          err instanceof Error ? err.message : "Could not load outputs",
-        );
+        toastError(err instanceof Error ? err.message : "Could not load outputs");
         setLoaded(true);
       });
     return () => {
       active = false;
     };
   }, [playbookId, initialOutputs, toastError]);
+
+  // Close mobile overlay on Escape.
+  useEffect(() => {
+    if (!mobileOpen || !onMobileClose) return;
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") onMobileClose?.();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [mobileOpen, onMobileClose]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -187,14 +197,11 @@ export function PlaybookOutputsEditor({
 
   const sortableIds = useMemo(() => rows.map((r) => r.id), [rows]);
 
-  const setRow = useCallback(
-    (id: string, patch: Partial<DraftRow>) => {
-      setRows((current) =>
-        current.map((row) => (row.id === id ? { ...row, ...patch } : row)),
-      );
-    },
-    [],
-  );
+  const setRow = useCallback((id: string, patch: Partial<DraftRow>) => {
+    setRows((current) =>
+      current.map((row) => (row.id === id ? { ...row, ...patch } : row)),
+    );
+  }, []);
 
   const setRowError = useCallback((id: string, message: string | undefined) => {
     setRowErrors((current) => {
@@ -229,6 +236,8 @@ export function PlaybookOutputsEditor({
         saved: null,
       },
     ]);
+    // Auto-expand when adding so the new row is visible.
+    setCollapsed(false);
   }, []);
 
   const handleSaveRow = useCallback(
@@ -253,10 +262,6 @@ export function PlaybookOutputsEditor({
       if (!parsedApi.ok) {
         setRowError(id, parsedApi.error);
         return;
-      }
-      if (row.kind === "api" && !parsedApi.value) {
-        // Allowed — api_check is optional even for api kind. Keep behavior
-        // permissive and let the founder fill it in later.
       }
 
       setRowError(id, undefined);
@@ -306,7 +311,6 @@ export function PlaybookOutputsEditor({
       const row = rows.find((r) => r.id === id);
       if (!row) return;
       if (row.isPending) {
-        // Pending rows have no server state — drop locally.
         setRows((current) => current.filter((r) => r.id !== id));
         setRowError(id, undefined);
         return;
@@ -323,7 +327,6 @@ export function PlaybookOutputsEditor({
           current && current.id === id ? { ...current, impactCount: count } : current,
         );
       } catch {
-        // Non-fatal — show confirm without the count.
         setPendingDelete((current) =>
           current && current.id === id ? { ...current, impactCount: 0 } : current,
         );
@@ -368,7 +371,6 @@ export function PlaybookOutputsEditor({
 
       startTransition(() => {
         reorderPlaybookOutputsAction(playbookId, persistedIds).catch((err) => {
-          // Roll back on failure so the UI matches the database.
           setRows(previous);
           toastError(err instanceof Error ? err.message : "Reorder failed");
         });
@@ -377,93 +379,147 @@ export function PlaybookOutputsEditor({
     [rows, playbookId, toastError],
   );
 
-  return (
-    <section
-      data-testid="playbook-outputs-editor"
-      aria-labelledby={headingId}
-      className="mt-10 border-t border-border pt-7"
-    >
-      <h2
-        id={headingId}
-        className="mb-4 text-[15px] font-semibold tracking-[-0.01em] text-t1"
-      >
-        Outputs
-      </h2>
+  const total = rows.length;
 
-      {!loaded ? (
-        <ul
-          aria-label="Loading outputs"
-          data-testid="playbook-outputs-skeleton"
-          className="flex flex-col gap-2.5"
-        >
-          {Array.from({ length: 3 }, (_, i) => (
-            <li
-              key={i}
-              className="animate-pulse rounded-md border border-border bg-bg p-3"
+  return (
+    <>
+      <div
+        className={cn(
+          "fixed inset-0 z-40 bg-[var(--overlay)] backdrop-blur-[2px] transition-opacity duration-200 lg:hidden",
+          mobileOpen ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
+        aria-hidden
+        onClick={onMobileClose}
+      />
+      <aside
+        data-testid="playbook-outputs-editor"
+        aria-label="Playbook outputs"
+        className={cn(
+          "fixed inset-y-0 right-0 z-50 flex w-[92vw] max-w-[460px] flex-col border-l border-border bg-bg shadow-[var(--shadow-canvas)] transition-transform duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]",
+          mobileOpen ? "translate-x-0" : "translate-x-full",
+          "lg:static lg:z-auto lg:w-[420px] lg:shrink-0 lg:translate-x-0 lg:shadow-none lg:transition-none",
+        )}
+      >
+        <header className="flex shrink-0 items-center justify-between gap-2 border-b border-border bg-bg px-4 py-3">
+          <div className="flex h-8 items-center">
+            <p className="text-[13px] font-semibold tracking-tight text-t1">
+              Metadata
+            </p>
+          </div>
+          {onMobileClose ? (
+            <button
+              type="button"
+              onClick={onMobileClose}
+              aria-label="Close outputs panel"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-t3 transition hover:bg-bg-2 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent lg:hidden"
             >
-              <div className="flex items-start gap-2">
-                <div className="mt-1 h-7 w-6 rounded bg-bg-2" />
-                <div className="min-w-0 flex-1 space-y-2">
-                  <div className="flex items-center gap-2">
-                    <div className="h-3 flex-1 rounded bg-bg-2" />
-                    <div className="h-3 w-14 rounded bg-bg-2" />
-                  </div>
-                  <div className="h-2.5 w-3/4 rounded bg-bg-2" />
-                </div>
-              </div>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <div className="flex flex-col gap-2.5">
-          {rows.length > 0 ? (
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
-            >
-              <SortableContext
-                items={sortableIds}
-                strategy={verticalListSortingStrategy}
+              <X className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+          <section
+            className={cn("pb-drawer-sec", "pb-drawer-outputs")}
+            data-collapsed={collapsed}
+          >
+            <div className="pb-drawer-sec__head">
+              <button
+                type="button"
+                className="pb-drawer-sec__toggle"
+                onClick={() => setCollapsed((prev) => !prev)}
+                aria-expanded={!collapsed}
               >
-                <ul className="flex flex-col gap-2.5">
-                  {rows.map((row) => (
-                    <SortableOutputRow
-                      key={row.id}
-                      row={row}
-                      error={rowErrors[row.id]}
-                      saving={savingIds.has(row.id)}
-                      dirty={isDirty(row)}
-                      onChange={(patch) => setRow(row.id, patch)}
-                      onSave={() => handleSaveRow(row.id)}
-                      onDelete={() => openDeleteConfirm(row.id)}
-                      onDiscard={() => {
-                        if (row.saved) {
-                          setRows((current) =>
-                            current.map((r) =>
-                              r.id === row.id ? fromServer(row.saved!) : r,
-                            ),
-                          );
-                        }
-                        setRowError(row.id, undefined);
-                      }}
-                    />
+                <ChevronRight
+                  size={12}
+                  className={cn(
+                    "pb-drawer-sec__chev",
+                    !collapsed && "pb-drawer-sec__chev--open",
+                  )}
+                  aria-hidden
+                />
+                <span className="pb-drawer-sec__lbl">
+                  Outputs <span className="pb-drawer-sec__count">{total}</span>
+                </span>
+              </button>
+            </div>
+
+            {!collapsed ? (
+              !loaded ? (
+                <ul
+                  aria-label="Loading outputs"
+                  data-testid="playbook-outputs-skeleton"
+                  className="mt-2 flex flex-col gap-2"
+                >
+                  {Array.from({ length: 3 }, (_, i) => (
+                    <li
+                      key={i}
+                      className="animate-pulse rounded-lg border border-border bg-bg-3 p-2.5"
+                    >
+                      <div className="flex items-center gap-2">
+                        <div className="h-6 w-6 shrink-0 rounded-full bg-bg-4" />
+                        <div className="min-w-0 flex-1 space-y-1.5">
+                          <div className="h-2.5 w-2/3 rounded bg-bg-4" />
+                          <div className="h-2 w-1/2 rounded bg-bg-4" />
+                        </div>
+                      </div>
+                    </li>
                   ))}
                 </ul>
-              </SortableContext>
-            </DndContext>
-          ) : null}
-          <button
-            type="button"
-            onClick={handleAdd}
-            data-testid="playbook-outputs-add"
-            className="group/add inline-flex items-center justify-center gap-1.5 rounded-md border border-dashed border-border bg-transparent px-4 py-3 text-[12px] font-medium text-t3 transition hover:border-border-hi hover:bg-bg-2 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-          >
-            <Plus className="h-3.5 w-3.5 transition group-hover/add:text-accent" />
-            Add output
-          </button>
+              ) : (
+                <>
+                  {rows.length > 0 ? (
+                    <DndContext
+                      sensors={sensors}
+                      collisionDetection={closestCenter}
+                      onDragEnd={handleDragEnd}
+                    >
+                      <SortableContext
+                        items={sortableIds}
+                        strategy={verticalListSortingStrategy}
+                      >
+                        <ul className="mt-2 flex flex-col gap-2">
+                          {rows.map((row) => (
+                            <SortableOutputRow
+                              key={row.id}
+                              row={row}
+                              error={rowErrors[row.id]}
+                              saving={savingIds.has(row.id)}
+                              dirty={isDirty(row)}
+                              onChange={(patch) => setRow(row.id, patch)}
+                              onSave={() => handleSaveRow(row.id)}
+                              onDelete={() => openDeleteConfirm(row.id)}
+                              onDiscard={() => {
+                                if (row.saved) {
+                                  setRows((current) =>
+                                    current.map((r) =>
+                                      r.id === row.id ? fromServer(row.saved!) : r,
+                                    ),
+                                  );
+                                }
+                                setRowError(row.id, undefined);
+                              }}
+                            />
+                          ))}
+                        </ul>
+                      </SortableContext>
+                    </DndContext>
+                  ) : null}
+                  <button
+                    type="button"
+                    onClick={handleAdd}
+                    data-testid="playbook-outputs-add"
+                    className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-border bg-transparent px-3 py-2.5 text-[12px] font-medium text-t3 transition hover:border-border-hi hover:bg-bg-2 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                  >
+                    <Plus className="h-3.5 w-3.5" aria-hidden />
+                    Add output
+                  </button>
+                </>
+              )
+            ) : null}
+          </section>
         </div>
-      )}
+      </aside>
 
       {pendingDelete ? (
         <ConfirmModal
@@ -471,7 +527,9 @@ export function PlaybookOutputsEditor({
           description={
             <div className="space-y-2">
               <p>
-                This will permanently delete <span className="font-medium text-t1">{pendingDelete.name}</span> from this playbook&rsquo;s definition.
+                This will permanently delete{" "}
+                <span className="font-medium text-t1">{pendingDelete.name}</span>{" "}
+                from this playbook&rsquo;s definition.
               </p>
               <p className="text-t3">
                 Tasks already created from this playbook keep their own copy of
@@ -481,9 +539,13 @@ export function PlaybookOutputsEditor({
                 <p className="text-t3">Checking impact…</p>
               ) : pendingDelete.impactCount > 0 ? (
                 <p data-testid="playbook-outputs-delete-impact" className="text-t2">
-                  {pendingDelete.impactCount} produced task output {pendingDelete.impactCount === 1 ? "row" : "rows"} will keep its history.
+                  {pendingDelete.impactCount} produced task output{" "}
+                  {pendingDelete.impactCount === 1 ? "row" : "rows"} will keep its
+                  history.
                 </p>
-              ) : null}
+              ) : (
+                <p className="text-t3">Not referenced by any task yet.</p>
+              )}
             </div>
           }
           confirmLabel="Delete"
@@ -492,7 +554,7 @@ export function PlaybookOutputsEditor({
           onCancel={() => setPendingDelete(null)}
         />
       ) : null}
-    </section>
+    </>
   );
 }
 
@@ -535,6 +597,7 @@ function SortableOutputRow({
 
   const showApiCheck = row.kind === "api";
   const canDiscard = !row.isPending && dirty;
+  const showActions = dirty || row.isPending;
 
   return (
     <li
@@ -542,12 +605,12 @@ function SortableOutputRow({
       data-testid={`playbook-output-row-${row.id}`}
       style={style}
       className={cn(
-        "rounded-md border border-border bg-bg px-3 py-2.5 transition-colors",
-        dirty && "border-border-hi bg-bg-2/60",
+        "group/output rounded-lg border border-border bg-bg-3 px-2.5 py-2 transition-colors hover:border-border-hi",
+        dirty && "border-border-hi bg-bg-4",
         isDragging && "shadow-lg",
       )}
     >
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2">
         <button
           type="button"
           ref={setActivatorNodeRef as unknown as React.Ref<HTMLButtonElement>}
@@ -555,9 +618,9 @@ function SortableOutputRow({
           data-testid={`playbook-output-drag-${row.id}`}
           {...(attributes as unknown as Record<string, unknown>)}
           {...(listeners as unknown as Record<string, unknown>)}
-          className="flex h-7 w-5 cursor-grab items-center justify-center rounded text-t3 hover:bg-bg-3 hover:text-t2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          className="flex h-6 w-4 shrink-0 cursor-grab items-center justify-center rounded text-t3/70 transition hover:text-t2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
         >
-          <GripVertical className="h-4 w-4" />
+          <GripVertical className="h-3.5 w-3.5" />
         </button>
 
         <KindAvatarPicker
@@ -573,23 +636,23 @@ function SortableOutputRow({
             ariaLabel="Output name"
             placeholder="Output name"
             maxLength={NAME_MAX}
-            className="block text-[14px] font-semibold tracking-tight text-t1"
+            className="block w-full text-[13px] font-semibold tracking-tight text-t1"
           />
           <InlineEditableText
             value={row.description}
             onChange={(next) => onChange({ description: next })}
             ariaLabel="Output description"
             placeholder="Add a description"
-            multiline
-            className="mt-0.5 text-[12px] leading-5 text-t2"
+            className="mt-0.5 block w-full text-[11.5px] leading-5 text-t2"
           />
+
           {showApiCheck ? (
             <details
-              className="group mt-2 rounded-md border border-border bg-bg-2"
+              className="group mt-2 rounded-md border border-border bg-bg-3"
               data-testid={`playbook-output-api-check-wrap-${row.id}`}
             >
-              <summary className="flex cursor-pointer list-none items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium uppercase tracking-[0.08em] text-t2 [&::-webkit-details-marker]:hidden">
-                <ChevronDown className="h-3.5 w-3.5 transition group-open:rotate-180" />
+              <summary className="flex cursor-pointer list-none items-center gap-1 px-2 py-1.5 text-[10.5px] font-medium uppercase tracking-[0.08em] text-t2 [&::-webkit-details-marker]:hidden">
+                <ChevronDown className="h-3 w-3 transition group-open:rotate-180" />
                 api_check
               </summary>
               <textarea
@@ -599,15 +662,16 @@ function SortableOutputRow({
                 rows={4}
                 aria-label="api_check JSON"
                 data-testid={`playbook-output-api-check-${row.id}`}
-                className="block w-full resize-y rounded-b-md border-0 border-t border-border bg-bg px-2.5 py-2 font-mono text-[11px] text-t1 placeholder:text-t3 focus:outline-none"
+                className="block w-full resize-y rounded-b-md border-0 border-t border-border bg-bg px-2 py-1.5 font-mono text-[10.5px] text-t1 placeholder:text-t3 focus:outline-none"
                 spellCheck={false}
               />
             </details>
           ) : null}
+
           {error ? (
             <p
               data-testid={`playbook-output-error-${row.id}`}
-              className="mt-1 text-[12px] text-rose-400"
+              className="mt-1 text-[11px] text-rose-400"
               role="alert"
             >
               {error}
@@ -615,44 +679,44 @@ function SortableOutputRow({
           ) : null}
         </div>
 
-        <div className="flex shrink-0 items-center gap-1.5">
+        <div className="mx-entity-actions mx-entity-actions-group shrink-0 bg-bg-4! border-border-hi!">
+          {showActions && canDiscard ? (
+            <button
+              type="button"
+              onClick={onDiscard}
+              disabled={saving}
+              aria-label="Discard changes"
+              title="Discard changes"
+              data-testid={`playbook-output-cancel-${row.id}`}
+              className="mx-entity-action"
+            >
+              <Undo2 size={11} strokeWidth={2.1} aria-hidden />
+            </button>
+          ) : null}
+          {showActions ? (
+            <button
+              type="button"
+              onClick={onSave}
+              disabled={saving}
+              aria-label="Save"
+              title="Save"
+              data-testid={`playbook-output-save-${row.id}`}
+              className="mx-entity-action mx-entity-action-success"
+            >
+              <Save size={11} strokeWidth={2.1} aria-hidden />
+              <span className="sr-only">{saving ? "Saving…" : "Save"}</span>
+            </button>
+          ) : null}
           <button
             type="button"
             onClick={onDelete}
             aria-label="Delete output"
             title="Delete output"
             data-testid={`playbook-output-delete-${row.id}`}
-            className="flex h-7 w-7 items-center justify-center rounded-md border border-border bg-bg-2 text-t3 transition hover:border-border-hi hover:bg-bg-3 hover:text-rose-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+            className="mx-entity-action mx-entity-action-danger"
           >
-            <Trash2 className="h-3.5 w-3.5" />
+            <Trash2 size={11} strokeWidth={2.1} aria-hidden />
           </button>
-          {canDiscard ? (
-            <button
-              type="button"
-              onClick={onDiscard}
-              disabled={saving}
-              data-testid={`playbook-output-cancel-${row.id}`}
-              className="flex h-7 cursor-pointer items-center gap-1.5 rounded-md border border-border bg-bg-2 px-2.5 text-[11.5px] font-medium text-t2 transition hover:border-border-hi hover:bg-bg-3 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Discard
-            </button>
-          ) : null}
-          {dirty || row.isPending ? (
-            <button
-              type="button"
-              onClick={onSave}
-              disabled={saving}
-              data-testid={`playbook-output-save-${row.id}`}
-              className={cn(
-                "flex h-7 items-center gap-1.5 rounded-md px-2.5 text-[11.5px] font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
-                saving
-                  ? "cursor-not-allowed border border-border bg-bg-2 text-t3 opacity-70"
-                  : "border border-[#10b981] bg-[#10b981] text-white shadow-[0_0_0_1px_rgba(16,185,129,0.16),0_8px_22px_rgba(16,185,129,0.24)] hover:bg-[#22c55e]",
-              )}
-            >
-              {saving ? "Saving…" : row.isPending ? "Add" : "Save"}
-            </button>
-          ) : null}
         </div>
       </div>
     </li>
@@ -668,7 +732,8 @@ interface KindAvatarPickerProps {
 function KindAvatarPicker({ rowId, value, onChange }: KindAvatarPickerProps) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
-  const current = kindOption(value);
+  const currentAvatar = outputKindAvatar(value);
+  const currentLabel = kindLabel(value);
 
   useEffect(() => {
     if (!open) return;
@@ -692,7 +757,7 @@ function KindAvatarPicker({ rowId, value, onChange }: KindAvatarPickerProps) {
       <button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
-        aria-label={`Output kind: ${current.label}. Change kind.`}
+        aria-label={`Output kind: ${currentLabel}. Change kind.`}
         aria-haspopup="listbox"
         aria-expanded={open}
         data-testid={`playbook-output-kind-${rowId}`}
@@ -700,20 +765,21 @@ function KindAvatarPicker({ rowId, value, onChange }: KindAvatarPickerProps) {
         className="rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
       >
         <ItemAvatar
-          emoji={current.emoji}
-          color={current.color}
-          label={current.label}
-          size="md"
+          emoji={currentAvatar.emoji}
+          color={currentAvatar.color}
+          label={currentLabel}
+          size="sm"
         />
       </button>
       {open ? (
         <div
           role="listbox"
           aria-label="Output kind"
-          className="absolute left-0 top-full z-30 mt-2 w-44 overflow-hidden rounded-lg border border-border-hi bg-bg-2 shadow-[var(--shadow-canvas)]"
+          className="absolute left-0 top-full z-30 mt-2 w-40 overflow-hidden rounded-lg border border-border-hi bg-bg-2 shadow-[var(--shadow-canvas)]"
         >
-          {KIND_OPTIONS.map((opt) => {
+          {KIND_PICKER_OPTIONS.map((opt) => {
             const selected = opt.value === value;
+            const avatar = OUTPUT_KIND_AVATAR[opt.value];
             return (
               <button
                 key={opt.value}
@@ -726,13 +792,13 @@ function KindAvatarPicker({ rowId, value, onChange }: KindAvatarPickerProps) {
                 }}
                 data-testid={`playbook-output-kind-option-${rowId}-${opt.value}`}
                 className={cn(
-                  "flex w-full items-center gap-2.5 px-2.5 py-1.5 text-left text-[12.5px] transition",
+                  "flex w-full items-center gap-2.5 px-2.5 py-1.5 text-left text-[12px] transition",
                   selected ? "bg-primary-bg text-accent" : "text-t2 hover:bg-bg-3 hover:text-t1",
                 )}
               >
                 <ItemAvatar
-                  emoji={opt.emoji}
-                  color={opt.color}
+                  emoji={avatar.emoji}
+                  color={avatar.color}
                   label={opt.label}
                   size="sm"
                 />

--- a/products/dashboard/components/ui/inline-editable-text.tsx
+++ b/products/dashboard/components/ui/inline-editable-text.tsx
@@ -61,11 +61,12 @@ export function InlineEditableText({
   // once on focus so the cursor lands where the user clicked instead of
   // selecting the whole value.
   const pendingCaretRef = useRef<number | null>(null);
-  // Read-mode box size captured on click. Applied to the editor so its
-  // box matches the previous label exactly — no width growth as the user
-  // types (which would push siblings like the color dot), no height jump
-  // on entry.
-  const pendingRectRef = useRef<{ width: number; height: number } | null>(null);
+  // Read-mode height captured on click. Applied to multiline textareas
+  // so the initial height matches the read-mode block and doesn't jump
+  // on entry. Width is controlled by CSS (parent container) so the input
+  // grows and shrinks as the user types instead of scrolling inside a
+  // fixed pixel box.
+  const pendingRectRef = useRef<{ height: number } | null>(null);
 
   useEffect(() => {
     // Run only when transitioning into edit mode — focus once.
@@ -89,8 +90,6 @@ export function InlineEditableText({
       const initial = rect ? rect.height : 0;
       textareaRef.current.style.height = "auto";
       textareaRef.current.style.height = `${Math.max(initial, textareaRef.current.scrollHeight)}px`;
-    } else if (!multiline && inputRef.current && rect) {
-      inputRef.current.style.width = `${rect.width}px`;
     }
     // `draft` is intentionally excluded — we only want this on edit-mode entry.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -100,7 +99,7 @@ export function InlineEditableText({
     if (event) {
       pendingCaretRef.current = caretOffsetFromPoint(event.clientX, event.clientY);
       const rect = event.currentTarget.getBoundingClientRect();
-      pendingRectRef.current = { width: rect.width, height: rect.height };
+      pendingRectRef.current = { height: rect.height };
     } else {
       pendingCaretRef.current = null;
       pendingRectRef.current = null;
@@ -177,11 +176,12 @@ export function InlineEditableText({
         maxLength={maxLength}
         aria-label={ariaLabel}
         placeholder={placeholder}
-        // `width` is locked at edit-mode entry via the inline style set
-        // in the focus effect, so typing doesn't push neighboring
-        // controls. Long text scrolls horizontally inside the input.
+        // Width follows the parent container (block w-full), so the input
+        // grows and shrinks as the user types instead of scrolling inside
+        // a fixed pixel box. Callers control how wide the field can get by
+        // constraining the wrapping parent (e.g. `min-w-0 flex-1`, `max-w-3xl`).
         className={cn(
-          "min-w-0 max-w-full bg-transparent border-0 p-0 outline-none",
+          "block w-full min-w-0 max-w-full bg-transparent border-0 p-0 outline-none",
           editUnderline,
           className,
         )}
@@ -223,7 +223,7 @@ export function InlineEditableText({
       onClick={(event) => beginEdit(event)}
       aria-label={`Edit ${ariaLabel}`}
       className={cn(
-        "block text-left bg-transparent border-0 p-0 cursor-text min-w-0 max-w-full truncate",
+        "block w-full text-left bg-transparent border-0 p-0 cursor-text min-w-0 max-w-full truncate",
         !value && "text-t3",
         className,
       )}

--- a/products/dashboard/lib/workflows/output-kind.ts
+++ b/products/dashboard/lib/workflows/output-kind.ts
@@ -13,7 +13,7 @@ export const OUTPUT_KIND_AVATAR: Record<PlaybookOutputKind, OutputKindAvatar> = 
   file: { emoji: "📎", color: "#3b82f6" },
   media: { emoji: "🎬", color: "#a855f7" },
   link: { emoji: "🔗", color: "#06b6d4" },
-  api: { emoji: "🔌", color: "#10b981" },
+  api: { emoji: "🔌", color: "#ec4899" },
   manual: { emoji: "✏️", color: "#f59e0b" },
 };
 

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -1576,11 +1576,22 @@ export function createWorkflowRepository(
         .map((id, index) => ({ id, position: index }));
       if (updates.length === 0) return;
 
-      // Apply in a single round-trip: per-row UPDATEs would be N round-trips,
-      // so we use upsert(onConflict: id) which writes all positions at once.
-      const { error } = await client
-        .from("playbook_outputs")
-        .upsert(updates, { onConflict: "id" });
+      // Per-row UPDATEs touch only the `position` column. An earlier upsert
+      // approach tripped NOT NULL constraints on `name`/`playbook_id`
+      // because PostgREST evaluates upserts as INSERT…ON CONFLICT, which
+      // requires every NOT NULL column on the INSERT branch. N is small
+      // (a handful of outputs per playbook) so we parallelize with
+      // Promise.all to keep latency flat.
+      const results = await Promise.all(
+        updates.map(({ id, position }) =>
+          client
+            .from("playbook_outputs")
+            .update({ position })
+            .eq("id", id)
+            .eq("playbook_id", playbookId),
+        ),
+      );
+      const error = results.find((r) => r.error)?.error;
       if (error) {
         throw new WorkflowRepositoryError("reorderPlaybookOutputs failed", error);
       }


### PR DESCRIPTION
## Summary

Reframes the playbook edit page's outputs management as a persistent right-side **metadata dock** instead of a section bolted onto the bottom of the rendered Markdown preview. Outputs are now visible and editable in both View and Edit modes, share the visual language of the workflow drawer's I/O sections (`pb-drawer-sec` chrome, IO row layout, button groups), and use the shared kind palette.

Also folds in a couple of fixes uncovered while building the dock:

- `reorderPlaybookOutputs` was issuing a Supabase upsert with only `{ id, position }`, which PostgREST treats as `INSERT … ON CONFLICT` and fails on `NOT NULL` columns like `playbook_id` / `name`. Switched to per-row `UPDATE`s touching only `position`.
- `InlineEditableText` pinned the edit-mode input width to the read-mode element's pixel width on click, so short content locked the input into a narrow box that scrolled while typing. Both modes now default to `w-full` and inherit width from the wrapping parent.
- `OUTPUT_KIND_AVATAR`: `api` moves from cyan to pink so it no longer reads as the same color as `link` on pip rails and avatars.

Commits are split per concern so the merge commit preserves the audit trail.

## Test plan

- [ ] `npm run validate` (root) — schemas/policy unchanged but checks nothing regressed
- [ ] `cd products/dashboard && npm run test` — unit/component tests (dock tests, repo tests, inline-editable callers)
- [ ] `cd products/dashboard && npm run typecheck`
- [ ] Open a playbook → confirm the right dock renders in both **View** and **Edit** modes
- [ ] Add, rename, change kind, drag-reorder, and delete an output (with and without produced `task_outputs`) — confirm no NOT NULL errors and the confirm dialog never collapses mid-fetch
- [ ] Edit the playbook's title/description inline — confirm the input grows with content and shrinks on deletion (no horizontal scroll)
- [ ] Narrow window below `lg` → confirm the dock collapses to the toolbar's "Outputs" toggle and slides in as an overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)