### PR TITLE
feat(dashboard): template ↔ instance sync + template-level overview

### DIFF
--- a/interfaces/interfaces.yaml
+++ b/interfaces/interfaces.yaml
@@ -145,6 +145,54 @@ interfaces:
         outputs:
           item:
             type: object
+      get_instance_template_diff:
+        description: >
+          Compute the structural diff between an instance and its current
+          template. Drives the "Sync with template" drawer on a workflow
+          instance: which stages/skills/tasks were added, removed, or
+          changed since the instance was materialized. Pure read; the
+          actual diff function is `diffInstanceFromTemplate` in
+          `lib/workflows/template-sync.ts`.
+        inputs:
+          instance_id:
+            type: string
+            format: uuid
+        outputs:
+          diff:
+            type: object
+      apply_template_sync:
+        description: >
+          Apply the user-selected subset of an instance/template diff back
+          onto the instance. Server re-derives the diff and re-checks the
+          pristine rule (status='not_started' AND no produced outputs) on
+          every per-task field update, silently dropping selections that
+          are no longer applicable. Stages/skills are additive only — the
+          drawer never removes anything that exists on the instance.
+          Emits a `template_sync_applied` workflow event for the audit
+          trail and bumps `workflow_instances.template_synced_at`.
+        inputs:
+          instance_id:
+            type: string
+            format: uuid
+          selection:
+            type: object
+        outputs:
+          instance:
+            type: object
+      get_template_matrix:
+        description: >
+          Roll up instance task state grouped by the template's
+          `task_templates[]` entries (matched via
+          `workflow_tasks.template_task_id`). Drives the template-level
+          matrix overview at `/workflows/templates/[templateId]` — one
+          stacked status bar per cell across every instance of the
+          template.
+        inputs:
+          template_id:
+            type: string
+        outputs:
+          matrix:
+            type: object
 
 policies:
   human_in_the_loop:

--- a/products/dashboard/__tests__/lib/workflows/aggregate.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/aggregate.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  aggregateTasksByTemplateCell,
   computeOverviewStats,
   computeTemplateHealth,
   percentComplete,
@@ -12,6 +13,7 @@ import {
   type OverviewSnapshot,
 } from "@/lib/workflows/aggregate";
 import type {
+  TaskIOSummary,
   WorkflowEvent,
   WorkflowInstance,
   WorkflowTask,
@@ -326,5 +328,98 @@ describe("pickRecentEvents", () => {
   it("returns an empty list for non-positive limits", () => {
     expect(pickRecentEvents(snapshot, 0)).toEqual([]);
     expect(pickRecentEvents(snapshot, -3)).toEqual([]);
+  });
+});
+
+describe("aggregateTasksByTemplateCell", () => {
+  it("rolls up status across instances per template cell, keyed by template_task_id", () => {
+    const tpl: WorkflowTemplate = {
+      ...template("delivery", "Client Delivery", "#6366f1"),
+      stages: [
+        { id: "stage-a", label: "Discover" },
+        { id: "stage-b", label: "Deliver" },
+      ],
+      skills: [
+        { id: "skill-x", label: "Sales", owners: [] },
+      ],
+      taskTemplates: [
+        {
+          id: "tt-1",
+          skillId: "skill-x",
+          stageId: "stage-a",
+          playbookId: "pb-discovery",
+          notes: "",
+          checkpoint: false,
+          inputs: [],
+          owners: [],
+        },
+        {
+          id: "tt-2",
+          skillId: "skill-x",
+          stageId: "stage-b",
+          playbookId: "pb-deliver",
+          notes: "",
+          checkpoint: false,
+          inputs: [],
+          owners: [],
+        },
+      ],
+    };
+    const inst1: WorkflowInstance = { ...instance("acme", "delivery"), createdAt: "2026-05-01T00:00:00Z" };
+    const inst2: WorkflowInstance = { ...instance("globex", "delivery"), createdAt: "2026-05-02T00:00:00Z" };
+    const inst3: WorkflowInstance = { ...instance("initech", "delivery"), createdAt: "2026-05-03T00:00:00Z" };
+
+    const tasks: WorkflowTask[] = [
+      // tt-1: 2 not_started, 1 in_progress
+      task("k-a1", "acme", "not_started", { templateTaskId: "tt-1" }),
+      task("k-g1", "globex", "in_progress", { templateTaskId: "tt-1" }),
+      task("k-i1", "initech", "not_started", { templateTaskId: "tt-1" }),
+      // tt-2: 1 complete (acme), nothing else
+      task("k-a2", "acme", "complete", { templateTaskId: "tt-2" }),
+      // ad-hoc task — must not skew the rollup
+      task("k-adhoc", "globex", "in_progress", { templateTaskId: undefined }),
+    ];
+    const io: TaskIOSummary[] = [
+      { taskId: "k-i1", outputs: [], hasUnmetLinkedInput: true },
+    ];
+
+    const cells = aggregateTasksByTemplateCell(tpl, [inst1, inst2, inst3], tasks, io);
+
+    expect(cells).toHaveLength(2);
+    const tt1 = cells.find((c) => c.templateTaskId === "tt-1")!;
+    expect(tt1.statusCounts.not_started).toBe(2);
+    expect(tt1.statusCounts.in_progress).toBe(1);
+    expect(tt1.statusCounts.complete).toBe(0);
+    expect(tt1.instances.map((i) => i.instanceId)).toEqual(["acme", "globex", "initech"]);
+    const initech = tt1.instances.find((i) => i.instanceId === "initech")!;
+    expect(initech.hasUnmetLinkedInput).toBe(true);
+
+    const tt2 = cells.find((c) => c.templateTaskId === "tt-2")!;
+    expect(tt2.statusCounts.complete).toBe(1);
+    expect(tt2.instances.map((i) => i.instanceId)).toEqual(["acme"]);
+  });
+
+  it("returns zeroed cells when the template has no instances yet", () => {
+    const tpl: WorkflowTemplate = {
+      ...template("delivery", "Client Delivery", "#6366f1"),
+      stages: [{ id: "stage-a", label: "Discover" }],
+      skills: [{ id: "skill-x", label: "Sales", owners: [] }],
+      taskTemplates: [
+        {
+          id: "tt-only",
+          skillId: "skill-x",
+          stageId: "stage-a",
+          playbookId: "pb-x",
+          notes: "",
+          checkpoint: false,
+          inputs: [],
+          owners: [],
+        },
+      ],
+    };
+    const cells = aggregateTasksByTemplateCell(tpl, [], [], []);
+    expect(cells).toHaveLength(1);
+    expect(cells[0]!.statusCounts.not_started).toBe(0);
+    expect(cells[0]!.instances).toEqual([]);
   });
 });

--- a/products/dashboard/__tests__/lib/workflows/repository.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/repository.test.ts
@@ -369,6 +369,27 @@ describe("workflow repository", () => {
       );
     });
 
+    it("populates template_task_id lineage on every materialized task", async () => {
+      const repo = createWorkflowRepository(makeFakeClient(store));
+      const instance = await repo.createInstance("client-delivery", "Acme Corp");
+
+      // Every task should carry the lineage back to the template task it
+      // was cloned from — drives the diff drawer + template-level rollup.
+      for (const task of instance.tasks) {
+        expect(typeof task.templateTaskId).toBe("string");
+        expect((task.templateTaskId ?? "").length).toBeGreaterThan(0);
+      }
+      // The fake store's template task_templates omit explicit ids, so
+      // mapTemplate falls back to the deterministic synthetic id —
+      // `${templateId}::${skillId}::${stageId}::${index}`. Same shape is
+      // round-tripped through to the instance task.
+      const ids = instance.tasks.map((t) => t.templateTaskId).sort();
+      expect(ids).toEqual([
+        "client-delivery::pm::validation::1",
+        "client-delivery::sales-ops::pre-sales::0",
+      ]);
+    });
+
     it("snapshots stages and skills so later template edits do not mutate the instance", async () => {
       const repo = createWorkflowRepository(makeFakeClient(store));
 

--- a/products/dashboard/__tests__/lib/workflows/template-sync.test.ts
+++ b/products/dashboard/__tests__/lib/workflows/template-sync.test.ts
@@ -1,0 +1,289 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import {
+  diffInstanceFromTemplate,
+  filterApplicableTaskUpdates,
+} from "@/lib/workflows/template-sync";
+import type {
+  TaskIOSummary,
+  TemplateSyncSelection,
+  WorkflowInput,
+  WorkflowInstance,
+  WorkflowTask,
+  WorkflowTaskTemplate,
+  WorkflowTemplate,
+} from "@/lib/workflows/types";
+
+/**
+ * Unit tests for `diffInstanceFromTemplate` (pure, no Supabase). Covers the
+ * three classes of change the sync drawer surfaces — added, removed,
+ * changed — plus the pristine/non-pristine gate that decides whether a
+ * task field change is syncable or merely informational.
+ */
+
+function template(overrides: Partial<WorkflowTemplate> = {}): WorkflowTemplate {
+  return {
+    id: "tpl-1",
+    label: "Client Delivery",
+    color: "#6366f1",
+    multiInstance: true,
+    stages: [
+      { id: "stage-a", label: "Discover" },
+      { id: "stage-b", label: "Deliver" },
+    ],
+    skills: [
+      { id: "skill-x", label: "Sales", owners: [] },
+      { id: "skill-y", label: "Project", owners: [] },
+    ],
+    taskTemplates: [
+      taskTemplate("tt-1", "skill-x", "stage-a", { playbookId: "pb-discovery" }),
+      taskTemplate("tt-2", "skill-y", "stage-b", { playbookId: "pb-deliver" }),
+    ],
+    createdAt: "2026-05-17T09:00:00Z",
+    updatedAt: "2026-05-17T09:00:00Z",
+    ...overrides,
+  };
+}
+
+function taskTemplate(
+  id: string,
+  skillId: string,
+  stageId: string,
+  overrides: Partial<WorkflowTaskTemplate> = {},
+): WorkflowTaskTemplate {
+  return {
+    id,
+    skillId,
+    stageId,
+    playbookId: null,
+    notes: "",
+    checkpoint: false,
+    inputs: [],
+    owners: [],
+    ...overrides,
+  };
+}
+
+function instance(overrides: Partial<WorkflowInstance> = {}): WorkflowInstance {
+  return {
+    id: "inst-1",
+    templateId: "tpl-1",
+    label: "Acme",
+    status: "active",
+    stages: [
+      { id: "stage-a", label: "Discover" },
+      { id: "stage-b", label: "Deliver" },
+    ],
+    skills: [
+      { id: "skill-x", label: "Sales", owners: [] },
+      { id: "skill-y", label: "Project", owners: [] },
+    ],
+    templateSyncedAt: "2026-05-17T09:00:00Z",
+    createdAt: "2026-05-17T09:00:00Z",
+    updatedAt: "2026-05-17T09:00:00Z",
+    ...overrides,
+  };
+}
+
+function task(
+  id: string,
+  templateTaskId: string | null,
+  overrides: Partial<WorkflowTask> = {},
+): WorkflowTask {
+  return {
+    id,
+    instanceId: "inst-1",
+    skillId: "skill-x",
+    stageId: "stage-a",
+    notes: "",
+    status: "not_started",
+    substatus: "",
+    checkpoint: false,
+    inputs: [],
+    outputs: [],
+    playbookId: null,
+    owners: [],
+    templateTaskId,
+    pausedReason: null,
+    pausedBy: null,
+    pausedAt: null,
+    createdAt: "2026-05-17T09:00:00Z",
+    updatedAt: "2026-05-17T09:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("diffInstanceFromTemplate — stages", () => {
+  it("reports stages added to the template but missing on the instance", () => {
+    const tpl = template({
+      stages: [
+        { id: "stage-a", label: "Discover" },
+        { id: "stage-b", label: "Deliver" },
+        { id: "stage-c", label: "Wrap up" },
+      ],
+    });
+    const inst = instance(); // still only stage-a + stage-b
+    const diff = diffInstanceFromTemplate(tpl, inst, []);
+    expect(diff.stages.added.map((s) => s.id)).toEqual(["stage-c"]);
+    expect(diff.stages.removedFromTemplate).toEqual([]);
+    expect(diff.stages.renamed).toEqual([]);
+  });
+
+  it("flags stages removed from the template without proposing removal", () => {
+    const tpl = template({ stages: [{ id: "stage-a", label: "Discover" }] });
+    const inst = instance();
+    const diff = diffInstanceFromTemplate(tpl, inst, []);
+    expect(diff.stages.removedFromTemplate.map((s) => s.id)).toEqual(["stage-b"]);
+    expect(diff.stages.added).toEqual([]);
+  });
+
+  it("detects label renames while preserving the id", () => {
+    const tpl = template({
+      stages: [
+        { id: "stage-a", label: "Discovery" },
+        { id: "stage-b", label: "Deliver" },
+      ],
+    });
+    const diff = diffInstanceFromTemplate(tpl, instance(), []);
+    expect(diff.stages.renamed).toEqual([
+      { id: "stage-a", from: { id: "stage-a", label: "Discover" }, to: { id: "stage-a", label: "Discovery" } },
+    ]);
+  });
+});
+
+describe("diffInstanceFromTemplate — skills", () => {
+  it("reports added/removed/renamed skills symmetrically with stages", () => {
+    const tpl = template({
+      skills: [
+        { id: "skill-x", label: "Sales (new)", owners: [] },
+        { id: "skill-z", label: "Marketing", owners: [] },
+      ],
+    });
+    const diff = diffInstanceFromTemplate(tpl, instance(), []);
+    expect(diff.skills.added.map((s) => s.id)).toEqual(["skill-z"]);
+    expect(diff.skills.removedFromTemplate.map((s) => s.id)).toEqual(["skill-y"]);
+    expect(diff.skills.renamed.map((r) => r.id)).toEqual(["skill-x"]);
+  });
+});
+
+describe("diffInstanceFromTemplate — tasks", () => {
+  it("classifies tasks by lineage: added, removed, changed", () => {
+    const tpl = template({
+      taskTemplates: [
+        // tt-1 exists on both sides
+        taskTemplate("tt-1", "skill-x", "stage-a", { playbookId: "pb-discovery", notes: "Updated notes" }),
+        // tt-3 is new on the template
+        taskTemplate("tt-3", "skill-y", "stage-a", { playbookId: "pb-followup" }),
+      ],
+    });
+    const tasks: WorkflowTask[] = [
+      task("task-1", "tt-1", { playbookId: "pb-discovery", notes: "Old notes" }),
+      // tt-2 was on the template originally but is now removed
+      task("task-2", "tt-2", { skillId: "skill-y", stageId: "stage-b", playbookId: "pb-deliver" }),
+      // ad-hoc task created on the instance — never had a template counterpart,
+      // must not appear in any diff bucket
+      task("task-adhoc", null, { skillId: "skill-x", stageId: "stage-b" }),
+    ];
+    const diff = diffInstanceFromTemplate(tpl, instance(), tasks);
+    expect(diff.tasks.added.map((t) => t.id)).toEqual(["tt-3"]);
+    expect(diff.tasks.removedFromTemplate.map((t) => t.id)).toEqual(["task-2"]);
+    expect(diff.tasks.changed.map((c) => c.templateTaskId)).toEqual(["tt-1"]);
+    expect(diff.tasks.changed[0]!.fields.notes).toEqual({
+      from: "Old notes",
+      to: "Updated notes",
+    });
+  });
+
+  it("marks a changed task as informational once it has moved off not_started", () => {
+    const tpl = template({
+      taskTemplates: [taskTemplate("tt-1", "skill-x", "stage-a", { notes: "New notes" })],
+    });
+    const inst = instance();
+    const startedTask = task("task-1", "tt-1", {
+      notes: "Old",
+      status: "in_progress",
+    });
+    const diff = diffInstanceFromTemplate(tpl, inst, [startedTask]);
+    expect(diff.tasks.changed).toHaveLength(1);
+    expect(diff.tasks.changed[0]!.syncable).toBe("informational_only");
+    expect(diff.tasks.changed[0]!.syncBlockedReason).toBe("task_not_pristine");
+  });
+
+  it("marks a pristine not_started task with produced outputs as informational", () => {
+    const tpl = template({
+      taskTemplates: [taskTemplate("tt-1", "skill-x", "stage-a", { notes: "New" })],
+    });
+    const pristineTask = task("task-1", "tt-1", { notes: "Old" });
+    const io: TaskIOSummary[] = [
+      {
+        taskId: "task-1",
+        outputs: [
+          { id: "po-1", position: 0, status: "produced", name: "Brief" },
+        ],
+        hasUnmetLinkedInput: false,
+      },
+    ];
+    const diff = diffInstanceFromTemplate(tpl, instance(), [pristineTask], io);
+    expect(diff.tasks.changed[0]!.syncable).toBe("informational_only");
+  });
+
+  it("captures input add/remove/rewire deltas inside the changed entry", () => {
+    const keepInput: WorkflowInput = {
+      id: "in-1",
+      upstreamOutputId: "po-brief",
+    };
+    const addInput: WorkflowInput = {
+      id: "in-2",
+      upstreamOutputId: "po-plan",
+      upstreamTaskRef: "tt-other",
+    };
+    const dropInput: WorkflowInput = {
+      id: "in-old",
+      upstreamOutputId: "po-stale",
+    };
+    const tpl = template({
+      taskTemplates: [
+        taskTemplate("tt-1", "skill-x", "stage-a", {
+          inputs: [keepInput, addInput],
+        }),
+      ],
+    });
+    const t1 = task("task-1", "tt-1", {
+      inputs: [keepInput, dropInput],
+    });
+    const diff = diffInstanceFromTemplate(tpl, instance(), [t1]);
+    const inputs = diff.tasks.changed[0]!.fields.inputs!;
+    expect(inputs.added.map((i) => i.id)).toEqual(["in-2"]);
+    expect(inputs.removed.map((i) => i.id)).toEqual(["in-old"]);
+    expect(inputs.changed).toEqual([]);
+  });
+});
+
+describe("filterApplicableTaskUpdates", () => {
+  it("drops selection ids that are not syncable in the diff", () => {
+    const tpl = template({
+      taskTemplates: [
+        taskTemplate("tt-1", "skill-x", "stage-a", { notes: "n1" }),
+        taskTemplate("tt-2", "skill-y", "stage-b", { notes: "n2" }),
+      ],
+    });
+    const inst = instance();
+    const tasks: WorkflowTask[] = [
+      task("task-1", "tt-1", { notes: "old" }),
+      task("task-2", "tt-2", { notes: "old", status: "in_progress" }),
+    ];
+    const diff = diffInstanceFromTemplate(tpl, inst, tasks);
+    const selection: TemplateSyncSelection = {
+      stageIdsToAdd: [],
+      skillIdsToAdd: [],
+      stageIdsToRename: [],
+      skillIdsToRename: [],
+      taskTemplateIdsToAdd: [],
+      instanceTaskIdsToUpdate: ["task-1", "task-2"],
+    };
+    const applicable = filterApplicableTaskUpdates(selection, diff);
+    expect(applicable).toEqual(["task-1"]);
+  });
+});

--- a/products/dashboard/app/(dashboard)/workflows/actions.ts
+++ b/products/dashboard/app/(dashboard)/workflows/actions.ts
@@ -11,13 +11,16 @@ import {
 } from "@/lib/workflows/aggregate";
 import type {
   DrawerData,
+  InstanceTemplateDiff,
   OutputArtifact,
   PlaybookOutput,
   TaskInputState,
   TaskOutput,
   TemplateOutputGroup,
+  TemplateSyncSelection,
   WorkflowInput,
   WorkflowInstance,
+  WorkflowInstanceDetail,
   WorkflowTask,
   WorkflowTaskCreateInput,
   WorkflowTaskStatus,
@@ -1279,4 +1282,61 @@ export async function refinePlaybookAction(
 
   revalidatePath("/", "layout");
   return { task };
+}
+
+/**
+ * Read the diff between an instance and its template. Called by the sync
+ * drawer when it opens. Pure read — no revalidate.
+ */
+export async function getInstanceTemplateDiffAction(
+  instanceId: string,
+): Promise<{ diff: InstanceTemplateDiff }> {
+  const trimmedId = normalizeTaskField(instanceId, "instanceId", 80);
+  if (!trimmedId) {
+    throw new Error("getInstanceTemplateDiffAction: instanceId is required");
+  }
+  const repo = await getServerWorkflowRepository();
+  const diff = await repo.getInstanceTemplateDiff(trimmedId);
+  return { diff };
+}
+
+/**
+ * Apply the user-selected subset of a template→instance diff. Server
+ * re-derives the diff and re-checks pristine on every task update; non-
+ * applicable selection entries are silently dropped.
+ */
+export async function applyTemplateSyncAction(
+  instanceId: string,
+  selection: TemplateSyncSelection,
+): Promise<{ instance: WorkflowInstanceDetail }> {
+  const trimmedId = normalizeTaskField(instanceId, "instanceId", 80);
+  if (!trimmedId) {
+    throw new Error("applyTemplateSyncAction: instanceId is required");
+  }
+  if (!selection || typeof selection !== "object") {
+    throw new Error("applyTemplateSyncAction: selection is required");
+  }
+  // Defensive — coerce missing arrays to empty so partial selections don't
+  // crash applyTemplateSync downstream.
+  const safeSelection: TemplateSyncSelection = {
+    stageIdsToAdd: Array.isArray(selection.stageIdsToAdd) ? selection.stageIdsToAdd : [],
+    skillIdsToAdd: Array.isArray(selection.skillIdsToAdd) ? selection.skillIdsToAdd : [],
+    stageIdsToRename: Array.isArray(selection.stageIdsToRename) ? selection.stageIdsToRename : [],
+    skillIdsToRename: Array.isArray(selection.skillIdsToRename) ? selection.skillIdsToRename : [],
+    taskTemplateIdsToAdd: Array.isArray(selection.taskTemplateIdsToAdd)
+      ? selection.taskTemplateIdsToAdd
+      : [],
+    instanceTaskIdsToUpdate: Array.isArray(selection.instanceTaskIdsToUpdate)
+      ? selection.instanceTaskIdsToUpdate
+      : [],
+  };
+
+  const repo = await getServerWorkflowRepository();
+  const instance = await repo.applyTemplateSync(trimmedId, safeSelection);
+  revalidatePath("/", "layout");
+  revalidatePath(`/workflows/${trimmedId}`);
+  if (instance.templateId) {
+    revalidatePath(`/workflows/templates/${instance.templateId}`);
+  }
+  return { instance };
 }

--- a/products/dashboard/app/(dashboard)/workflows/templates/[templateId]/page.tsx
+++ b/products/dashboard/app/(dashboard)/workflows/templates/[templateId]/page.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { PencilLine } from "lucide-react";
+
+import { ShellEvents } from "@/components/shell-events";
+import { TemplateOverviewMatrix } from "@/components/workflows/template-overview-matrix";
+import { getServerWorkflowRepository } from "@/lib/workflows/repository.server";
+
+/**
+ * Template-level overview route — stacked status across every instance of
+ * the template, grouped by template task (skill × stage cell). Pairs with
+ * `/workflows/templates/[templateId]/edit` (template editor); this page is
+ * read-only and answers "where is each playbook of the workflow currently
+ * stuck across our live work?".
+ */
+
+interface Params {
+  templateId: string;
+}
+
+export default async function WorkflowTemplateOverviewPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { templateId } = await params;
+  const repo = await getServerWorkflowRepository();
+  const [matrix, playbooks] = await Promise.all([
+    repo.getTemplateMatrix(templateId),
+    repo.getFrameworkItems("playbook"),
+  ]);
+
+  if (!matrix) {
+    notFound();
+  }
+
+  const playbookNameById = new Map(playbooks.map((p) => [p.id, p.name]));
+
+  return (
+    <>
+      <ShellEvents route="/workflows/templates/[templateId]" />
+      <div className="flex h-full flex-col overflow-hidden">
+        <header className="flex flex-shrink-0 items-start justify-between gap-3 border-b border-border bg-bg px-6 py-4">
+          <div className="min-w-0">
+            <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+              Workflow template
+            </p>
+            <h1 className="mt-1 text-[20px] font-bold tracking-tight text-t1">
+              {matrix.template.label}
+            </h1>
+            <p className="mt-1 text-[13px] text-t2">
+              {matrix.cells.length}{" "}
+              {matrix.cells.length === 1 ? "playbook" : "playbooks"} ·{" "}
+              {matrix.template.skills.length}{" "}
+              {matrix.template.skills.length === 1 ? "skill" : "skills"} ·{" "}
+              {matrix.template.stages.length}{" "}
+              {matrix.template.stages.length === 1 ? "stage" : "stages"} ·{" "}
+              {matrix.instances.length}{" "}
+              {matrix.instances.length === 1 ? "instance" : "instances"}
+            </p>
+          </div>
+          <Link
+            href={`/workflows/templates/${matrix.template.id}/edit`}
+            className="flex items-center gap-1.5 rounded-md border border-border bg-bg-2 px-2 py-1 text-[12px] text-t1 hover:bg-bg-3"
+          >
+            <PencilLine className="h-3.5 w-3.5" /> Edit template
+          </Link>
+        </header>
+        <div className="flex-1 overflow-auto px-6 py-6">
+          <TemplateOverviewMatrix
+            matrix={matrix}
+            playbookNameById={playbookNameById}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/products/dashboard/components/workflows/process-matrix.tsx
+++ b/products/dashboard/components/workflows/process-matrix.tsx
@@ -87,6 +87,7 @@ import { AddPlaybookDrawer } from "./add-playbook-drawer";
 import { HeaderActionsMenu } from "./header-actions-menu";
 import { PlaybookDrawer } from "./playbook-drawer";
 import { TaskCard } from "./task-card";
+import { TemplateSyncButton } from "./template-sync-drawer";
 import { WiringOverlay } from "./wiring-overlay";
 import { WorkflowInstanceHeader } from "./workflow-instance-header";
 
@@ -581,23 +582,26 @@ export function ProcessMatrix({
       onSave: editMode || isDirty ? saveInstanceEdits : undefined,
       onCancelEdit: editMode ? handleCancelEdit : undefined,
       actions: (
-        <HeaderActionsMenu
-          entityLabel={savedLabel}
-          entityType="instance"
-          onDelete={async () => {
-            try {
-              await deleteInstanceAction(instance.id);
-              toastSuccess("Instance deleted");
-            } catch (err) {
-              toastError(
-                err instanceof Error && err.message
-                  ? err.message
-                  : "Could not delete the instance.",
-              );
-              throw err;
-            }
-          }}
-        />
+        <div className="flex items-center gap-1.5">
+          <TemplateSyncButton instanceId={instance.id} />
+          <HeaderActionsMenu
+            entityLabel={savedLabel}
+            entityType="instance"
+            onDelete={async () => {
+              try {
+                await deleteInstanceAction(instance.id);
+                toastSuccess("Instance deleted");
+              } catch (err) {
+                toastError(
+                  err instanceof Error && err.message
+                    ? err.message
+                    : "Could not delete the instance.",
+                );
+                throw err;
+              }
+            }}
+          />
+        </div>
       ),
     });
 

--- a/products/dashboard/components/workflows/template-overview-matrix.tsx
+++ b/products/dashboard/components/workflows/template-overview-matrix.tsx
@@ -1,0 +1,207 @@
+import Link from "next/link";
+
+import {
+  TASK_STATUS_LABEL,
+  TASK_STATUS_ORDER,
+  TASK_STATUS_VAR,
+} from "@/lib/workflows/task-status";
+import type {
+  TemplateCellAggregate,
+  TemplateMatrix,
+  WorkflowTaskStatus,
+} from "@/lib/workflows/types";
+
+interface Props {
+  matrix: TemplateMatrix;
+  playbookNameById: Map<string, string>;
+}
+
+/**
+ * Read-only matrix view that mirrors the per-instance Process Matrix layout
+ * (skills as rows, stages as columns) but with each cell collapsed to a
+ * stacked status bar across every instance of the template.
+ *
+ * Server-rendered: drill-down into a specific instance is just a `<Link>`
+ * to the corresponding workflow instance page; the empty-instance case
+ * (template with zero instances) renders a friendly placeholder instead
+ * of an empty grid so the page never looks broken.
+ */
+export function TemplateOverviewMatrix({ matrix, playbookNameById }: Props) {
+  const { template, instances, cells } = matrix;
+
+  if (template.stages.length === 0 || template.skills.length === 0) {
+    return (
+      <p className="text-[13px] text-t3">
+        This template has no stages or skills yet. Edit the template to
+        define the matrix.
+      </p>
+    );
+  }
+
+  // Cells keyed by (skillId, stageId) for O(1) lookup while we iterate the
+  // template's row × column shape.
+  const cellByCoord = new Map<string, TemplateCellAggregate>();
+  for (const c of cells) {
+    cellByCoord.set(`${c.skillId}::${c.stageId}`, c);
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full border-separate border-spacing-2 text-[12px]">
+        <thead>
+          <tr>
+            <th className="sticky left-0 z-10 bg-bg text-left">
+              <span className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+                Skill ↓ / Stage →
+              </span>
+            </th>
+            {template.stages.map((stage) => (
+              <th
+                key={stage.id}
+                className="min-w-[180px] text-left align-bottom text-t1"
+              >
+                <div className="font-medium">{stage.label}</div>
+                {stage.sub ? (
+                  <div className="text-[10px] text-t3">{stage.sub}</div>
+                ) : null}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {template.skills.map((skill) => (
+            <tr key={skill.id}>
+              <th
+                scope="row"
+                className="sticky left-0 z-10 min-w-[140px] bg-bg text-left align-top font-medium text-t1"
+              >
+                {skill.label}
+              </th>
+              {template.stages.map((stage) => {
+                const cell = cellByCoord.get(`${skill.id}::${stage.id}`);
+                if (!cell) {
+                  return <td key={stage.id} className="align-top" />;
+                }
+                return (
+                  <td key={stage.id} className="align-top">
+                    <CellPanel
+                      cell={cell}
+                      playbookName={
+                        cell.playbookId
+                          ? (playbookNameById.get(cell.playbookId) ?? cell.playbookId)
+                          : "Unassigned"
+                      }
+                    />
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {instances.length === 0 ? (
+        <p className="mt-6 text-[13px] text-t3">
+          No instances of this template yet. Create one from the sidebar to
+          start populating the rollup.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+interface CellPanelProps {
+  cell: TemplateCellAggregate;
+  playbookName: string;
+}
+
+function CellPanel({ cell, playbookName }: CellPanelProps) {
+  const total = cell.instances.length;
+  const anyBlocked = cell.instances.some((i) => i.hasUnmetLinkedInput);
+  return (
+    <div className="rounded-md border border-border bg-bg-2 p-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p
+            className="truncate text-[12px] font-medium text-t1"
+            title={playbookName}
+          >
+            {playbookName}
+          </p>
+          <p className="text-[10px] text-t3">
+            {total} {total === 1 ? "instance" : "instances"}
+            {anyBlocked ? " · blockers" : ""}
+          </p>
+        </div>
+      </div>
+      <StackedStatusBar counts={cell.statusCounts} total={total} />
+      {total > 0 ? (
+        <ul className="mt-2 space-y-0.5">
+          {cell.instances.slice(0, 4).map((inst) => (
+            <li key={inst.taskId} className="truncate text-[11px]">
+              <Link
+                href={`/workflows/${inst.instanceId}`}
+                className="text-t2 hover:text-t1"
+                title={`${inst.instanceLabel} · ${TASK_STATUS_LABEL[inst.status]}`}
+              >
+                <span
+                  className="mr-1 inline-block h-2 w-2 rounded-full align-middle"
+                  style={{ background: TASK_STATUS_VAR[inst.status] }}
+                  aria-hidden
+                />
+                {inst.instanceLabel}
+                {inst.hasUnmetLinkedInput ? (
+                  <span className="ml-1 text-[color:var(--err,#dc2626)]">⚠</span>
+                ) : null}
+              </Link>
+            </li>
+          ))}
+          {total > 4 ? (
+            <li className="text-[10px] text-t3">+{total - 4} more</li>
+          ) : null}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+interface StackedStatusBarProps {
+  counts: Record<WorkflowTaskStatus, number>;
+  total: number;
+}
+
+function StackedStatusBar({ counts, total }: StackedStatusBarProps) {
+  if (total === 0) {
+    return (
+      <div
+        className="mt-2 h-2 w-full rounded-full bg-bg-3"
+        aria-hidden
+      />
+    );
+  }
+  return (
+    <div
+      className="mt-2 flex h-2 w-full overflow-hidden rounded-full bg-bg-3"
+      role="img"
+      aria-label={TASK_STATUS_ORDER.filter((s) => counts[s] > 0)
+        .map((s) => `${counts[s]} ${TASK_STATUS_LABEL[s]}`)
+        .join(", ")}
+    >
+      {TASK_STATUS_ORDER.map((status) => {
+        const count = counts[status] ?? 0;
+        if (count === 0) return null;
+        const pct = (count / total) * 100;
+        return (
+          <span
+            key={status}
+            style={{
+              width: `${pct}%`,
+              background: TASK_STATUS_VAR[status],
+            }}
+            title={`${count} ${TASK_STATUS_LABEL[status]}`}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/products/dashboard/components/workflows/template-sync-drawer.tsx
+++ b/products/dashboard/components/workflows/template-sync-drawer.tsx
@@ -1,0 +1,615 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { RefreshCw, X } from "lucide-react";
+
+import {
+  applyTemplateSyncAction,
+  getInstanceTemplateDiffAction,
+} from "@/app/(dashboard)/workflows/actions";
+import { IconButtonTooltip } from "@/components/ui/icon-button-tooltip";
+import { useToast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+import type {
+  InstanceTemplateDiff,
+  TaskFieldDiff,
+  TemplateSyncSelection,
+} from "@/lib/workflows/types";
+
+interface TemplateSyncButtonProps {
+  instanceId: string;
+}
+
+/**
+ * Header icon + drawer combo for "Sync with template". Lives next to the
+ * delete action in the workflow instance header. Pulls a fresh diff on open
+ * and lets the founder tick the changes they want applied. Removed-from-
+ * template entities are shown as informational rows with no action.
+ */
+export function TemplateSyncButton({ instanceId }: TemplateSyncButtonProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <IconButtonTooltip
+        type="button"
+        tooltip="Sync with template"
+        align="end"
+        onClick={() => setOpen(true)}
+      >
+        <RefreshCw className="h-3.5 w-3.5" strokeWidth={2.2} />
+      </IconButtonTooltip>
+      {open ? (
+        <TemplateSyncDrawer
+          instanceId={instanceId}
+          onClose={() => setOpen(false)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+interface TemplateSyncDrawerProps {
+  instanceId: string;
+  onClose: () => void;
+}
+
+function TemplateSyncDrawer({ instanceId, onClose }: TemplateSyncDrawerProps) {
+  const router = useRouter();
+  const { success: toastSuccess, error: toastError } = useToast();
+  const [diff, setDiff] = useState<InstanceTemplateDiff | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [openClass, setOpenClass] = useState(false);
+  const [selection, setSelection] = useState<TemplateSyncSelection>(() => ({
+    stageIdsToAdd: [],
+    skillIdsToAdd: [],
+    stageIdsToRename: [],
+    skillIdsToRename: [],
+    taskTemplateIdsToAdd: [],
+    instanceTaskIdsToUpdate: [],
+  }));
+  const [isPending, startTransition] = useTransition();
+
+  // Two-step open so the slide animation fires after first paint.
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setOpenClass(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { diff } = await getInstanceTemplateDiffAction(instanceId);
+        if (cancelled) return;
+        setDiff(diff);
+        // Default selection: every safe additive change pre-ticked, every
+        // syncable update pre-ticked. Removed entries have no checkbox.
+        setSelection({
+          stageIdsToAdd: diff.stages.added.map((s) => s.id),
+          skillIdsToAdd: diff.skills.added.map((s) => s.id),
+          stageIdsToRename: diff.stages.renamed.map((r) => r.id),
+          skillIdsToRename: diff.skills.renamed.map((r) => r.id),
+          taskTemplateIdsToAdd: diff.tasks.added
+            .map((t) => t.id)
+            .filter((id): id is string => typeof id === "string" && id.length > 0),
+          instanceTaskIdsToUpdate: diff.tasks.changed
+            .filter((c) => c.syncable === "yes")
+            .map((c) => c.instanceTaskId),
+        });
+      } catch (err) {
+        if (cancelled) return;
+        setLoadError(
+          err instanceof Error && err.message
+            ? err.message
+            : "Could not load template diff",
+        );
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [instanceId]);
+
+  const toggleInList = useCallback(
+    (key: keyof TemplateSyncSelection, id: string) => {
+      setSelection((current) => {
+        const list = current[key];
+        const next = list.includes(id)
+          ? list.filter((x) => x !== id)
+          : [...list, id];
+        return { ...current, [key]: next };
+      });
+    },
+    [],
+  );
+
+  const counts = useMemo(() => {
+    if (!diff) return { available: 0, blocked: 0, selected: 0 };
+    const available =
+      diff.stages.added.length +
+      diff.stages.renamed.length +
+      diff.skills.added.length +
+      diff.skills.renamed.length +
+      diff.tasks.added.length +
+      diff.tasks.changed.filter((c) => c.syncable === "yes").length;
+    const blocked = diff.tasks.changed.filter(
+      (c) => c.syncable !== "yes",
+    ).length;
+    const selected =
+      selection.stageIdsToAdd.length +
+      selection.stageIdsToRename.length +
+      selection.skillIdsToAdd.length +
+      selection.skillIdsToRename.length +
+      selection.taskTemplateIdsToAdd.length +
+      selection.instanceTaskIdsToUpdate.length;
+    return { available, blocked, selected };
+  }, [diff, selection]);
+
+  const handleApply = useCallback(() => {
+    if (!diff || counts.selected === 0) return;
+    startTransition(async () => {
+      try {
+        await applyTemplateSyncAction(instanceId, selection);
+        toastSuccess(
+          counts.selected === 1
+            ? "Applied 1 change from template"
+            : `Applied ${counts.selected} changes from template`,
+        );
+        router.refresh();
+        onClose();
+      } catch (err) {
+        toastError(
+          err instanceof Error && err.message
+            ? err.message
+            : "Could not apply template changes",
+        );
+      }
+    });
+  }, [counts.selected, diff, instanceId, onClose, router, selection, toastError, toastSuccess]);
+
+  const lastSyncedLabel = useMemo(() => {
+    if (!diff?.templateSyncedAt) return null;
+    try {
+      return new Date(diff.templateSyncedAt).toLocaleString();
+    } catch {
+      return null;
+    }
+  }, [diff]);
+
+  return (
+    <>
+      <div
+        className={cn(
+          "pb-drawer-overlay",
+          openClass && "pb-drawer-overlay--open",
+        )}
+        aria-hidden
+        onClick={onClose}
+      />
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label="Sync with template"
+        className={cn("pb-drawer", openClass && "pb-drawer--open")}
+        data-testid="template-sync-drawer"
+      >
+        <header className="flex items-start justify-between gap-3 border-b border-border bg-bg-2 px-5 py-4">
+          <div className="min-w-0">
+            <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+              Sync with template
+            </p>
+            <h2 className="mt-1 text-[16px] font-semibold text-t1">
+              {loading
+                ? "Loading diff…"
+                : counts.available === 0
+                  ? "Instance is up to date"
+                  : counts.available === 1
+                    ? "1 change available"
+                    : `${counts.available} changes available`}
+              {counts.blocked > 0 ? (
+                <span className="ml-2 text-[13px] font-normal text-t3">
+                  · {counts.blocked} blocked by in-progress work
+                </span>
+              ) : null}
+            </h2>
+            {lastSyncedLabel ? (
+              <p className="mt-1 text-[12px] text-t3">
+                Last synced {lastSyncedLabel}
+              </p>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close sync drawer"
+            className="rounded-md p-1 text-t3 hover:bg-bg-3 hover:text-t1"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 text-[13px] text-t2">
+          {loading ? (
+            <p className="text-t3">Loading…</p>
+          ) : loadError ? (
+            <p className="text-[color:var(--err,#dc2626)]">{loadError}</p>
+          ) : diff ? (
+            <DiffSections
+              diff={diff}
+              selection={selection}
+              onToggle={toggleInList}
+            />
+          ) : null}
+        </div>
+
+        <footer className="flex items-center justify-between gap-3 border-t border-border bg-bg-2 px-5 py-3">
+          <span className="text-[12px] text-t3">
+            {counts.selected} selected
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-border bg-bg px-3 py-1.5 text-[13px] font-medium text-t1 hover:bg-bg-3"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleApply}
+              disabled={isPending || counts.selected === 0}
+              className="rounded-md border border-transparent bg-t1 px-3 py-1.5 text-[13px] font-medium text-bg disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isPending
+                ? "Applying…"
+                : counts.selected === 0
+                  ? "Apply"
+                  : `Apply ${counts.selected} change${counts.selected === 1 ? "" : "s"}`}
+            </button>
+          </div>
+        </footer>
+      </aside>
+    </>
+  );
+}
+
+interface DiffSectionsProps {
+  diff: InstanceTemplateDiff;
+  selection: TemplateSyncSelection;
+  onToggle: (key: keyof TemplateSyncSelection, id: string) => void;
+}
+
+function DiffSections({ diff, selection, onToggle }: DiffSectionsProps) {
+  const empty =
+    diff.stages.added.length === 0 &&
+    diff.stages.removedFromTemplate.length === 0 &&
+    diff.stages.renamed.length === 0 &&
+    diff.skills.added.length === 0 &&
+    diff.skills.removedFromTemplate.length === 0 &&
+    diff.skills.renamed.length === 0 &&
+    diff.tasks.added.length === 0 &&
+    diff.tasks.removedFromTemplate.length === 0 &&
+    diff.tasks.changed.length === 0;
+
+  if (empty) {
+    return (
+      <p className="text-t3">
+        Nothing to sync — this instance matches the template.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <DiffGroup
+        title="Stages"
+        empty={
+          diff.stages.added.length === 0 &&
+          diff.stages.renamed.length === 0 &&
+          diff.stages.removedFromTemplate.length === 0
+        }
+      >
+        {diff.stages.added.map((s) => (
+          <CheckboxRow
+            key={`stage-add-${s.id}`}
+            id={s.id}
+            checked={selection.stageIdsToAdd.includes(s.id)}
+            onToggle={() => onToggle("stageIdsToAdd", s.id)}
+            label="Add stage"
+            value={s.label}
+            hint={s.sub ?? undefined}
+          />
+        ))}
+        {diff.stages.renamed.map((r) => (
+          <CheckboxRow
+            key={`stage-rename-${r.id}`}
+            id={r.id}
+            checked={selection.stageIdsToRename.includes(r.id)}
+            onToggle={() => onToggle("stageIdsToRename", r.id)}
+            label="Rename stage"
+            value={`${r.from.label} → ${r.to.label}`}
+          />
+        ))}
+        {diff.stages.removedFromTemplate.map((s) => (
+          <InfoRow
+            key={`stage-removed-${s.id}`}
+            label="Removed in template"
+            value={s.label}
+            note="Kept on this instance."
+          />
+        ))}
+      </DiffGroup>
+
+      <DiffGroup
+        title="Skills"
+        empty={
+          diff.skills.added.length === 0 &&
+          diff.skills.renamed.length === 0 &&
+          diff.skills.removedFromTemplate.length === 0
+        }
+      >
+        {diff.skills.added.map((s) => (
+          <CheckboxRow
+            key={`skill-add-${s.id}`}
+            id={s.id}
+            checked={selection.skillIdsToAdd.includes(s.id)}
+            onToggle={() => onToggle("skillIdsToAdd", s.id)}
+            label="Add skill"
+            value={s.label}
+          />
+        ))}
+        {diff.skills.renamed.map((r) => (
+          <CheckboxRow
+            key={`skill-rename-${r.id}`}
+            id={r.id}
+            checked={selection.skillIdsToRename.includes(r.id)}
+            onToggle={() => onToggle("skillIdsToRename", r.id)}
+            label="Rename skill"
+            value={`${r.from.label} → ${r.to.label}`}
+          />
+        ))}
+        {diff.skills.removedFromTemplate.map((s) => (
+          <InfoRow
+            key={`skill-removed-${s.id}`}
+            label="Removed in template"
+            value={s.label}
+            note="Kept on this instance."
+          />
+        ))}
+      </DiffGroup>
+
+      <DiffGroup
+        title="Tasks"
+        empty={
+          diff.tasks.added.length === 0 &&
+          diff.tasks.changed.length === 0 &&
+          diff.tasks.removedFromTemplate.length === 0
+        }
+      >
+        {diff.tasks.added.map((t) =>
+          t.id ? (
+            <CheckboxRow
+              key={`task-add-${t.id}`}
+              id={t.id}
+              checked={selection.taskTemplateIdsToAdd.includes(t.id)}
+              onToggle={() => onToggle("taskTemplateIdsToAdd", t.id as string)}
+              label="Add task"
+              value={t.playbookId ?? `${t.skillId} · ${t.stageId}`}
+              hint={`${t.skillId} · ${t.stageId}`}
+            />
+          ) : null,
+        )}
+        {diff.tasks.changed.map((c) => (
+          <TaskChangeRow
+            key={`task-changed-${c.instanceTaskId}`}
+            change={c}
+            selected={selection.instanceTaskIdsToUpdate.includes(c.instanceTaskId)}
+            onToggle={() =>
+              onToggle("instanceTaskIdsToUpdate", c.instanceTaskId)
+            }
+          />
+        ))}
+        {diff.tasks.removedFromTemplate.map((t) => (
+          <InfoRow
+            key={`task-removed-${t.id}`}
+            label="Removed in template"
+            value={t.playbookId ?? `${t.skillId} · ${t.stageId}`}
+            note={`Kept on this instance (status: ${t.status}).`}
+          />
+        ))}
+      </DiffGroup>
+    </div>
+  );
+}
+
+interface DiffGroupProps {
+  title: string;
+  empty: boolean;
+  children: React.ReactNode;
+}
+
+function DiffGroup({ title, empty, children }: DiffGroupProps) {
+  return (
+    <section>
+      <h3 className="mb-2 font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+        {title}
+      </h3>
+      {empty ? (
+        <p className="text-[12px] text-t3">No changes.</p>
+      ) : (
+        <ul className="flex flex-col gap-2">{children}</ul>
+      )}
+    </section>
+  );
+}
+
+interface CheckboxRowProps {
+  id: string;
+  checked: boolean;
+  onToggle: () => void;
+  label: string;
+  value: string;
+  hint?: string;
+}
+
+function CheckboxRow({
+  id,
+  checked,
+  onToggle,
+  label,
+  value,
+  hint,
+}: CheckboxRowProps) {
+  const inputId = `sync-${id}`;
+  return (
+    <li>
+      <label
+        htmlFor={inputId}
+        className="flex cursor-pointer items-start gap-3 rounded-md border border-border bg-bg-2 px-3 py-2 hover:border-border-hi"
+      >
+        <input
+          id={inputId}
+          type="checkbox"
+          className="mt-0.5"
+          checked={checked}
+          onChange={onToggle}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+            {label}
+          </p>
+          <p className="truncate text-[13px] text-t1">{value}</p>
+          {hint ? <p className="truncate text-[11px] text-t3">{hint}</p> : null}
+        </div>
+      </label>
+    </li>
+  );
+}
+
+interface InfoRowProps {
+  label: string;
+  value: string;
+  note?: string;
+}
+
+function InfoRow({ label, value, note }: InfoRowProps) {
+  return (
+    <li className="rounded-md border border-dashed border-border bg-bg-2 px-3 py-2 opacity-80">
+      <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+        {label}
+      </p>
+      <p className="truncate text-[13px] text-t1">{value}</p>
+      {note ? <p className="text-[11px] text-t3">{note}</p> : null}
+    </li>
+  );
+}
+
+interface TaskChangeRowProps {
+  change: TaskFieldDiff;
+  selected: boolean;
+  onToggle: () => void;
+}
+
+function TaskChangeRow({ change, selected, onToggle }: TaskChangeRowProps) {
+  const syncable = change.syncable === "yes";
+  const fieldLines = describeFieldChanges(change);
+  const inputId = `sync-task-${change.instanceTaskId}`;
+  return (
+    <li>
+      <label
+        htmlFor={inputId}
+        className={cn(
+          "flex items-start gap-3 rounded-md border bg-bg-2 px-3 py-2",
+          syncable
+            ? "cursor-pointer border-border hover:border-border-hi"
+            : "border-dashed border-border opacity-80",
+        )}
+      >
+        <input
+          id={inputId}
+          type="checkbox"
+          className="mt-0.5"
+          checked={selected}
+          onChange={onToggle}
+          disabled={!syncable}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-t3">
+            {syncable ? "Update task" : "Update task (informational)"}
+          </p>
+          <ul className="mt-1 space-y-1 text-[12px] text-t2">
+            {fieldLines.map((line, idx) => (
+              <li key={idx} className="text-t1">
+                <span className="font-mono text-[10px] uppercase text-t3">
+                  {line.field}
+                </span>{" "}
+                <span className="text-t3">{line.from}</span>{" "}
+                <span className="text-t3">→</span>{" "}
+                <span>{line.to}</span>
+              </li>
+            ))}
+          </ul>
+          {!syncable ? (
+            <p className="mt-1 text-[11px] text-t3">
+              Task already started (status: {change.instanceStatus}). Sync
+              is informational only.
+            </p>
+          ) : null}
+        </div>
+      </label>
+    </li>
+  );
+}
+
+function describeFieldChanges(
+  change: TaskFieldDiff,
+): { field: string; from: string; to: string }[] {
+  const lines: { field: string; from: string; to: string }[] = [];
+  if (change.fields.notes) {
+    lines.push({
+      field: "notes",
+      from: trimForDisplay(change.fields.notes.from),
+      to: trimForDisplay(change.fields.notes.to),
+    });
+  }
+  if (change.fields.playbookId) {
+    lines.push({
+      field: "playbook",
+      from: change.fields.playbookId.from ?? "—",
+      to: change.fields.playbookId.to ?? "—",
+    });
+  }
+  if (change.fields.checkpoint) {
+    lines.push({
+      field: "checkpoint",
+      from: change.fields.checkpoint.from ? "on" : "off",
+      to: change.fields.checkpoint.to ? "on" : "off",
+    });
+  }
+  if (change.fields.owners) {
+    lines.push({
+      field: "owners",
+      from: change.fields.owners.from.join(", ") || "—",
+      to: change.fields.owners.to.join(", ") || "—",
+    });
+  }
+  if (change.fields.inputs) {
+    const i = change.fields.inputs;
+    const parts: string[] = [];
+    if (i.added.length) parts.push(`+${i.added.length} added`);
+    if (i.removed.length) parts.push(`-${i.removed.length} removed`);
+    if (i.changed.length) parts.push(`~${i.changed.length} changed`);
+    lines.push({ field: "inputs", from: "current", to: parts.join(", ") || "rewired" });
+  }
+  return lines;
+}
+
+function trimForDisplay(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= 60) return trimmed || "—";
+  return `${trimmed.slice(0, 57)}…`;
+}

--- a/products/dashboard/lib/workflows/aggregate.ts
+++ b/products/dashboard/lib/workflows/aggregate.ts
@@ -1,7 +1,10 @@
 import type {
+  TaskIOSummary,
+  TemplateCellAggregate,
   WorkflowEvent,
   WorkflowInstance,
   WorkflowTask,
+  WorkflowTaskStatus,
   WorkflowTemplate,
 } from "./types";
 
@@ -226,4 +229,86 @@ export function pickActiveTasks(snapshot: OverviewSnapshot): ActiveTask[] {
       };
     })
     .filter((entry): entry is ActiveTask => entry !== null);
+}
+
+const EMPTY_STATUS_COUNTS = (): Record<WorkflowTaskStatus, number> => ({
+  not_started: 0,
+  waiting: 0,
+  paused: 0,
+  in_progress: 0,
+  running: 0,
+  complete: 0,
+  failed: 0,
+});
+
+/**
+ * Roll up instance task state grouped by the template's `task_templates[]`
+ * entries. Drives the template-level matrix overview at
+ * `/workflows/templates/[templateId]`, where each cell shows the status mix
+ * across every instance of the template.
+ *
+ * Tasks that have no `templateTaskId` (ad-hoc creations on an instance)
+ * are silently skipped — they have no template-level cell to roll up into.
+ * Tasks whose `templateTaskId` no longer matches any current template task
+ * (the template removed the cell after some instances had already
+ * materialized it) are also skipped here; they surface in the per-instance
+ * sync drawer instead.
+ *
+ * `taskIO` mirrors what `WorkflowInstanceDetail.taskIO` carries and is used
+ * to flag instances whose linked inputs are unmet — same source the
+ * per-instance matrix already uses for its glyphs.
+ */
+export function aggregateTasksByTemplateCell(
+  template: WorkflowTemplate,
+  instances: readonly WorkflowInstance[],
+  tasks: readonly WorkflowTask[],
+  taskIO: readonly TaskIOSummary[],
+): TemplateCellAggregate[] {
+  const instanceById = new Map(instances.map((i) => [i.id, i]));
+  const ioByTaskId = new Map(taskIO.map((io) => [io.taskId, io]));
+  const tasksByTemplateTaskId = new Map<string, WorkflowTask[]>();
+  for (const task of tasks) {
+    if (!task.templateTaskId) continue;
+    const bucket = tasksByTemplateTaskId.get(task.templateTaskId) ?? [];
+    bucket.push(task);
+    tasksByTemplateTaskId.set(task.templateTaskId, bucket);
+  }
+
+  return template.taskTemplates
+    .filter((tpl): tpl is typeof tpl & { id: string } =>
+      typeof tpl.id === "string" && tpl.id.length > 0,
+    )
+    .map((tpl) => {
+      const cellTasks = tasksByTemplateTaskId.get(tpl.id) ?? [];
+      const statusCounts = EMPTY_STATUS_COUNTS();
+      const instanceEntries: TemplateCellAggregate["instances"] = [];
+      for (const task of cellTasks) {
+        statusCounts[task.status] = (statusCounts[task.status] ?? 0) + 1;
+        const inst = instanceById.get(task.instanceId);
+        if (!inst) continue;
+        instanceEntries.push({
+          instanceId: inst.id,
+          instanceLabel: inst.label,
+          taskId: task.id,
+          status: task.status,
+          hasUnmetLinkedInput: ioByTaskId.get(task.id)?.hasUnmetLinkedInput ?? false,
+          owners: task.owners,
+        });
+      }
+      // Stable order: instance creation order (oldest first) matches how the
+      // overview already lists instances per template.
+      instanceEntries.sort((a, b) => {
+        const ai = instanceById.get(a.instanceId)?.createdAt ?? "";
+        const bi = instanceById.get(b.instanceId)?.createdAt ?? "";
+        return ai.localeCompare(bi);
+      });
+      return {
+        templateTaskId: tpl.id,
+        skillId: tpl.skillId,
+        stageId: tpl.stageId,
+        playbookId: tpl.playbookId ?? null,
+        statusCounts,
+        instances: instanceEntries,
+      };
+    });
 }

--- a/products/dashboard/lib/workflows/repository.ts
+++ b/products/dashboard/lib/workflows/repository.ts
@@ -4,6 +4,7 @@ import type {
   DrawerData,
   FrameworkItem,
   FrameworkItemType,
+  InstanceTemplateDiff,
   OutputArtifact,
   PlaybookInput,
   PlaybookOutput,
@@ -12,6 +13,9 @@ import type {
   TaskInputState,
   TaskOutput,
   TaskOutputStatus,
+  TemplateMatrix,
+  TemplateOutputGroup,
+  TemplateSyncSelection,
   WorkflowEvent,
   WorkflowEventInput,
   WorkflowInput,
@@ -20,6 +24,7 @@ import type {
   WorkflowCheckpointTransitionStatus,
   WorkflowRepository,
   WorkflowSkill,
+  WorkflowStage,
   WorkflowTask,
   WorkflowTaskCreateInput,
   WorkflowTaskPatch,
@@ -27,8 +32,13 @@ import type {
   WorkflowTaskTemplate,
   WorkflowTemplatePatch,
   WorkflowTemplate,
-  TemplateOutputGroup,
 } from "./types";
+
+import {
+  diffInstanceFromTemplate,
+  filterApplicableTaskUpdates,
+} from "./template-sync";
+import { aggregateTasksByTemplateCell } from "./aggregate";
 
 interface WorkflowTemplateRow {
   id: string;
@@ -49,6 +59,7 @@ interface WorkflowInstanceRow {
   status: WorkflowInstance["status"];
   stages: unknown;
   skills: unknown;
+  template_synced_at: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -66,6 +77,7 @@ interface WorkflowTaskRow {
   outputs: unknown;
   playbook_id: string | null;
   owners: unknown;
+  template_task_id: string | null;
   paused_reason: string | null;
   paused_by: string | null;
   paused_at: string | null;
@@ -316,6 +328,7 @@ function mapInstance(row: WorkflowInstanceRow): WorkflowInstance {
     status: row.status,
     stages: toJsonArray(row.stages),
     skills: migrateSkills(row.skills),
+    templateSyncedAt: row.template_synced_at ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -337,6 +350,7 @@ function mapTask(row: WorkflowTaskRow): WorkflowTask {
     owners: toJsonArray<unknown>(row.owners)
       .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
       .map((value) => value.trim()),
+    templateTaskId: row.template_task_id ?? null,
     pausedReason: row.paused_reason,
     pausedBy: row.paused_by,
     pausedAt: row.paused_at,
@@ -719,6 +733,122 @@ async function loadInstanceTaskIO(
   });
 }
 
+/**
+ * One-shot loader used by both `getInstanceTemplateDiff` and
+ * `applyTemplateSync`. Pulls the template, instance, tasks, and per-task IO
+ * summary in parallel — same data the pure `diffInstanceFromTemplate`
+ * function expects. Kept separate from `getInstance` because we always need
+ * the template here (not optional) and we don't care about events.
+ */
+async function loadInstanceDetailForSync(
+  client: SupabaseClient,
+  instanceId: string,
+): Promise<{
+  template: WorkflowTemplate;
+  instance: WorkflowInstance;
+  tasks: WorkflowTask[];
+  taskIO: TaskIOSummary[];
+}> {
+  const { data: instanceRow, error: instErr } = await client
+    .from("workflow_instances")
+    .select("*")
+    .eq("id", instanceId)
+    .maybeSingle();
+  if (instErr) {
+    throw new WorkflowRepositoryError(
+      "loadInstanceDetailForSync instance lookup failed",
+      instErr,
+    );
+  }
+  if (!instanceRow) {
+    throw new WorkflowRepositoryError(
+      `loadInstanceDetailForSync: unknown instance_id "${instanceId}"`,
+    );
+  }
+  const instance = mapInstance(instanceRow as WorkflowInstanceRow);
+
+  const [{ data: tplRow, error: tplErr }, { data: taskRows, error: tasksErr }] =
+    await Promise.all([
+      client
+        .from("workflow_templates")
+        .select("*")
+        .eq("id", instance.templateId)
+        .maybeSingle(),
+      client
+        .from("workflow_tasks")
+        .select("*")
+        .eq("instance_id", instanceId)
+        .order("created_at", { ascending: true }),
+    ]);
+  if (tplErr) {
+    throw new WorkflowRepositoryError(
+      "loadInstanceDetailForSync template lookup failed",
+      tplErr,
+    );
+  }
+  if (!tplRow) {
+    throw new WorkflowRepositoryError(
+      `loadInstanceDetailForSync: template "${instance.templateId}" missing`,
+    );
+  }
+  if (tasksErr) {
+    throw new WorkflowRepositoryError(
+      "loadInstanceDetailForSync tasks lookup failed",
+      tasksErr,
+    );
+  }
+  const template = mapTemplate(tplRow as WorkflowTemplateRow);
+  const tasks = (taskRows ?? []).map((row) => mapTask(row as WorkflowTaskRow));
+  const taskIO = await loadInstanceTaskIO(client, tasks);
+  return { template, instance, tasks, taskIO };
+}
+
+/**
+ * Walk the given task rows, rewriting `inputs[].upstreamTaskRef` from any
+ * known *template* task id to the corresponding instance task id. Used by
+ * `applyTemplateSync` after newly-added cells and updated cells are
+ * persisted. Same shape as the post-insert remap in `createInstance`.
+ *
+ * Every `WorkflowInput` is now an upstream-output reference (no more
+ * link-mode discriminator); the remap simply translates the task pointer
+ * when one was snapshotted from the template.
+ */
+async function remapUpstreamRefs(
+  client: SupabaseClient,
+  rows: WorkflowTaskRow[],
+  templateIdToInstanceId: Map<string, string>,
+): Promise<void> {
+  if (rows.length === 0 || templateIdToInstanceId.size === 0) return;
+  for (const row of rows) {
+    const normalized = normalizeInputs(row.inputs);
+    let changed = false;
+    const remapped = normalized.map((input) => {
+      if (
+        input.upstreamTaskRef &&
+        templateIdToInstanceId.has(input.upstreamTaskRef)
+      ) {
+        const next = templateIdToInstanceId.get(input.upstreamTaskRef) as string;
+        if (next !== input.upstreamTaskRef) {
+          changed = true;
+          return { ...input, upstreamTaskRef: next };
+        }
+      }
+      return input;
+    });
+    if (!changed) continue;
+    const { error } = await client
+      .from("workflow_tasks")
+      .update({ inputs: inputsToJsonb(remapped) })
+      .eq("id", row.id);
+    if (error) {
+      throw new WorkflowRepositoryError(
+        "remapUpstreamRefs failed",
+        error,
+      );
+    }
+  }
+}
+
 function unwrap<T>(label: string, data: T | null, error: unknown): T {
   if (error) {
     throw new WorkflowRepositoryError(`${label} failed`, error);
@@ -732,7 +862,7 @@ function unwrap<T>(label: string, data: T | null, error: unknown): T {
 export function createWorkflowRepository(
   client: SupabaseClient,
 ): WorkflowRepository {
-  return {
+  const repo: WorkflowRepository = {
     async getTemplates(): Promise<WorkflowTemplate[]> {
       const { data, error } = await client
         .from("workflow_templates")
@@ -922,6 +1052,7 @@ export function createWorkflowRepository(
       }
       const template = mapTemplate(tplRow as WorkflowTemplateRow);
 
+      const createdAtIso = new Date().toISOString();
       const { data: insertedInstance, error: insertErr } = await client
         .from("workflow_instances")
         .insert({
@@ -930,6 +1061,8 @@ export function createWorkflowRepository(
           status: "active",
           stages: template.stages,
           skills: template.skills as unknown as WorkflowSkill[],
+          // Fresh instance is in sync with the template by construction.
+          template_synced_at: createdAtIso,
         })
         .select("*")
         .single();
@@ -953,6 +1086,7 @@ export function createWorkflowRepository(
             outputs: outputsToJsonb(tpl.outputs ?? []),
             playbook_id: tpl.playbookId ?? null,
             owners: tpl.owners ?? [],
+            template_task_id: tpl.id ?? null,
           }),
         );
 
@@ -972,18 +1106,17 @@ export function createWorkflowRepository(
         // Wiring refs in template JSONB point at *template* task ids; the
         // instance materializes with fresh task uuids, so any
         // `inputs[].upstreamTaskRef` set in the template needs to be
-        // re-pointed at the corresponding instance task. Match by
-        // (skill_id, stage_id) — unique within a template. The auto-satisfy
-        // trigger keys off `upstreamOutputId` so it works regardless, but
-        // any UI that resolves the upstream task by id (the wiring SVG,
-        // future graph views) depends on this remap.
+        // re-pointed at the corresponding instance task. We now key the
+        // remap on `template_task_id` directly (rename-proof; future-proof
+        // if the editor ever allows multiple cards per cell). The
+        // auto-satisfy trigger keys off `upstreamOutputId` so it works
+        // regardless, but any UI that resolves the upstream task by id
+        // (the wiring SVG, future graph views) depends on this remap.
         const templateIdToInstanceId = new Map<string, string>();
-        for (const tpl of template.taskTemplates) {
-          if (!tpl.id) continue;
-          const match = insertedRows.find(
-            (row) => row.skill_id === tpl.skillId && row.stage_id === tpl.stageId,
-          );
-          if (match) templateIdToInstanceId.set(tpl.id, match.id);
+        for (const row of insertedRows) {
+          if (row.template_task_id) {
+            templateIdToInstanceId.set(row.template_task_id, row.id);
+          }
         }
 
         const updates: { id: string; inputs: unknown[] }[] = [];
@@ -1873,6 +2006,370 @@ export function createWorkflowRepository(
       return mapTask(unwrap("resumeTask", data, error) as WorkflowTaskRow);
     },
 
+    async getInstanceTemplateDiff(instanceId: string): Promise<InstanceTemplateDiff> {
+      const detail = await loadInstanceDetailForSync(client, instanceId);
+      return diffInstanceFromTemplate(
+        detail.template,
+        detail.instance,
+        detail.tasks,
+        detail.taskIO,
+      );
+    },
+
+    async applyTemplateSync(
+      instanceId: string,
+      selection: TemplateSyncSelection,
+    ): Promise<WorkflowInstanceDetail> {
+      // Re-derive the diff server-side. The drawer's selection is just a
+      // list of ids it would *like* applied; we ignore anything not in the
+      // freshly computed diff (e.g. a stage already added by a concurrent
+      // tab) and re-run the pristine check on tasks (status may have moved
+      // off not_started between the drawer fetch and this call).
+      const detail = await loadInstanceDetailForSync(client, instanceId);
+      const diff = diffInstanceFromTemplate(
+        detail.template,
+        detail.instance,
+        detail.tasks,
+        detail.taskIO,
+      );
+
+      const applied: { kind: string; id: string }[] = [];
+
+      // --- Stages: add + rename ---
+      const stageIdsAddSet = new Set(selection.stageIdsToAdd);
+      const stageIdsRenameSet = new Set(selection.stageIdsToRename);
+      const stagesToAdd = diff.stages.added.filter((s) => stageIdsAddSet.has(s.id));
+      const stagesToRename = diff.stages.renamed.filter((s) =>
+        stageIdsRenameSet.has(s.id),
+      );
+      const nextStages: WorkflowStage[] = detail.instance.stages.map((s) => {
+        const rename = stagesToRename.find((r) => r.id === s.id);
+        if (rename) return { id: rename.to.id, label: rename.to.label, sub: rename.to.sub };
+        return { id: s.id, label: s.label, sub: s.sub };
+      });
+      for (const s of stagesToAdd) {
+        nextStages.push({ id: s.id, label: s.label, sub: s.sub });
+        applied.push({ kind: "stage_add", id: s.id });
+      }
+      for (const r of stagesToRename) applied.push({ kind: "stage_rename", id: r.id });
+
+      // --- Skills: add + rename ---
+      const skillIdsAddSet = new Set(selection.skillIdsToAdd);
+      const skillIdsRenameSet = new Set(selection.skillIdsToRename);
+      const skillsToAdd = diff.skills.added.filter((s) => skillIdsAddSet.has(s.id));
+      const skillsToRename = diff.skills.renamed.filter((s) =>
+        skillIdsRenameSet.has(s.id),
+      );
+      const nextSkills: WorkflowSkill[] = detail.instance.skills.map((s) => {
+        const rename = skillsToRename.find((r) => r.id === s.id);
+        if (rename) return { id: rename.to.id, label: rename.to.label, owners: s.owners };
+        return s;
+      });
+      for (const s of skillsToAdd) {
+        nextSkills.push({ id: s.id, label: s.label, owners: s.owners ?? [] });
+        applied.push({ kind: "skill_add", id: s.id });
+      }
+      for (const r of skillsToRename) applied.push({ kind: "skill_rename", id: r.id });
+
+      const stageOrSkillChanged =
+        stagesToAdd.length > 0 ||
+        stagesToRename.length > 0 ||
+        skillsToAdd.length > 0 ||
+        skillsToRename.length > 0;
+
+      if (stageOrSkillChanged) {
+        const { error: instUpdErr } = await client
+          .from("workflow_instances")
+          .update({ stages: nextStages, skills: nextSkills })
+          .eq("id", instanceId);
+        if (instUpdErr) {
+          throw new WorkflowRepositoryError(
+            "applyTemplateSync stages/skills update failed",
+            instUpdErr,
+          );
+        }
+      }
+
+      // --- Tasks: add new cells materialized from template_task_id ---
+      // Build the lineage→instance id map up front because new tasks may
+      // reference other tasks (existing or just-added) via
+      // `inputs[].upstreamTaskRef`.
+      const templateIdToInstanceId = new Map<string, string>();
+      for (const task of detail.tasks) {
+        if (task.templateTaskId) templateIdToInstanceId.set(task.templateTaskId, task.id);
+      }
+
+      const addIdsSet = new Set(selection.taskTemplateIdsToAdd);
+      const tasksToAdd = diff.tasks.added.filter(
+        (t) => t.id !== undefined && addIdsSet.has(t.id),
+      );
+
+      const newlyInsertedRows: WorkflowTaskRow[] = [];
+      if (tasksToAdd.length > 0) {
+        const rowsToInsert = tasksToAdd.map((tpl) => ({
+          instance_id: instanceId,
+          skill_id: tpl.skillId,
+          stage_id: tpl.stageId,
+          notes: tpl.notes ?? "",
+          status: "not_started" as const,
+          substatus: "",
+          checkpoint: tpl.checkpoint ?? false,
+          // Preserve template upstream refs verbatim; we remap them in a
+          // second pass once we know the new instance task ids.
+          inputs: inputsToJsonb(tpl.inputs ?? []),
+          // Per-task outputs snapshot, same shape createInstance uses
+          // (migration 20260515120000_workflow_task_outputs_snapshot.sql).
+          outputs: outputsToJsonb(tpl.outputs ?? []),
+          playbook_id: tpl.playbookId ?? null,
+          owners: tpl.owners ?? [],
+          template_task_id: tpl.id ?? null,
+        }));
+        const { data: insertedTasks, error: insertTasksErr } = await client
+          .from("workflow_tasks")
+          .insert(rowsToInsert)
+          .select("*");
+        if (insertTasksErr) {
+          throw new WorkflowRepositoryError(
+            "applyTemplateSync task insert failed",
+            insertTasksErr,
+          );
+        }
+        for (const row of (insertedTasks ?? []) as WorkflowTaskRow[]) {
+          newlyInsertedRows.push(row);
+          if (row.template_task_id) {
+            templateIdToInstanceId.set(row.template_task_id, row.id);
+          }
+          applied.push({ kind: "task_add", id: row.id });
+        }
+
+        // Materialize task_inputs rows so deriveStatus can flip them from
+        // waiting → not_started as upstream outputs land. Matches the
+        // backfill pattern in 20260507120000_playbook_outputs_and_status.sql.
+        const taskInputsRows: Record<string, unknown>[] = [];
+        for (const row of newlyInsertedRows) {
+          const inputs = normalizeInputs(row.inputs);
+          for (const input of inputs) {
+            taskInputsRows.push({
+              task_id: row.id,
+              input_id: input.id,
+              received: false,
+              received_at: null,
+              received_from: null,
+            });
+          }
+        }
+        if (taskInputsRows.length > 0) {
+          const { error: tiErr } = await client
+            .from("task_inputs")
+            .upsert(taskInputsRows, { onConflict: "task_id,input_id" });
+          if (tiErr) {
+            throw new WorkflowRepositoryError(
+              "applyTemplateSync task_inputs materialize failed",
+              tiErr,
+            );
+          }
+        }
+      }
+
+      // --- Tasks: update existing pristine cells ---
+      // Re-check the syncable flag against the freshly-computed diff. The
+      // selection may carry instance task ids that have since moved off
+      // not_started — those are dropped silently.
+      const applicableUpdateIds = filterApplicableTaskUpdates(selection, diff);
+      const updateIdSet = new Set(applicableUpdateIds);
+      const updatesToApply = diff.tasks.changed.filter((c) =>
+        updateIdSet.has(c.instanceTaskId),
+      );
+
+      for (const change of updatesToApply) {
+        const tpl = detail.template.taskTemplates.find((t) => t.id === change.templateTaskId);
+        if (!tpl) continue;
+        // Re-check pristine inside the conditional update to close the race
+        // between diff and apply.
+        const rowPatch: Record<string, unknown> = {};
+        if (change.fields.notes) rowPatch.notes = change.fields.notes.to;
+        if (change.fields.playbookId) rowPatch.playbook_id = change.fields.playbookId.to;
+        if (change.fields.checkpoint) {
+          rowPatch.checkpoint = change.fields.checkpoint.to;
+        }
+        if (change.fields.owners) rowPatch.owners = change.fields.owners.to;
+        if (change.fields.inputs) {
+          rowPatch.inputs = inputsToJsonb(tpl.inputs ?? []);
+        }
+        if (Object.keys(rowPatch).length === 0) continue;
+        const { data: updatedRow, error: taskUpdErr } = await client
+          .from("workflow_tasks")
+          .update(rowPatch)
+          .eq("id", change.instanceTaskId)
+          .eq("status", "not_started")
+          .select("*")
+          .maybeSingle();
+        if (taskUpdErr) {
+          throw new WorkflowRepositoryError(
+            "applyTemplateSync task update failed",
+            taskUpdErr,
+          );
+        }
+        // updatedRow is null iff the conditional update missed (the task
+        // was started between diff and apply). Drop silently — UI labels it
+        // informational on the next refresh.
+        if (!updatedRow) continue;
+        applied.push({ kind: "task_update", id: change.instanceTaskId });
+
+        // Reconcile task_inputs when the inputs array changed. The task is
+        // guaranteed pristine here (status=not_started, no produced
+        // outputs) so no `received_*` audit state can be lost: just wipe
+        // and re-seed from the template's input list.
+        if (change.fields.inputs) {
+          const { error: delErr } = await client
+            .from("task_inputs")
+            .delete()
+            .eq("task_id", change.instanceTaskId);
+          if (delErr) {
+            throw new WorkflowRepositoryError(
+              "applyTemplateSync task_inputs wipe failed",
+              delErr,
+            );
+          }
+          const tiInsert = (tpl.inputs ?? []).map((input) => ({
+            task_id: change.instanceTaskId,
+            input_id: input.id,
+            received: false,
+            received_at: null,
+            received_from: null,
+          }));
+          if (tiInsert.length > 0) {
+            const { error: insErr } = await client
+              .from("task_inputs")
+              .insert(tiInsert);
+            if (insErr) {
+              throw new WorkflowRepositoryError(
+                "applyTemplateSync task_inputs insert failed",
+                insErr,
+              );
+            }
+          }
+        }
+      }
+
+      // --- Remap upstreamTaskRef on newly inserted + updated rows ---
+      // After both adds and updates landed, any `inputs[].upstreamTaskRef`
+      // still pointing at a *template* task id needs to be re-pointed at
+      // the corresponding instance task id. Same pattern as createInstance.
+      const rowsNeedingRemap: WorkflowTaskRow[] = [];
+      rowsNeedingRemap.push(...newlyInsertedRows);
+      if (updatesToApply.length > 0) {
+        const { data: refreshed, error: refErr } = await client
+          .from("workflow_tasks")
+          .select("*")
+          .in("id", updatesToApply.map((c) => c.instanceTaskId));
+        if (refErr) {
+          throw new WorkflowRepositoryError(
+            "applyTemplateSync remap fetch failed",
+            refErr,
+          );
+        }
+        for (const row of (refreshed ?? []) as WorkflowTaskRow[]) {
+          rowsNeedingRemap.push(row);
+        }
+      }
+      await remapUpstreamRefs(client, rowsNeedingRemap, templateIdToInstanceId);
+
+      // --- Bump template_synced_at + emit an event ---
+      if (applied.length > 0) {
+        const syncedAt = new Date().toISOString();
+        const { error: stampErr } = await client
+          .from("workflow_instances")
+          .update({ template_synced_at: syncedAt })
+          .eq("id", instanceId);
+        if (stampErr) {
+          throw new WorkflowRepositoryError(
+            "applyTemplateSync stamp failed",
+            stampErr,
+          );
+        }
+        const { error: evErr } = await client
+          .from("workflow_events")
+          .insert({
+            instance_id: instanceId,
+            task_id: null,
+            name: "template_sync_applied",
+            description: `Applied ${applied.length} change${applied.length === 1 ? "" : "s"} from template`,
+            payload: { applied },
+          });
+        if (evErr) {
+          throw new WorkflowRepositoryError(
+            "applyTemplateSync event insert failed",
+            evErr,
+          );
+        }
+      }
+
+      const refreshed = await repo.getInstance(instanceId);
+      if (!refreshed) {
+        throw new WorkflowRepositoryError(
+          "applyTemplateSync: instance vanished after apply",
+        );
+      }
+      return refreshed;
+    },
+
+    async getTemplateMatrix(templateId: string): Promise<TemplateMatrix | null> {
+      const { data: tplRow, error: tplErr } = await client
+        .from("workflow_templates")
+        .select("*")
+        .eq("id", templateId)
+        .maybeSingle();
+      if (tplErr) {
+        throw new WorkflowRepositoryError("getTemplateMatrix template lookup failed", tplErr);
+      }
+      if (!tplRow) return null;
+      const template = mapTemplate(tplRow as WorkflowTemplateRow);
+
+      const { data: instanceRows, error: instErr } = await client
+        .from("workflow_instances")
+        .select("*")
+        .eq("template_id", templateId)
+        .order("created_at", { ascending: true });
+      if (instErr) {
+        throw new WorkflowRepositoryError(
+          "getTemplateMatrix instances lookup failed",
+          instErr,
+        );
+      }
+      const instances = (instanceRows ?? []).map((row) =>
+        mapInstance(row as WorkflowInstanceRow),
+      );
+
+      if (instances.length === 0) {
+        return {
+          template,
+          instances,
+          cells: aggregateTasksByTemplateCell(template, instances, [], []),
+        };
+      }
+
+      const instanceIds = instances.map((i) => i.id);
+      const { data: taskRows, error: taskErr } = await client
+        .from("workflow_tasks")
+        .select("*")
+        .in("instance_id", instanceIds);
+      if (taskErr) {
+        throw new WorkflowRepositoryError(
+          "getTemplateMatrix tasks lookup failed",
+          taskErr,
+        );
+      }
+      const tasks = (taskRows ?? []).map((row) => mapTask(row as WorkflowTaskRow));
+      const taskIO = await loadInstanceTaskIO(client, tasks);
+
+      return {
+        template,
+        instances,
+        cells: aggregateTasksByTemplateCell(template, instances, tasks, taskIO),
+      };
+    },
+
     async getFrameworkItems(type?: FrameworkItemType): Promise<FrameworkItem[]> {
       let query = client
         .from("framework_items")
@@ -2075,4 +2572,5 @@ export function createWorkflowRepository(
       }
     },
   };
+  return repo;
 }

--- a/products/dashboard/lib/workflows/template-sync.ts
+++ b/products/dashboard/lib/workflows/template-sync.ts
@@ -1,0 +1,257 @@
+import type {
+  InputDiff,
+  InstanceTemplateDiff,
+  SkillRename,
+  StageRename,
+  TaskFieldDiff,
+  TaskIOSummary,
+  TemplateSyncSelection,
+  WorkflowInput,
+  WorkflowInstance,
+  WorkflowSkill,
+  WorkflowStage,
+  WorkflowTask,
+  WorkflowTaskTemplate,
+  WorkflowTemplate,
+} from "./types";
+
+/**
+ * Pure diff between an instance and its template. No DB calls; everything
+ * needed is passed in. The repository layer wraps this with the actual
+ * loads (`getInstanceTemplateDiff`) and the apply path
+ * (`applyTemplateSync`).
+ *
+ * The "syncable" decision for a per-task field change is intentionally
+ * conservative — only tasks that are still `not_started` AND have produced
+ * no outputs are eligible to be overwritten. Anything else is shown as
+ * informational so the user can see the divergence but can't accidentally
+ * blow away in-flight work.
+ *
+ * `taskIO` carries per-task output status (from the same shape the matrix
+ * uses) so we can detect "any produced output" without re-querying. Passing
+ * an empty array degrades gracefully to "pristine iff status=not_started",
+ * which is the right answer for unit tests that don't care about outputs.
+ */
+export function diffInstanceFromTemplate(
+  template: WorkflowTemplate,
+  instance: WorkflowInstance,
+  tasks: readonly WorkflowTask[],
+  taskIO: readonly TaskIOSummary[] = [],
+): InstanceTemplateDiff {
+  return {
+    templateId: template.id,
+    instanceId: instance.id,
+    templateSyncedAt: instance.templateSyncedAt ?? null,
+    stages: diffStages(template.stages, instance.stages),
+    skills: diffSkills(template.skills, instance.skills),
+    tasks: diffTasks(template.taskTemplates, tasks, taskIO),
+  };
+}
+
+function diffStages(
+  templateStages: readonly WorkflowStage[],
+  instanceStages: readonly WorkflowStage[],
+): InstanceTemplateDiff["stages"] {
+  const instanceById = new Map(instanceStages.map((s) => [s.id, s]));
+  const templateById = new Map(templateStages.map((s) => [s.id, s]));
+
+  const added = templateStages.filter((s) => !instanceById.has(s.id));
+  const removedFromTemplate = instanceStages.filter((s) => !templateById.has(s.id));
+  const renamed: StageRename[] = [];
+  for (const tpl of templateStages) {
+    const inst = instanceById.get(tpl.id);
+    if (!inst) continue;
+    if (inst.label !== tpl.label || (inst.sub ?? "") !== (tpl.sub ?? "")) {
+      renamed.push({ id: tpl.id, from: inst, to: tpl });
+    }
+  }
+  return { added, removedFromTemplate, renamed };
+}
+
+function diffSkills(
+  templateSkills: readonly WorkflowSkill[],
+  instanceSkills: readonly WorkflowSkill[],
+): InstanceTemplateDiff["skills"] {
+  const instanceById = new Map(instanceSkills.map((s) => [s.id, s]));
+  const templateById = new Map(templateSkills.map((s) => [s.id, s]));
+
+  const added = templateSkills.filter((s) => !instanceById.has(s.id));
+  const removedFromTemplate = instanceSkills.filter((s) => !templateById.has(s.id));
+  const renamed: SkillRename[] = [];
+  for (const tpl of templateSkills) {
+    const inst = instanceById.get(tpl.id);
+    if (!inst) continue;
+    if (inst.label !== tpl.label) {
+      renamed.push({ id: tpl.id, from: inst, to: tpl });
+    }
+  }
+  return { added, removedFromTemplate, renamed };
+}
+
+function diffTasks(
+  templateTasks: readonly WorkflowTaskTemplate[],
+  instanceTasks: readonly WorkflowTask[],
+  taskIO: readonly TaskIOSummary[],
+): InstanceTemplateDiff["tasks"] {
+  const ioByTaskId = new Map(taskIO.map((io) => [io.taskId, io]));
+
+  // Instance tasks indexed by the template task they came from. Ad-hoc
+  // tasks (templateTaskId === null) are simply not part of the lineage
+  // diff — they were created by the user on the instance, not from the
+  // template, and the template has nothing to say about them.
+  const instanceByTemplateTaskId = new Map<string, WorkflowTask>();
+  for (const task of instanceTasks) {
+    if (task.templateTaskId) {
+      instanceByTemplateTaskId.set(task.templateTaskId, task);
+    }
+  }
+
+  const templateTaskIds = new Set(
+    templateTasks
+      .map((t) => t.id)
+      .filter((id): id is string => typeof id === "string" && id.length > 0),
+  );
+
+  const added: WorkflowTaskTemplate[] = templateTasks.filter(
+    (t) => typeof t.id === "string" && t.id.length > 0 && !instanceByTemplateTaskId.has(t.id),
+  );
+
+  const removedFromTemplate: WorkflowTask[] = instanceTasks.filter(
+    (t): boolean =>
+      typeof t.templateTaskId === "string" &&
+      t.templateTaskId.length > 0 &&
+      !templateTaskIds.has(t.templateTaskId),
+  );
+
+  const changed: TaskFieldDiff[] = [];
+  for (const tpl of templateTasks) {
+    if (!tpl.id) continue;
+    const inst = instanceByTemplateTaskId.get(tpl.id);
+    if (!inst) continue;
+    const fields = compareTaskFields(tpl, inst);
+    if (!hasAnyFieldDiff(fields)) continue;
+    const pristine = isPristine(inst, ioByTaskId.get(inst.id));
+    changed.push({
+      instanceTaskId: inst.id,
+      templateTaskId: tpl.id,
+      instanceStatus: inst.status,
+      fields,
+      syncable: pristine ? "yes" : "informational_only",
+      syncBlockedReason: pristine ? undefined : "task_not_pristine",
+    });
+  }
+
+  return { added, removedFromTemplate, changed };
+}
+
+function compareTaskFields(
+  tpl: WorkflowTaskTemplate,
+  inst: WorkflowTask,
+): TaskFieldDiff["fields"] {
+  const fields: TaskFieldDiff["fields"] = {};
+  const tplNotes = tpl.notes ?? "";
+  const instNotes = inst.notes ?? "";
+  if (tplNotes !== instNotes) {
+    fields.notes = { from: instNotes, to: tplNotes };
+  }
+  const tplPlaybook = tpl.playbookId ?? null;
+  const instPlaybook = inst.playbookId ?? null;
+  if (tplPlaybook !== instPlaybook) {
+    fields.playbookId = { from: instPlaybook, to: tplPlaybook };
+  }
+  const tplCheckpoint = tpl.checkpoint ?? false;
+  if (tplCheckpoint !== inst.checkpoint) {
+    fields.checkpoint = { from: inst.checkpoint, to: tplCheckpoint };
+  }
+  const tplOwners = (tpl.owners ?? []).slice();
+  const instOwners = inst.owners.slice();
+  if (!arraysEqual(tplOwners, instOwners)) {
+    fields.owners = { from: instOwners, to: tplOwners };
+  }
+  const inputDiff = diffInputs(tpl.inputs ?? [], inst.inputs);
+  if (
+    inputDiff.added.length > 0 ||
+    inputDiff.removed.length > 0 ||
+    inputDiff.changed.length > 0
+  ) {
+    fields.inputs = inputDiff;
+  }
+  return fields;
+}
+
+function hasAnyFieldDiff(fields: TaskFieldDiff["fields"]): boolean {
+  return (
+    fields.notes !== undefined ||
+    fields.playbookId !== undefined ||
+    fields.checkpoint !== undefined ||
+    fields.owners !== undefined ||
+    fields.inputs !== undefined
+  );
+}
+
+function diffInputs(
+  templateInputs: readonly WorkflowInput[],
+  instanceInputs: readonly WorkflowInput[],
+): InputDiff {
+  const instanceById = new Map(instanceInputs.map((i) => [i.id, i]));
+  const templateById = new Map(templateInputs.map((i) => [i.id, i]));
+  const added = templateInputs.filter((i) => !instanceById.has(i.id));
+  const removed = instanceInputs.filter((i) => !templateById.has(i.id));
+  const changed: InputDiff["changed"] = [];
+  for (const tpl of templateInputs) {
+    const inst = instanceById.get(tpl.id);
+    if (!inst) continue;
+    if (!inputsEqual(tpl, inst)) {
+      changed.push({ id: tpl.id, from: inst, to: tpl });
+    }
+  }
+  return { added, removed, changed };
+}
+
+function inputsEqual(a: WorkflowInput, b: WorkflowInput): boolean {
+  // WorkflowInput is now always an upstream-output reference (no display
+  // fields, no link-mode discriminator). Two inputs are equal iff they
+  // point at the same upstream output (and snapshot the same upstream
+  // task pointer when present).
+  return (
+    a.upstreamOutputId === b.upstreamOutputId &&
+    (a.upstreamTaskRef ?? null) === (b.upstreamTaskRef ?? null)
+  );
+}
+
+function arraysEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function isPristine(
+  task: WorkflowTask,
+  io: TaskIOSummary | undefined,
+): boolean {
+  if (task.status !== "not_started") return false;
+  if (!io) return true;
+  return !io.outputs.some((o) => o.status === "produced");
+}
+
+/**
+ * Filter a user selection down to the entries that are still applicable
+ * given a freshly-computed diff. Used inside `applyTemplateSync` so a task
+ * that became non-pristine between the drawer fetch and the apply call is
+ * silently dropped instead of overwriting in-flight work.
+ *
+ * The set logic also gates on the diff actually containing the entry —
+ * a stale ticked checkbox for a stage that's already been added (e.g. a
+ * concurrent sync from another tab) becomes a no-op.
+ */
+export function filterApplicableTaskUpdates(
+  selection: TemplateSyncSelection,
+  diff: InstanceTemplateDiff,
+): string[] {
+  const syncableIds = new Set(
+    diff.tasks.changed
+      .filter((t) => t.syncable === "yes")
+      .map((t) => t.instanceTaskId),
+  );
+  return selection.instanceTaskIdsToUpdate.filter((id) => syncableIds.has(id));
+}

--- a/products/dashboard/lib/workflows/types.ts
+++ b/products/dashboard/lib/workflows/types.ts
@@ -126,6 +126,12 @@ export interface WorkflowTask {
    *  Per-task so two cards pointing at the same playbook can carry different
    *  owners (e.g. different sales people across instances). */
   owners: string[];
+  /** Lineage back to the `task_templates[].id` this task was materialized
+   *  from. Null on ad-hoc instance tasks created via createTask, and on
+   *  legacy rows authored before the lineage migration. Drives template-
+   *  level rollup (aggregateTasksByTemplateCell) and the template sync
+   *  diff. Optional in the type so older test fixtures stay valid. */
+  templateTaskId?: string | null;
   /** Why the task is paused (e.g. `'checkpoint'`, `'awaiting_input'`).
    *  Drives the drawer pause banner; null when status !== 'paused'. */
   pausedReason?: string | null;
@@ -262,6 +268,12 @@ export interface WorkflowInstance {
    *  template so edits to the template do not mutate existing instances. */
   stages: WorkflowStage[];
   skills: WorkflowSkill[];
+  /** Last time this instance was reconciled with its template via
+   *  applyTemplateSync (set to createdAt for fresh instances). Drives the
+   *  "Last synced" label in the sync drawer. Null on legacy rows that
+   *  predate the lineage migration and have never been touched by sync.
+   *  Optional in the type so older test fixtures stay valid. */
+  templateSyncedAt?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -351,6 +363,119 @@ export interface WorkflowEventInput {
   name: string;
   description?: string;
   payload?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Template ↔ instance sync — diff shape returned by
+// `WorkflowRepository.getInstanceTemplateDiff`, and the selection shape the
+// sync drawer sends back to `applyTemplateSync`. The diff is computed by the
+// pure `diffInstanceFromTemplate` in `lib/workflows/template-sync.ts`.
+// ---------------------------------------------------------------------------
+
+export interface StageRename {
+  id: string;
+  from: WorkflowStage;
+  to: WorkflowStage;
+}
+
+export interface SkillRename {
+  id: string;
+  from: WorkflowSkill;
+  to: WorkflowSkill;
+}
+
+export interface InputDiff {
+  added: WorkflowInput[];
+  removed: WorkflowInput[];
+  changed: { id: string; from: WorkflowInput; to: WorkflowInput }[];
+}
+
+/**
+ * Per-task diff. `syncable === "yes"` iff the instance task is pristine —
+ * `status === "not_started"` AND no `task_outputs.status='produced'` rows.
+ * The repository re-checks this server-side before applying; the UI uses
+ * it to render the checkbox-vs-info-row split.
+ */
+export interface TaskFieldDiff {
+  instanceTaskId: string;
+  templateTaskId: string;
+  instanceStatus: WorkflowTaskStatus;
+  fields: {
+    notes?: { from: string; to: string };
+    playbookId?: { from: string | null; to: string | null };
+    checkpoint?: { from: boolean; to: boolean };
+    owners?: { from: string[]; to: string[] };
+    inputs?: InputDiff;
+  };
+  syncable: "yes" | "informational_only";
+  syncBlockedReason?: "task_not_pristine";
+}
+
+export interface InstanceTemplateDiff {
+  templateId: string;
+  instanceId: string;
+  templateSyncedAt: string | null;
+  stages: {
+    added: WorkflowStage[];
+    removedFromTemplate: WorkflowStage[];
+    renamed: StageRename[];
+  };
+  skills: {
+    added: WorkflowSkill[];
+    removedFromTemplate: WorkflowSkill[];
+    renamed: SkillRename[];
+  };
+  tasks: {
+    added: WorkflowTaskTemplate[];
+    removedFromTemplate: WorkflowTask[];
+    changed: TaskFieldDiff[];
+  };
+}
+
+/**
+ * Sent by the sync drawer to `applyTemplateSync`. Each list holds the ids of
+ * the diff entries the user ticked. The repository re-derives the diff
+ * server-side and only applies changes whose id appears here AND still
+ * satisfies the apply rules (e.g. a task that became non-pristine between
+ * the drawer fetch and the apply call is silently dropped from `taskChanges`).
+ */
+export interface TemplateSyncSelection {
+  stageIdsToAdd: string[];
+  skillIdsToAdd: string[];
+  stageIdsToRename: string[];
+  skillIdsToRename: string[];
+  taskTemplateIdsToAdd: string[];
+  /** Instance task ids whose changed fields should be overwritten from the
+   *  template. The repository ignores entries whose backing instance task is
+   *  no longer pristine. */
+  instanceTaskIdsToUpdate: string[];
+}
+
+/**
+ * Returned by `WorkflowRepository.getTemplateMatrix`. One entry per
+ * `task_templates[]` on the template, with status counts and per-instance
+ * detail rolled up across every instance of that template.
+ */
+export interface TemplateCellAggregate {
+  templateTaskId: string;
+  skillId: string;
+  stageId: string;
+  playbookId: string | null;
+  statusCounts: Record<WorkflowTaskStatus, number>;
+  instances: {
+    instanceId: string;
+    instanceLabel: string;
+    taskId: string;
+    status: WorkflowTaskStatus;
+    hasUnmetLinkedInput: boolean;
+    owners: string[];
+  }[];
+}
+
+export interface TemplateMatrix {
+  template: WorkflowTemplate;
+  instances: WorkflowInstance[];
+  cells: TemplateCellAggregate[];
 }
 
 export interface WorkflowRepository {
@@ -490,6 +615,24 @@ export interface WorkflowRepository {
     pausedBy?: string | null,
   ): Promise<WorkflowTask>;
   resumeTask(taskId: string): Promise<WorkflowTask>;
+  /** Compute the diff between an instance and its template's current state.
+   *  Loads template, instance, tasks, and the per-task IO summary in one
+   *  pass; the diff itself is computed by the pure
+   *  `diffInstanceFromTemplate` helper. */
+  getInstanceTemplateDiff(instanceId: string): Promise<InstanceTemplateDiff>;
+  /** Apply the user-selected subset of a sync diff to the instance. Server
+   *  re-derives the diff and re-checks pristine-ness on each task update;
+   *  non-applicable selection entries are dropped silently. Returns the
+   *  refreshed instance detail so the matrix can re-render. */
+  applyTemplateSync(
+    instanceId: string,
+    selection: TemplateSyncSelection,
+  ): Promise<WorkflowInstanceDetail>;
+  /** Roll up status across every instance of a template, grouped by the
+   *  template's `task_templates[]` (matched via `template_task_id`).
+   *  Drives the template-level matrix overview at
+   *  `/workflows/templates/[templateId]`. */
+  getTemplateMatrix(templateId: string): Promise<TemplateMatrix | null>;
   getFrameworkItems(type?: FrameworkItemType): Promise<FrameworkItem[]>;
   upsertFrameworkItem(item: FrameworkItem): Promise<FrameworkItem>;
   deleteFrameworkItem(itemId: string): Promise<void>;

--- a/products/dashboard/supabase/migrations/20260517120000_template_instance_lineage.sql
+++ b/products/dashboard/supabase/migrations/20260517120000_template_instance_lineage.sql
@@ -1,0 +1,107 @@
+-- Template ↔ instance lineage + last-synced marker.
+--
+-- Today an instance task only knows its `instance_id`; the path back to the
+-- originating `task_templates[].id` is recovered by `createInstance` via a
+-- composite key. Since the multi-card matrix change (PR #233) cells can
+-- carry more than one card, so `(skill_id, stage_id)` alone is no longer
+-- unique within a template — the remap now prefers
+-- `(skill_id, stage_id, playbook_id)` with ordinal as a final tiebreaker.
+-- Implicit recovery works for fresh creates, but it can't distinguish
+-- "this cell was always here" from "this cell was added later", and goes
+-- stale the moment we want a stable handle for template-level rollup or
+-- sync diffing.
+--
+-- This migration makes the lineage explicit:
+--   * `workflow_tasks.template_task_id` (nullable — ad-hoc tasks created on
+--     an instance via createTask have no template counterpart)
+--   * `workflow_instances.template_synced_at` (nullable — null on instances
+--     that have never been touched by sync; set by createInstance for new
+--     instances and by applyTemplateSync going forward)
+--
+-- Backfill: for every existing task, look up the parent instance's
+-- task_templates and prefer matches on (skill_id, stage_id, playbook_id).
+-- When multi-card cells share the same triplet, fall back to ordinal
+-- pairing within the cell (Nth task at that cell ↔ Nth task_template
+-- entry at that cell). Any task whose cell doesn't match a current
+-- template entry stays NULL — those are ad-hoc rows or tasks whose
+-- template counterpart was already removed.
+
+alter table public.workflow_tasks
+  add column if not exists template_task_id text;
+
+create index if not exists workflow_tasks_template_task_id_idx
+  on public.workflow_tasks (instance_id, template_task_id);
+
+alter table public.workflow_instances
+  add column if not exists template_synced_at timestamptz;
+
+-- Backfill template_task_id for existing rows.
+--
+-- The CTE computes a per-cell ordinal on both sides so multi-card cells
+-- pair Nth-with-Nth instead of collapsing onto a single template task. The
+-- match is then a single equi-join on
+-- (instance_id, skill_id, stage_id, playbook_id, ordinal). Rows whose cell
+-- triplet doesn't exist on the template are left NULL on purpose.
+with template_cards as (
+  select
+    i.id                       as instance_id,
+    (tpl->>'skillId')          as skill_id,
+    (tpl->>'stageId')          as stage_id,
+    nullif(tpl->>'playbookId', '') as playbook_id,
+    coalesce(
+      nullif(tpl->>'id', ''),
+      format('%s::%s::%s::%s',
+             wt.id,
+             (tpl->>'skillId'),
+             (tpl->>'stageId'),
+             (tpl_idx::int - 1))
+    )                          as template_task_id,
+    row_number() over (
+      partition by i.id,
+                   (tpl->>'skillId'),
+                   (tpl->>'stageId'),
+                   nullif(tpl->>'playbookId', '')
+      order by tpl_idx
+    )                          as cell_ord
+  from public.workflow_instances i
+  join public.workflow_templates wt on wt.id = i.template_id
+  cross join lateral jsonb_array_elements(coalesce(wt.task_templates, '[]'::jsonb))
+                     with ordinality as arr(tpl, tpl_idx)
+),
+instance_cards as (
+  select
+    tt.id          as task_id,
+    tt.instance_id,
+    tt.skill_id,
+    tt.stage_id,
+    tt.playbook_id,
+    row_number() over (
+      partition by tt.instance_id, tt.skill_id, tt.stage_id, tt.playbook_id
+      order by tt.created_at, tt.id
+    )              as cell_ord
+  from public.workflow_tasks tt
+  where tt.template_task_id is null
+)
+update public.workflow_tasks t
+   set template_task_id = m.template_task_id
+  from instance_cards ic
+  join template_cards m
+    on m.instance_id = ic.instance_id
+   and m.skill_id    = ic.skill_id
+   and m.stage_id    = ic.stage_id
+   and m.playbook_id is not distinct from ic.playbook_id
+   and m.cell_ord    = ic.cell_ord
+ where t.id = ic.task_id;
+
+-- Initialize template_synced_at to created_at on existing instances so the
+-- sync drawer reads "Last synced <created time>" instead of null — they're
+-- in sync at the moment they were created by definition.
+update public.workflow_instances
+   set template_synced_at = created_at
+ where template_synced_at is null;
+
+comment on column public.workflow_tasks.template_task_id is
+  'Lineage back to workflow_templates.task_templates[].id. Null for ad-hoc instance tasks (createTask) with no template counterpart. Drives the sync drawer diff and the template-level matrix rollup.';
+
+comment on column public.workflow_instances.template_synced_at is
+  'Last time the instance was reconciled with its template via applyTemplateSync (or created, for fresh instances). Surfaces "Last synced" in the sync drawer.';


### PR DESCRIPTION
## Summary

Adds explicit lineage between an instance task and the template task it was materialized from, then uses it to power two new surfaces:

- **"Sync with template" drawer** on each workflow instance — inspect-and-apply diff that lets the founder pull added stages / skills / cells and update pristine cells (`not_started`, no produced outputs) without disturbing in-flight work. Removed-from-template entities surface as flag-only rows.
- **`/workflows/templates/[templateId]`** — read-only stacked matrix that rolls up status counts across every instance of the template, per cell, with drill-in to each instance.

### Schema (`20260517120000_template_instance_lineage.sql`)

- `workflow_tasks.template_task_id` — backfilled by `(skill_id, stage_id, playbook_id)` with per-cell ordinal tiebreaker so multi-card cells line up deterministically.
- `workflow_instances.template_synced_at` — seeded to `created_at` for existing rows; bumped by `applyTemplateSync` going forward.

### Repository

- `createInstance` now populates `template_task_id` directly and keys the input remap on lineage instead of name match.
- New `getInstanceTemplateDiff`, `applyTemplateSync` (re-derives the diff server-side and re-checks the pristine gate inside the conditional UPDATE), and `getTemplateMatrix`.

### UI

- `components/workflows/template-sync-drawer.tsx` — added / removed / renamed / changed sections; pristine-only rows get a checkbox, in-flight rows render flag-only.
- `components/workflows/template-overview-matrix.tsx` — stacked roll-up of per-cell status counts with click-through to each instance.
- `process-matrix.tsx` — entry point for the sync drawer trigger.

### Helpers + tests

- `diffInstanceFromTemplate` in `lib/workflows/template-sync.ts`
- `aggregateTasksByTemplateCell` in `lib/workflows/aggregate.ts`
- Unit coverage in `__tests__/lib/workflows/{template-sync,aggregate,repository}.test.ts` for added / removed / renamed / changed permutations and the pristine vs informational-only gate.

`interfaces/interfaces.yaml` extended with the three new operations.

## Test plan

- [ ] `cd products/dashboard && npx vitest run __tests__/lib/workflows`
- [ ] `cd products/dashboard && npx tsc --noEmit` (only pre-existing unrelated errors)
- [ ] `supabase migration up` locally — confirm `workflow_tasks.template_task_id` backfills with no nulls for rows whose `(skill_id, stage_id, playbook_id)` matches a template task; `workflow_instances.template_synced_at` matches `created_at`
- [ ] Open an instance whose template has since added a new stage / cell → "Sync with template" drawer lists it under **Added**; applying inserts the cell as `not_started`; in-flight cells stay untouched
- [ ] Edit a template's playbook (rename / swap kind) → drawer surfaces it under **Changed**; checkbox only available on pristine instance cells
- [ ] Remove a cell from the template → drawer surfaces under **Removed** as flag-only (no checkbox); instance task remains in place
- [ ] Visit `/workflows/templates/<templateId>` → stacked matrix renders the per-cell status counts across all instances; clicking a count drills into the matching instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)