### PR TITLE
feat(dashboard): group playbooks by skill/workflow + drawer/dock polish

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,7 +6,7 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
       "cwd": "products/dashboard",
-      "port": 3000
+      "autoPort": true
     }
   ]
 }

--- a/products/dashboard/__tests__/components/framework/playbook-outputs-dock.test.tsx
+++ b/products/dashboard/__tests__/components/framework/playbook-outputs-dock.test.tsx
@@ -89,7 +89,10 @@ describe("PlaybookOutputsDock", () => {
 
     await user.click(screen.getByTestId("playbook-outputs-add"));
 
-    const newRow = screen.getAllByRole("listitem").at(-1)!;
+    const outputRows = screen
+      .getAllByRole("listitem")
+      .filter((el) => el.dataset.testid?.startsWith("playbook-output-row-"));
+    const newRow = outputRows.at(-1)!;
     // Type the name into the inline-editable field.
     await user.click(within(newRow).getByRole("button", { name: /edit output name/i }));
     const nameInput = within(newRow).getByLabelText("Output name") as HTMLInputElement;
@@ -189,13 +192,19 @@ describe("PlaybookOutputsDock", () => {
     );
 
     await user.click(screen.getByTestId("playbook-outputs-add"));
-    const rows = screen.getAllByRole("listitem");
+    const rows = screen
+      .getAllByRole("listitem")
+      .filter((el) => el.dataset.testid?.startsWith("playbook-output-row-"));
     const pendingRow = rows.at(-1)!;
     await user.click(
       within(pendingRow).getByRole("button", { name: /delete output/i }),
     );
 
     expect(deleteMock).not.toHaveBeenCalled();
-    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+    expect(
+      screen
+        .getAllByRole("listitem")
+        .filter((el) => el.dataset.testid?.startsWith("playbook-output-row-")),
+    ).toHaveLength(1);
   });
 });

--- a/products/dashboard/app/(dashboard)/framework/playbooks/page.tsx
+++ b/products/dashboard/app/(dashboard)/framework/playbooks/page.tsx
@@ -4,16 +4,22 @@ import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
 
 export default async function PlaybooksPage() {
   const repo = await getServerWorkflowRepository();
-  const [items, skills] = await Promise.all([
+  const [items, skills, templates] = await Promise.all([
     repo.getFrameworkItems("playbook"),
     repo.getFrameworkItems("skill"),
+    repo.getTemplates(),
   ]);
 
   return (
     <div className="flex h-full min-h-0 flex-col">
       <ShellEvents route="/framework/playbooks" />
       <div className="min-h-0 flex-1">
-        <FrameworkScreen initialItems={items} type="playbook" availableSkills={skills} />
+        <FrameworkScreen
+          initialItems={items}
+          type="playbook"
+          availableSkills={skills}
+          availableTemplates={templates}
+        />
       </div>
     </div>
   );

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -15,6 +15,7 @@ import {
   Code,
   ArrowDownAZ,
   ArrowUpAZ,
+  ChevronDown,
   Heading1,
   Heading2,
   Download,
@@ -194,7 +195,10 @@ export function FrameworkScreen({
   const [searchQuery, setSearchQuery] = useState("");
   const [filterIds, setFilterIds] = useState<string[]>([]);
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
-  const [groupBy, setGroupBy] = useState<PlaybookGroupBy>("none");
+  const [groupBy, setGroupBy] = useState<PlaybookGroupBy>(
+    type === "playbook" ? "skill" : "none",
+  );
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const [pending, startTransition] = useTransition();
   const editorTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const importInputRef = useRef<HTMLInputElement | null>(null);
@@ -410,6 +414,21 @@ export function FrameworkScreen({
       // Persistence is best-effort; ignore quota / disabled-storage errors.
     }
   }, [groupBy, type]);
+
+  // Switching grouping dimension drops the collapsed-set — group ids from
+  // the previous dimension are meaningless under the new one.
+  useEffect(() => {
+    setCollapsedGroups(new Set());
+  }, [groupBy]);
+
+  const toggleGroupCollapsed = useCallback((groupId: string) => {
+    setCollapsedGroups((current) => {
+      const next = new Set(current);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+  }, []);
 
   useLayoutEffect(() => {
     if (editorView !== "plain-text") {
@@ -1258,57 +1277,91 @@ export function FrameworkScreen({
                   {visibleItems.length > 0 ? (
                     groupBy !== "none" && type === "playbook" ? (
                       <div
-                        className="flex flex-col gap-6"
+                        className="flex flex-col gap-3"
                         data-testid={`framework-grid-${type}`}
                       >
-                        {groupedItems.map((group) => (
-                          <section
-                            key={group.id}
-                            data-testid={`framework-group-${group.id}`}
-                          >
-                            <header className="mb-3 flex items-center gap-2.5">
-                              <ItemAvatar
-                                emoji={group.emoji ?? undefined}
-                                initials={group.emoji ? null : group.label.slice(0, 2)}
-                                color={group.color}
-                                label={group.label}
-                                size="sm"
-                              />
-                              <h3 className="text-[13px] font-semibold tracking-[-0.01em] text-t1">
-                                {group.label}
-                              </h3>
-                              <span className="rounded-full bg-bg-2 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-t3">
-                                {group.items.length}
-                              </span>
-                            </header>
-                            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                              {group.items.map((item) => (
-                                <button
-                                  key={item.id}
-                                  type="button"
-                                  onClick={() => beginEdit(item)}
-                                  data-testid={`framework-card-${item.id}`}
-                                  className="group flex min-h-[92px] items-center gap-3 rounded-[16px] border border-border bg-bg px-4 py-4 text-left transition-[background-color,border-color,transform,box-shadow] duration-150 hover:border-border-hi hover:bg-bg hover:shadow-[0_14px_34px_rgba(15,23,42,0.08)] focus-visible:-translate-y-[1px] focus-visible:border-border-hi focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                        {groupedItems.map((group) => {
+                          const collapsed = collapsedGroups.has(group.id);
+                          const headerId = `framework-group-header-${group.id}`;
+                          const panelId = `framework-group-panel-${group.id}`;
+                          return (
+                            <section
+                              key={group.id}
+                              data-testid={`framework-group-${group.id}`}
+                              className="rounded-[14px] border border-border bg-bg-2/40"
+                            >
+                              <button
+                                id={headerId}
+                                type="button"
+                                onClick={() => toggleGroupCollapsed(group.id)}
+                                aria-expanded={!collapsed}
+                                aria-controls={panelId}
+                                data-testid={`framework-group-toggle-${group.id}`}
+                                className={cn(
+                                  "flex w-full items-center gap-2.5 px-3.5 py-2.5 text-left transition-colors hover:bg-bg-2/80 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent",
+                                  collapsed ? "rounded-[14px]" : "rounded-t-[14px]",
+                                )}
+                              >
+                                <ChevronDown
+                                  aria-hidden
+                                  className={cn(
+                                    "h-3.5 w-3.5 shrink-0 text-t3 transition-transform duration-150",
+                                    collapsed && "-rotate-90",
+                                  )}
+                                />
+                                <ItemAvatar
+                                  emoji={group.emoji ?? undefined}
+                                  initials={group.emoji ? null : group.label.slice(0, 2)}
+                                  color={group.color}
+                                  label={group.label}
+                                  size="sm"
+                                />
+                                <h3 className="min-w-0 flex-1 truncate text-[13.5px] font-semibold tracking-[-0.01em] text-t1">
+                                  {group.label}
+                                </h3>
+                                <span
+                                  aria-label={`${group.items.length} ${group.items.length === 1 ? "playbook" : "playbooks"}`}
+                                  className="shrink-0 rounded-md bg-bg px-1.5 py-0.5 font-mono text-[10.5px] tabular-nums text-t2 ring-1 ring-inset ring-border"
                                 >
-                                  <ItemAvatar
-                                    emoji={item.icon || "📄"}
-                                    color={resolveItemColor(item)}
-                                    label={item.name}
-                                    size="md"
-                                  />
-                                  <div className="min-w-0 flex-1">
-                                    <h2 className="overflow-hidden whitespace-nowrap text-[16px] leading-[1.15] font-semibold tracking-[-0.02em] text-t1 text-ellipsis">
-                                      {item.name}
-                                    </h2>
-                                    <p className="mt-1 overflow-hidden whitespace-nowrap text-[12.5px] leading-[1.35rem] text-t2 text-ellipsis">
-                                      {item.description}
-                                    </p>
-                                  </div>
-                                </button>
-                              ))}
-                            </div>
-                          </section>
-                        ))}
+                                  {group.items.length}
+                                </span>
+                              </button>
+                              {collapsed ? null : (
+                                <div
+                                  id={panelId}
+                                  role="region"
+                                  aria-labelledby={headerId}
+                                  className="grid gap-2.5 border-t border-border bg-bg p-3 sm:grid-cols-2 xl:grid-cols-3 rounded-b-[14px]"
+                                >
+                                  {group.items.map((item) => (
+                                    <button
+                                      key={item.id}
+                                      type="button"
+                                      onClick={() => beginEdit(item)}
+                                      data-testid={`framework-card-${item.id}`}
+                                      className="group flex min-h-[84px] items-center gap-3 rounded-[12px] border border-border bg-bg-2/60 px-3.5 py-3.5 text-left transition-[background-color,border-color,transform,box-shadow] duration-150 hover:border-border-hi hover:bg-bg hover:shadow-[0_10px_24px_rgba(15,23,42,0.08)] focus-visible:-translate-y-[1px] focus-visible:border-border-hi focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                                    >
+                                      <ItemAvatar
+                                        emoji={item.icon || "📄"}
+                                        color={resolveItemColor(item)}
+                                        label={item.name}
+                                        size="md"
+                                      />
+                                      <div className="min-w-0 flex-1">
+                                        <h2 className="overflow-hidden whitespace-nowrap text-[15px] leading-[1.15] font-semibold tracking-[-0.02em] text-t1 text-ellipsis">
+                                          {item.name}
+                                        </h2>
+                                        <p className="mt-0.5 overflow-hidden whitespace-nowrap text-[12.5px] leading-[1.35rem] text-t2 text-ellipsis">
+                                          {item.description}
+                                        </p>
+                                      </div>
+                                    </button>
+                                  ))}
+                                </div>
+                              )}
+                            </section>
+                          );
+                        })}
                       </div>
                     ) : (
                       <div

--- a/products/dashboard/components/framework/framework-screen.tsx
+++ b/products/dashboard/components/framework/framework-screen.tsx
@@ -19,6 +19,7 @@ import {
   Heading2,
   Download,
   Eye,
+  Layers,
   Link2,
   List,
   ListOrdered,
@@ -53,7 +54,11 @@ import { useAnalytics } from "@/lib/analytics/events";
 import { useToast } from "@/lib/toast";
 import { useUnsavedChangesGuard } from "@/lib/use-unsaved-changes-guard";
 import { resolveItemColor } from "@/lib/workflows/skill-colors";
-import type { FrameworkItem, FrameworkItemType } from "@/lib/workflows/types";
+import type {
+  FrameworkItem,
+  FrameworkItemType,
+  WorkflowTemplate,
+} from "@/lib/workflows/types";
 import { cn } from "@/lib/utils";
 
 interface FrameworkScreenProps {
@@ -65,6 +70,24 @@ interface FrameworkScreenProps {
   /** All Playbooks. Required when `type === "skill"` so the editor can
    * render the inverse "Allowed playbooks" multi-select. */
   availablePlaybooks?: FrameworkItem[];
+  /** All workflow templates. Used by the Playbooks page to support the
+   *  "Group by Workflow" view (bucket per template that references the
+   *  playbook). Unused on the Skills page. */
+  availableTemplates?: WorkflowTemplate[];
+}
+
+type PlaybookGroupBy = "none" | "skill" | "workflow";
+const PLAYBOOK_GROUP_BY_KEY = "framework.playbooks.groupBy";
+const PLAYBOOK_GROUP_BY_VALUES: PlaybookGroupBy[] = ["none", "skill", "workflow"];
+
+interface PlaybookGroup {
+  id: string;
+  label: string;
+  color: string;
+  emoji?: string | null;
+  items: FrameworkItem[];
+  /** Render below all named groups (Unassigned / Unused buckets). */
+  fallback?: boolean;
 }
 
 type EditorViewMode = "markdown" | "plain-text";
@@ -154,6 +177,7 @@ export function FrameworkScreen({
   type,
   availableSkills = [],
   availablePlaybooks = [],
+  availableTemplates = [],
 }: FrameworkScreenProps) {
   const { setConfig } = useDashboardTopBar();
   const { capture } = useAnalytics();
@@ -170,6 +194,7 @@ export function FrameworkScreen({
   const [searchQuery, setSearchQuery] = useState("");
   const [filterIds, setFilterIds] = useState<string[]>([]);
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
+  const [groupBy, setGroupBy] = useState<PlaybookGroupBy>("none");
   const [pending, startTransition] = useTransition();
   const editorTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const importInputRef = useRef<HTMLInputElement | null>(null);
@@ -219,6 +244,121 @@ export function FrameworkScreen({
       (left, right) => direction * left.name.localeCompare(right.name),
     );
   }, [filteredItems, sortDirection]);
+
+  // Index of templates that reference each playbook id, derived from
+  // `taskTemplates[].playbookId`. Used by the "Group by Workflow" view.
+  const templatesByPlaybookId = useMemo(() => {
+    if (type !== "playbook") return new Map<string, WorkflowTemplate[]>();
+    const index = new Map<string, WorkflowTemplate[]>();
+    for (const template of availableTemplates) {
+      const seen = new Set<string>();
+      for (const task of template.taskTemplates) {
+        if (!task.playbookId || seen.has(task.playbookId)) continue;
+        seen.add(task.playbookId);
+        const bucket = index.get(task.playbookId);
+        if (bucket) bucket.push(template);
+        else index.set(task.playbookId, [template]);
+      }
+    }
+    return index;
+  }, [availableTemplates, type]);
+
+  const skillsById = useMemo(() => {
+    const index = new Map<string, FrameworkItem>();
+    for (const skill of availableSkills) index.set(skill.id, skill);
+    return index;
+  }, [availableSkills]);
+
+  // When grouping is active, produce stacked sections in place of the flat
+  // grid. Items are non-exclusive: a playbook with two allowed skills appears
+  // under both. Empty groups never render — the "Unassigned"/"Unused" buckets
+  // only appear when at least one playbook would land in them.
+  const groupedItems = useMemo<PlaybookGroup[]>(() => {
+    if (type !== "playbook" || groupBy === "none") return [];
+
+    const groups = new Map<string, PlaybookGroup>();
+
+    const addToGroup = (
+      key: string,
+      seed: () => Omit<PlaybookGroup, "items">,
+      item: FrameworkItem,
+    ) => {
+      const existing = groups.get(key);
+      if (existing) {
+        existing.items.push(item);
+        return;
+      }
+      groups.set(key, { ...seed(), items: [item] });
+    };
+
+    if (groupBy === "skill") {
+      for (const item of visibleItems) {
+        const ids = item.allowedSkillIds ?? [];
+        if (ids.length === 0) {
+          addToGroup(
+            "__unassigned__",
+            () => ({
+              id: "__unassigned__",
+              label: "Unassigned",
+              color: "var(--border-hi)",
+              emoji: "—",
+              fallback: true,
+            }),
+            item,
+          );
+          continue;
+        }
+        for (const id of ids) {
+          const skill = skillsById.get(id);
+          addToGroup(
+            id,
+            () => ({
+              id,
+              label: skill?.name ?? "Unknown skill",
+              color: skill ? resolveItemColor(skill) : "var(--border-hi)",
+              emoji: skill?.icon ?? "🤖",
+            }),
+            item,
+          );
+        }
+      }
+    } else {
+      for (const item of visibleItems) {
+        const templates = templatesByPlaybookId.get(item.id) ?? [];
+        if (templates.length === 0) {
+          addToGroup(
+            "__unused__",
+            () => ({
+              id: "__unused__",
+              label: "Unused",
+              color: "var(--border-hi)",
+              emoji: "—",
+              fallback: true,
+            }),
+            item,
+          );
+          continue;
+        }
+        for (const template of templates) {
+          addToGroup(
+            template.id,
+            () => ({
+              id: template.id,
+              label: template.label,
+              color: template.color || "var(--border-hi)",
+            }),
+            item,
+          );
+        }
+      }
+    }
+
+    return [...groups.values()].sort((left, right) => {
+      if (left.fallback && !right.fallback) return 1;
+      if (!left.fallback && right.fallback) return -1;
+      return left.label.localeCompare(right.label);
+    });
+  }, [groupBy, skillsById, templatesByPlaybookId, type, visibleItems]);
   const isDirty =
     draftItem !== null &&
     (lastSavedItem === null || !areFrameworkItemsEqual(draftItem, lastSavedItem));
@@ -246,6 +386,30 @@ export function FrameworkScreen({
   useEffect(() => {
     setItems(initialItems);
   }, [initialItems]);
+
+  // Hydrate `groupBy` from localStorage on mount (playbooks only). The default
+  // ("none") means the page renders identically to the pre-grouping behavior
+  // when a user has never opened the control before.
+  useEffect(() => {
+    if (type !== "playbook" || typeof window === "undefined") return;
+    try {
+      const stored = window.localStorage.getItem(PLAYBOOK_GROUP_BY_KEY);
+      if (stored && (PLAYBOOK_GROUP_BY_VALUES as string[]).includes(stored)) {
+        setGroupBy(stored as PlaybookGroupBy);
+      }
+    } catch {
+      // localStorage can throw in private modes; fall back silently to default.
+    }
+  }, [type]);
+
+  useEffect(() => {
+    if (type !== "playbook" || typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(PLAYBOOK_GROUP_BY_KEY, groupBy);
+    } catch {
+      // Persistence is best-effort; ignore quota / disabled-storage errors.
+    }
+  }, [groupBy, type]);
 
   useLayoutEffect(() => {
     if (editorView !== "plain-text") {
@@ -1033,6 +1197,43 @@ export function FrameworkScreen({
                           }
                           onChange={setFilterIds}
                         />
+                        {type === "playbook" ? (
+                          <div
+                            className="inline-flex h-8 items-center rounded-md border border-border bg-bg p-0.5"
+                            role="tablist"
+                            aria-label="Group playbooks by"
+                            data-testid="framework-group-by"
+                          >
+                            <Layers
+                              aria-hidden
+                              className="ml-1.5 mr-1 h-3.5 w-3.5 text-t3"
+                            />
+                            {(
+                              [
+                                ["none", "None"],
+                                ["skill", "Skill"],
+                                ["workflow", "Workflow"],
+                              ] as const
+                            ).map(([value, label]) => (
+                              <button
+                                key={value}
+                                type="button"
+                                role="tab"
+                                aria-selected={groupBy === value}
+                                onClick={() => setGroupBy(value)}
+                                data-testid={`framework-group-by-${value}`}
+                                className={cn(
+                                  "flex h-full items-center rounded-[5px] px-2 text-[12px] font-medium transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+                                  groupBy === value
+                                    ? "bg-bg-3 text-t1"
+                                    : "text-t2 hover:bg-bg-2 hover:text-t1",
+                                )}
+                              >
+                                {label}
+                              </button>
+                            ))}
+                          </div>
+                        ) : null}
                         <button
                           type="button"
                           onClick={() =>
@@ -1055,35 +1256,91 @@ export function FrameworkScreen({
 
                   <div className="p-3 md:p-4">
                   {visibleItems.length > 0 ? (
-                    <div
-                      className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
-                      data-testid={`framework-grid-${type}`}
-                    >
-                      {visibleItems.map((item) => (
-                        <button
-                          key={item.id}
-                          type="button"
-                          onClick={() => beginEdit(item)}
-                          data-testid={`framework-card-${item.id}`}
-                          className="group flex min-h-[92px] items-center gap-3 rounded-[16px] border border-border bg-bg px-4 py-4 text-left transition-[background-color,border-color,transform,box-shadow] duration-150 hover:border-border-hi hover:bg-bg hover:shadow-[0_14px_34px_rgba(15,23,42,0.08)] focus-visible:-translate-y-[1px] focus-visible:border-border-hi focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-                        >
-                          <ItemAvatar
-                            emoji={item.icon || (type === "skill" ? "🤖" : "📄")}
-                            color={resolveItemColor(item)}
-                            label={item.name}
-                            size="md"
-                          />
-                          <div className="min-w-0 flex-1">
-                            <h2 className="overflow-hidden whitespace-nowrap text-[16px] leading-[1.15] font-semibold tracking-[-0.02em] text-t1 text-ellipsis">
-                              {item.name}
-                            </h2>
-                            <p className="mt-1 overflow-hidden whitespace-nowrap text-[12.5px] leading-[1.35rem] text-t2 text-ellipsis">
-                              {item.description}
-                            </p>
-                          </div>
-                        </button>
-                      ))}
-                    </div>
+                    groupBy !== "none" && type === "playbook" ? (
+                      <div
+                        className="flex flex-col gap-6"
+                        data-testid={`framework-grid-${type}`}
+                      >
+                        {groupedItems.map((group) => (
+                          <section
+                            key={group.id}
+                            data-testid={`framework-group-${group.id}`}
+                          >
+                            <header className="mb-3 flex items-center gap-2.5">
+                              <ItemAvatar
+                                emoji={group.emoji ?? undefined}
+                                initials={group.emoji ? null : group.label.slice(0, 2)}
+                                color={group.color}
+                                label={group.label}
+                                size="sm"
+                              />
+                              <h3 className="text-[13px] font-semibold tracking-[-0.01em] text-t1">
+                                {group.label}
+                              </h3>
+                              <span className="rounded-full bg-bg-2 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-t3">
+                                {group.items.length}
+                              </span>
+                            </header>
+                            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                              {group.items.map((item) => (
+                                <button
+                                  key={item.id}
+                                  type="button"
+                                  onClick={() => beginEdit(item)}
+                                  data-testid={`framework-card-${item.id}`}
+                                  className="group flex min-h-[92px] items-center gap-3 rounded-[16px] border border-border bg-bg px-4 py-4 text-left transition-[background-color,border-color,transform,box-shadow] duration-150 hover:border-border-hi hover:bg-bg hover:shadow-[0_14px_34px_rgba(15,23,42,0.08)] focus-visible:-translate-y-[1px] focus-visible:border-border-hi focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                                >
+                                  <ItemAvatar
+                                    emoji={item.icon || "📄"}
+                                    color={resolveItemColor(item)}
+                                    label={item.name}
+                                    size="md"
+                                  />
+                                  <div className="min-w-0 flex-1">
+                                    <h2 className="overflow-hidden whitespace-nowrap text-[16px] leading-[1.15] font-semibold tracking-[-0.02em] text-t1 text-ellipsis">
+                                      {item.name}
+                                    </h2>
+                                    <p className="mt-1 overflow-hidden whitespace-nowrap text-[12.5px] leading-[1.35rem] text-t2 text-ellipsis">
+                                      {item.description}
+                                    </p>
+                                  </div>
+                                </button>
+                              ))}
+                            </div>
+                          </section>
+                        ))}
+                      </div>
+                    ) : (
+                      <div
+                        className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+                        data-testid={`framework-grid-${type}`}
+                      >
+                        {visibleItems.map((item) => (
+                          <button
+                            key={item.id}
+                            type="button"
+                            onClick={() => beginEdit(item)}
+                            data-testid={`framework-card-${item.id}`}
+                            className="group flex min-h-[92px] items-center gap-3 rounded-[16px] border border-border bg-bg px-4 py-4 text-left transition-[background-color,border-color,transform,box-shadow] duration-150 hover:border-border-hi hover:bg-bg hover:shadow-[0_14px_34px_rgba(15,23,42,0.08)] focus-visible:-translate-y-[1px] focus-visible:border-border-hi focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                          >
+                            <ItemAvatar
+                              emoji={item.icon || (type === "skill" ? "🤖" : "📄")}
+                              color={resolveItemColor(item)}
+                              label={item.name}
+                              size="md"
+                            />
+                            <div className="min-w-0 flex-1">
+                              <h2 className="overflow-hidden whitespace-nowrap text-[16px] leading-[1.15] font-semibold tracking-[-0.02em] text-t1 text-ellipsis">
+                                {item.name}
+                              </h2>
+                              <p className="mt-1 overflow-hidden whitespace-nowrap text-[12.5px] leading-[1.35rem] text-t2 text-ellipsis">
+                                {item.description}
+                              </p>
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                    )
                   ) : (
                     <div
                       className="flex min-h-full min-w-0 items-center justify-center rounded-[18px] border border-dashed border-border-hi bg-bg-2/72 px-6 py-10 text-center"

--- a/products/dashboard/components/framework/playbook-metadata-dock.tsx
+++ b/products/dashboard/components/framework/playbook-metadata-dock.tsx
@@ -588,54 +588,52 @@ function PlaybookOutputsSection({
               ))}
             </ul>
           ) : (
-            <>
-              {rows.length > 0 ? (
-                <DndContext
-                  sensors={sensors}
-                  collisionDetection={closestCenter}
-                  onDragEnd={handleDragEnd}
-                >
-                  <SortableContext
-                    items={sortableIds}
-                    strategy={verticalListSortingStrategy}
-                  >
-                    <ul className="mt-2 flex flex-col gap-2">
-                      {rows.map((row) => (
-                        <SortableOutputRow
-                          key={row.id}
-                          row={row}
-                          error={rowErrors[row.id]}
-                          saving={savingIds.has(row.id)}
-                          dirty={isOutputDirty(row)}
-                          onChange={(patch) => setRow(row.id, patch)}
-                          onSave={() => handleSaveRow(row.id)}
-                          onDelete={() => openDeleteConfirm(row.id)}
-                          onDiscard={() => {
-                            if (row.saved) {
-                              setRows((current) =>
-                                current.map((r) =>
-                                  r.id === row.id ? fromServerOutput(row.saved!) : r,
-                                ),
-                              );
-                            }
-                            setRowError(row.id, undefined);
-                          }}
-                        />
-                      ))}
-                    </ul>
-                  </SortableContext>
-                </DndContext>
-              ) : null}
-              <button
-                type="button"
-                onClick={handleAdd}
-                data-testid="playbook-outputs-add"
-                className="mt-2 flex min-h-[56px] w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-border bg-transparent px-3 py-2.5 text-[12px] font-medium text-t3 transition hover:border-border-hi hover:bg-bg-2 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={sortableIds}
+                strategy={verticalListSortingStrategy}
               >
-                <Plus className="h-3.5 w-3.5" aria-hidden />
-                Add output
-              </button>
-            </>
+                <ul className="mt-2 flex flex-col gap-2">
+                  {rows.map((row) => (
+                    <SortableOutputRow
+                      key={row.id}
+                      row={row}
+                      error={rowErrors[row.id]}
+                      saving={savingIds.has(row.id)}
+                      dirty={isOutputDirty(row)}
+                      onChange={(patch) => setRow(row.id, patch)}
+                      onSave={() => handleSaveRow(row.id)}
+                      onDelete={() => openDeleteConfirm(row.id)}
+                      onDiscard={() => {
+                        if (row.saved) {
+                          setRows((current) =>
+                            current.map((r) =>
+                              r.id === row.id ? fromServerOutput(row.saved!) : r,
+                            ),
+                          );
+                        }
+                        setRowError(row.id, undefined);
+                      }}
+                    />
+                  ))}
+                  <li>
+                    <button
+                      type="button"
+                      onClick={handleAdd}
+                      data-testid="playbook-outputs-add"
+                      className="flex min-h-[56px] w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-border bg-transparent px-3 py-2.5 text-[12px] font-medium text-t3 transition hover:border-border-hi hover:bg-bg-2 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                    >
+                      <Plus className="h-3.5 w-3.5" aria-hidden />
+                      Add output
+                    </button>
+                  </li>
+                </ul>
+              </SortableContext>
+            </DndContext>
           )
         ) : null}
       </section>
@@ -875,46 +873,42 @@ function PlaybookInputsSection({
               ))}
             </ul>
           ) : (
-            <>
-              {rows.length > 0 ? (
-                <DndContext
-                  sensors={sensors}
-                  collisionDetection={closestCenter}
-                  onDragEnd={handleDragEnd}
-                >
-                  <SortableContext
-                    items={sortableIds}
-                    strategy={verticalListSortingStrategy}
-                  >
-                    <ul className="mt-2 flex flex-col gap-2">
-                      {rows.map((row) => (
-                        <SortableInputRow
-                          key={row.id}
-                          row={row}
-                          upstreamPlaybook={playbookById.get(row.upstreamPlaybookId)}
-                          onDelete={() => openDeleteConfirm(row)}
-                        />
-                      ))}
-                    </ul>
-                  </SortableContext>
-                </DndContext>
-              ) : null}
-              <div className="mt-2">
-                <PlaybookOutputPicker
-                  value={null}
-                  available={availableForAdd}
-                  playbooks={playbooks}
-                  fullWidthTrigger
-                  triggerLabel={busy ? "Adding…" : "Add input"}
-                  triggerLeadingIcon={
-                    <Plus className="h-3.5 w-3.5" aria-hidden />
-                  }
-                  hideTriggerChevron
-                  testId="playbook-inputs-add"
-                  onChange={handlePick}
-                />
-              </div>
-            </>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={sortableIds}
+                strategy={verticalListSortingStrategy}
+              >
+                <ul className="mt-2 flex flex-col gap-2">
+                  {rows.map((row) => (
+                    <SortableInputRow
+                      key={row.id}
+                      row={row}
+                      upstreamPlaybook={playbookById.get(row.upstreamPlaybookId)}
+                      onDelete={() => openDeleteConfirm(row)}
+                    />
+                  ))}
+                  <li>
+                    <PlaybookOutputPicker
+                      value={null}
+                      available={availableForAdd}
+                      playbooks={playbooks}
+                      fullWidthTrigger
+                      triggerLabel={busy ? "Adding…" : "Add input"}
+                      triggerLeadingIcon={
+                        <Plus className="h-3.5 w-3.5" aria-hidden />
+                      }
+                      hideTriggerChevron
+                      testId="playbook-inputs-add"
+                      onChange={handlePick}
+                    />
+                  </li>
+                </ul>
+              </SortableContext>
+            </DndContext>
           )
         ) : null}
       </section>

--- a/products/dashboard/components/framework/playbook-metadata-dock.tsx
+++ b/products/dashboard/components/framework/playbook-metadata-dock.tsx
@@ -575,9 +575,9 @@ function PlaybookOutputsSection({
               {Array.from({ length: 3 }, (_, i) => (
                 <li
                   key={i}
-                  className="animate-pulse rounded-lg border border-border bg-bg-3 p-2.5"
+                  className="flex min-h-[56px] animate-pulse items-center rounded-lg border border-border bg-bg-3 p-2.5"
                 >
-                  <div className="flex items-center gap-2">
+                  <div className="flex w-full items-center gap-2">
                     <div className="h-6 w-6 shrink-0 rounded-full bg-bg-4" />
                     <div className="min-w-0 flex-1 space-y-1.5">
                       <div className="h-2.5 w-2/3 rounded bg-bg-4" />
@@ -630,7 +630,7 @@ function PlaybookOutputsSection({
                 type="button"
                 onClick={handleAdd}
                 data-testid="playbook-outputs-add"
-                className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-border bg-transparent px-3 py-2.5 text-[12px] font-medium text-t3 transition hover:border-border-hi hover:bg-bg-2 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                className="mt-2 flex min-h-[56px] w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-border bg-transparent px-3 py-2.5 text-[12px] font-medium text-t3 transition hover:border-border-hi hover:bg-bg-2 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
               >
                 <Plus className="h-3.5 w-3.5" aria-hidden />
                 Add output
@@ -862,9 +862,9 @@ function PlaybookInputsSection({
               {Array.from({ length: 2 }, (_, i) => (
                 <li
                   key={i}
-                  className="animate-pulse rounded-lg border border-border bg-bg-3 p-2.5"
+                  className="flex min-h-[56px] animate-pulse items-center rounded-lg border border-border bg-bg-3 p-2.5"
                 >
-                  <div className="flex items-center gap-2">
+                  <div className="flex w-full items-center gap-2">
                     <div className="h-6 w-6 shrink-0 rounded-full bg-bg-4" />
                     <div className="min-w-0 flex-1 space-y-1.5">
                       <div className="h-2.5 w-2/3 rounded bg-bg-4" />
@@ -990,11 +990,11 @@ function SortableInputRow({
       data-testid={`playbook-input-row-${row.id}`}
       style={style}
       className={cn(
-        "rounded-lg border border-border bg-bg-3 px-2.5 py-2 transition-colors hover:border-border-hi",
+        "flex min-h-[56px] items-center rounded-lg border border-border bg-bg-3 px-2.5 py-2 transition-colors hover:border-border-hi",
         isDragging && "shadow-lg",
       )}
     >
-      <div className="flex items-center gap-2">
+      <div className="flex w-full items-center gap-2">
         <button
           type="button"
           ref={setActivatorNodeRef as unknown as React.Ref<HTMLButtonElement>}
@@ -1089,12 +1089,12 @@ function SortableOutputRow({
       data-testid={`playbook-output-row-${row.id}`}
       style={style}
       className={cn(
-        "group/output rounded-lg border border-border bg-bg-3 px-2.5 py-2 transition-colors hover:border-border-hi",
+        "group/output flex min-h-[56px] items-center rounded-lg border border-border bg-bg-3 px-2.5 py-2 transition-colors hover:border-border-hi",
         dirty && "border-border-hi bg-bg-4",
         isDragging && "shadow-lg",
       )}
     >
-      <div className="flex items-center gap-2">
+      <div className="flex w-full items-center gap-2">
         <button
           type="button"
           ref={setActivatorNodeRef as unknown as React.Ref<HTMLButtonElement>}

--- a/products/dashboard/components/ui/confirm-modal.tsx
+++ b/products/dashboard/components/ui/confirm-modal.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 import { useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Loader2 } from "lucide-react";
 
 interface ConfirmModalProps {
@@ -28,6 +29,11 @@ export function ConfirmModal({
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const [inFlight, setInFlight] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     previousFocusRef.current =
@@ -47,7 +53,12 @@ export function ConfirmModal({
     };
   }, [onCancel]);
 
-  return (
+  // Portal to document.body so `position: fixed` resolves against the
+  // viewport and isn't clipped by a `transform`/`filter` ancestor (e.g.
+  // the metadata dock's translate-x slide-in container).
+  if (!mounted) return null;
+
+  return createPortal(
     <div
       className="fixed inset-0 z-[70] flex items-center justify-center bg-(--overlay) p-4 backdrop-blur-[3px]"
       role="presentation"
@@ -97,6 +108,7 @@ export function ConfirmModal({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/products/dashboard/components/workflows/add-playbook-drawer.tsx
+++ b/products/dashboard/components/workflows/add-playbook-drawer.tsx
@@ -132,6 +132,7 @@ export function AddPlaybookDrawer({
     initial?.outputs ? initial.outputs.map((o) => ({ ...o })) : [],
   );
   const [outputsLoading, setOutputsLoading] = useState(false);
+  const [inputsLoading, setInputsLoading] = useState(false);
   const [query, setQuery] = useState("");
   /** User override for the Inputs collapse header. Defaults to `null`
    *  (expanded). Switching to "collapsed" lets the user hide the editor. */
@@ -222,10 +223,16 @@ export function AddPlaybookDrawer({
     if (mode !== "create") return;
     if (!selectedId || !loadPlaybookInputs) {
       setInputs([]);
+      setInputsLoading(false);
       return;
     }
     let cancelled = false;
+    // Clear immediately and flag loading so the section can show a "Loading
+    // inputs…" placeholder. Without this the section flips from N old rows
+    // straight to M new rows once the fetch resolves and the picker below
+    // jumps with the row count change.
     setInputs([]);
+    setInputsLoading(true);
     loadPlaybookInputs(selectedId)
       .then((defs) => {
         if (cancelled) return;
@@ -249,6 +256,10 @@ export function AddPlaybookDrawer({
       .catch(() => {
         if (cancelled) return;
         setInputs([]);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setInputsLoading(false);
       });
     return () => {
       cancelled = true;
@@ -623,7 +634,7 @@ export function AddPlaybookDrawer({
                         return (
                           <li
                             key={input.id}
-                            className="flex items-center gap-2.5 rounded-lg border border-border bg-bg-3 px-2.5 py-2"
+                            className="flex min-h-[56px] items-center gap-2.5 rounded-lg border border-border bg-bg-3 px-2.5 py-2"
                             data-testid={`input-row-${index}`}
                           >
                             {wiredPlaybook ? (
@@ -659,6 +670,14 @@ export function AddPlaybookDrawer({
                         );
                       })}
                       <li>
+                        {inputsLoading ? (
+                          <div
+                            className="flex min-h-[56px] w-full items-center justify-center rounded-md border border-dashed border-border bg-transparent px-4 py-3 text-[12px] font-medium text-t3"
+                            data-testid="add-playbook-drawer-inputs-loading"
+                          >
+                            Loading inputs…
+                          </div>
+                        ) : (
                         <PlaybookOutputPicker
                           value={null}
                           available={availableForDraft}
@@ -688,6 +707,7 @@ export function AddPlaybookDrawer({
                             ]);
                           }}
                         />
+                        )}
                       </li>
                     </ul>
                   ) : null}
@@ -849,7 +869,7 @@ function OutputsEditorSection({
             <ul className="space-y-2">
               {outputs.length === 0 ? (
                 <li
-                  className="rounded-lg border border-dashed border-border bg-bg-3 px-3 py-4 text-center text-[12px] text-t3"
+                  className="flex min-h-[56px] items-center justify-center rounded-lg border border-dashed border-border bg-bg-3 px-3 py-2 text-center text-[12px] text-t3"
                   data-testid="add-playbook-drawer-outputs-empty"
                 >
                   {emptyMessage}
@@ -903,7 +923,7 @@ function SortableOutputRow({ output, index, onRemove }: SortableOutputRowProps) 
       data-testid={`output-row-${index}`}
       style={style}
       className={cn(
-        "flex items-center gap-2 rounded-lg border border-border bg-bg-3 px-2 py-2",
+        "flex min-h-[56px] items-center gap-2 rounded-lg border border-border bg-bg-3 px-2 py-2",
         isDragging && "shadow-lg",
       )}
     >

--- a/products/dashboard/components/workflows/playbook-output-picker.tsx
+++ b/products/dashboard/components/workflows/playbook-output-picker.tsx
@@ -303,7 +303,7 @@ export function PlaybookOutputPicker({
         className={cn(
           "items-center rounded-md border border-dashed border-border bg-transparent text-t3 transition hover:border-border-hi hover:bg-bg-2 hover:text-t1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
           fullWidthTrigger
-            ? "flex w-full justify-center gap-1.5 px-4 py-3 text-[12px] font-medium"
+            ? "flex min-h-[56px] w-full items-center justify-center gap-1.5 px-4 py-3 text-[12px] font-medium"
             : "flex min-w-0 gap-1.5 px-2.5 py-1 text-[12px]",
           open && "border-accent text-t1",
         )}
@@ -331,7 +331,11 @@ type FilteredRow = {
   kind: string | null;
 };
 
-const PORTAL_DROPDOWN_WIDTH = 320;
+/** Floor for the portalled dropdown's width. The dropdown matches the
+ *  trigger's measured width so it sits flush under the "+ Add input"
+ *  button; this minimum kicks in only when the trigger is narrower than
+ *  the picker UI itself can reasonably render. */
+const PORTAL_DROPDOWN_MIN_WIDTH = 280;
 
 interface PortalDropdownProps {
   ref: React.RefObject<HTMLDivElement | null>;
@@ -407,19 +411,26 @@ function PortalDropdown({
   const positionStyle: React.CSSProperties = openUp
     ? { bottom: Math.max(8, viewportHeight - anchorRect.triggerTop + 8) }
     : { top: anchorRect.triggerBottom + 8 };
+  // Match the trigger's width so the dropdown reads as an extension of the
+  // "+ Add input" button. Floor protects very narrow triggers; cap stays
+  // inside the viewport so the dropdown can't ever overflow horizontally.
+  const dropdownWidth = Math.min(
+    Math.max(anchorRect.width, PORTAL_DROPDOWN_MIN_WIDTH),
+    viewportWidth - 16,
+  );
   let left =
     align === "end"
-      ? anchorRect.right - PORTAL_DROPDOWN_WIDTH
+      ? anchorRect.right - dropdownWidth
       : anchorRect.left;
   // Clamp horizontally so the dropdown stays inside the viewport.
-  left = Math.max(8, Math.min(left, viewportWidth - PORTAL_DROPDOWN_WIDTH - 8));
+  left = Math.max(8, Math.min(left, viewportWidth - dropdownWidth - 8));
 
   return (
     <div
       ref={ref}
       role="dialog"
       aria-label="Playbook outputs"
-      style={{ ...positionStyle, left, width: PORTAL_DROPDOWN_WIDTH }}
+      style={{ ...positionStyle, left, width: dropdownWidth }}
       data-open-direction={openUp ? "up" : "down"}
       className="fixed z-[80] overflow-hidden rounded-[12px] border border-border-hi bg-bg-2 shadow-[var(--shadow-canvas)]"
       data-testid={`${testId}-dropdown`}
@@ -447,7 +458,7 @@ function PortalDropdown({
               data-testid={`${testId}-search`}
             />
           </div>
-          <div className="max-h-[280px] overflow-y-auto p-1.5">
+          <div className="max-h-[280px] overflow-y-auto px-1.5 pb-1.5">
             {grouped.length === 0 ? (
               <div className="px-2.5 py-3 text-[11.5px] text-t3">No matches.</div>
             ) : (


### PR DESCRIPTION
## Summary
- Playbooks page now supports **Group by None / Skill / Workflow** with collapsible sections; default is Skill, choice persists to localStorage, sections render as discrete cards instead of floating headers
- Add Playbook drawer and Metadata dock get matching loading states: inputs section now has a loading placeholder that swaps in for the "+ Add input" button, and every row/skeleton/Add-button shares min-h-[56px] so transitions don't jump
- Playbook-output picker dropdown matches its trigger width and its sticky group headers sit flush against the scroll container; ConfirmModal portals to document.body so the dock's translate-x ancestor stops clipping it inside the panel
- Metadata dock Add buttons render inside the same \`<ul>\` as the cards so the list's gap-2 spacing applies uniformly

## Test plan
- [ ] Visit /framework/playbooks fresh in an incognito window → defaults to Group by Skill, every allowed skill becomes a section
- [ ] Switch Group by → Workflow and reload → choice persists; switch to None → flat grid; sections expand/collapse via chevron
- [ ] Open a playbook edit, switch between playbooks in the sidebar → input and output skeleton/loading states both flash without layout jump; delete-input modal centers over the whole viewport (not clipped to the dock)
- [ ] In a workflow template editor, click + Add playbook → click between playbooks in the picker → inputs and outputs both show "Loading…" placeholders that swap into cards without the picker/footer shifting
- [ ] In the inputs picker, scroll the long playbook · output list → sticky group headers fully occlude rows scrolling past

🤖 Generated with [Claude Code](https://claude.com/claude-code)